### PR TITLE
Avoid logging out user in case of an authorization exception with Boto3 IAM temporary credentials.

### DIFF
--- a/api/exception/handlers.py
+++ b/api/exception/handlers.py
@@ -16,7 +16,7 @@ def boto3_exception_handler(err):
     description = error['Message']
 
     logger.error(description, extra=dict(status=status, exception=type(err)))
-    return __handler_response(status, 'Something went wrong while invoking other AWS services')
+    return __handler_response(400, 'Something went wrong while invoking other AWS services')
 
 def websocket_mismatch_nop_handler(err):
     """ Handles websocket error caused by HMR in local development"""


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description
Avoid logging out user in case of an authorization exception with Boto3 IAM temporary credentials.
This PR prevents the user from getting logged out when boto3 library returns a 401/403 error.
Original errors and code still get logged to CloudWatch for debugging purposes.

## How Has This Been Tested?
- manually
- unit tests

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
