### PR TITLE
Remove a side effect from GetConfiguration to avoid a crash when inspecting a cluster

### DIFF
--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -196,10 +196,6 @@ function GetConfiguration(clusterName: any, callback?: Callback) {
     .then((response: any) => {
       console.log('Configuration Success', response)
       if (response.status === 200) {
-        setState(
-          ['clusters', 'index', clusterName, 'configuration'],
-          response.data,
-        )
         callback && callback(response.data)
       }
     })


### PR DESCRIPTION

## Description
Fixes an issue crashing the UI when selecting a cluster that was previously used as a source in the wizard ("from cluster" option).
Closes https://github.com/aws/aws-parallelcluster-ui/issues/36.

## How Has This Been Tested?
- start the wizard
- select "from cluster"
- press "cancel" so that it navigates back to the Clusters list
- select the same cluster you were copying from
- the UI doesn't crash anymore

I also verified that `GetConfiguration` callers handle the return data directly.

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
