### PR TITLE
Fix broken custom image selection if in 'BUILD_IN_PROGRESS' state

### DIFF
--- a/frontend/src/old-pages/CustomImages/CustomImageDetails.tsx
+++ b/frontend/src/old-pages/CustomImages/CustomImageDetails.tsx
@@ -69,12 +69,12 @@ function CustomImageProperties() {
   const loadingText = t('global.loading')
 
   const copyImageConfigUrl = useCallback(() => {
-    navigator.clipboard.writeText(image.imageConfiguration.url)
-  }, [image.imageConfiguration.url])
+    navigator.clipboard.writeText(image.imageConfiguration?.url)
+  }, [image.imageConfiguration?.url])
 
   const copyAmiId = useCallback(() => {
-    navigator.clipboard.writeText(image.ec2AmiInfo.amiId)
-  }, [image.ec2AmiInfo.amiId])
+    navigator.clipboard.writeText(image.ec2AmiInfo?.amiId)
+  }, [image.ec2AmiInfo?.amiId])
 
   return (
     <Container
@@ -89,7 +89,7 @@ function CustomImageProperties() {
           <ValueWithLabel
             label={t('customImages.imageDetails.properties.creationTime')}
           >
-            <DateView date={image.creationTime} />
+            {image.creationTime ? <DateView date={image.creationTime} /> : '-'}
           </ValueWithLabel>
           <ValueWithLabel
             label={t('customImages.imageDetails.properties.architecture')}
@@ -129,8 +129,8 @@ function CustomImageProperties() {
                 variant="inline-icon"
               />
             </Popover>
-            <Link href={image.imageConfiguration.url}>
-              {truncate(image.imageConfiguration.url, {
+            <Link href={image.imageConfiguration?.url}>
+              {truncate(image.imageConfiguration?.url, {
                 length: 100,
               })}
             </Link>


### PR DESCRIPTION
## Description
This PR fixes selection of a custom image in `BUILD_IN_PROGRESS` state, which currently throws an error triggering the `ErrorBoundary` component.

The issues is rooted in the fact that during build some properties of the `image` object are not present yet.

## How Has This Been Tested?

* Manually on local environment
   * Submitted image build 
   * Selected image in `BUILD_IN_PROGRESS` state
   * Image properties are displayed as expected

## Screenshots

<img width="1725" alt="Screenshot 2023-02-08 at 11 16 26" src="https://user-images.githubusercontent.com/25930133/217502008-8b0aa37c-8a8e-4d68-871c-4dede87c6a3d.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
