### PR TITLE
Remove status code check in cluster delete call

### DIFF
--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -163,12 +163,7 @@ async function DescribeCluster(clusterName: string, errorCallback?: Callback) {
 function DeleteCluster(clusterName: any, callback?: Callback) {
   var url = `api?path=/v3/clusters/${clusterName}`
   request('delete', url)
-    .then((response: any) => {
-      if (response.status === 200) {
-        console.log('Delete Success', response)
-        callback && callback(response.data)
-      }
-    })
+    .then((response: any) => callback && callback(response.data))
     .catch((error: any) => {
       if (error.response)
         notify(


### PR DESCRIPTION
## Description

Fixes a strange loop of errors after deleting a cluster by navigating back to the clusters list after deletion: this was not happening since the `DELETE /cluster` returns a 202 status code. I removed the check since the only successful status code is 202, thus the check is not needed. See https://github.com/aws/aws-parallelcluster/blob/0fb133defe823f73c221167aad70ee667b8b3a84/api/spec/openapi/ParallelCluster.openapi.yaml#L194 for more info.

## How Has This Been Tested?

- deleted a cluster, and verified it goes back to the clusters list
- after that, the cluster is no more selectable

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
