### PR TITLE
Bump default PCluster version to 3.5.0

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -22,7 +22,7 @@ Parameters:
   Version:
     Description: Version of AWS ParallelCluster to deploy
     Type: String
-    Default: 3.4.0
+    Default: 3.5.0
   ImageBuilderVpcId:
     Description: (Optional) Select the VPC to use for building the container images. If not selected, default VPC will be used.
     Type: String


### PR DESCRIPTION
## Description

Even though PCluster 3.5.0 is not released yet (at the time of this PR), we'll switch to 3.5.0 to be ready as soon as it's released. In the meantime, the 3.4.0 can be installed by changing the parameter manually.

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
