### PR TITLE
Fix broken reset password link

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -618,7 +618,7 @@ def create_user():
     cognito = boto3.client("cognito-idp")
     username = request.json.get("Username")
     phone_number = request.json.get("Phonenumber")
-    user_attributes = [{"Name": "email", "Value": username}]
+    user_attributes = [{"Name": "email", "Value": username}, {"Name": "email_verified", "Value": "True"}]
     if phone_number:
         user_attributes.append({"Name": "phone_number", "Value": phone_number})
     user = cognito.admin_create_user(

--- a/infrastructure/parallelcluster-ui-cognito.yaml
+++ b/infrastructure/parallelcluster-ui-cognito.yaml
@@ -86,6 +86,8 @@ Resources:
       UserAttributes:
         - Name: email
           Value: !Ref AdminUserEmail
+        - Name: email_verified
+          Value: True
       Username: !Ref AdminUserEmail
       UserPoolId: !Ref CognitoUserPool
 


### PR DESCRIPTION
## Description

Currently the workflow to reset the password of a Cognito user within PCUI is broken, since the reset code does not arrive to the specified email. The issue is rooted in the fact that users that belong to the PCUI Cognito user pool have the `email_verified` attribute set to `False` by default.

This PR aims at solving the aforementioned issue by setting `email_verified` to `True` in Cognito user pool both for admin user and new users.

Closes #35.

## How Has This Been Tested?

* User creation has been tested on local environment, with a Cognito user pool deployed in my personal account
* Admin user has been tested by uploading `parallelcluster-ui-cognito.yaml` template on S3 in my personal account, and testing a full deployment of PCUI
* Verified that for both users reset password link works and email is received

## References

* https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cognito-idp.html#CognitoIdentityProvider.Client.admin_create_user
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cognito-userpooluser.html#cfn-cognito-userpooluser-userattributes

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
