### PR TITLE
Let the user specify a custom name for the shared storage

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -742,7 +742,8 @@
           "label": "Shared source name",
           "maxLengthError": "Name can be at most {{maxChars}} characters",
           "forbiddenCharsError": "The name contains one or more forbidden characters",
-          "forbiddenKeywordError": "The name contains a forbidden keyword"
+          "forbiddenKeywordError": "The name contains a forbidden keyword",
+          "emptyError": "The name is required"
         },
         "useExisting": {
           "label": "External file system",

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -738,6 +738,12 @@
           "label": "Mount path",
           "help": "Configure the mount path for the shared storage on both the head node and compute nodes."
         },
+        "sourceName": {
+          "label": "Shared source name",
+          "maxLengthError": "Name can be at most {{maxChars}} characters",
+          "forbiddenCharsError": "The name contains one or more forbidden characters",
+          "forbiddenKeywordError": "The name contains a forbidden keyword"
+        },
         "useExisting": {
           "label": "External file system",
           "help": "Specify an external file system and mount it to all instances in the cluster.",

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -121,6 +121,11 @@ function storageValidate() {
               },
             )
             break
+          case 'empty':
+            errorMessage = i18next.t(
+              'wizard.storage.instance.sourceName.emptyError',
+            )
+            break
         }
         setState([...errorsPath, i, 'Name'], errorMessage)
         valid = false

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -11,7 +11,7 @@
 // limitations under the License.
 
 // Fameworks
-import * as React from 'react'
+import React, {useCallback} from 'react'
 import i18next from 'i18next'
 import {Trans, useTranslation} from 'react-i18next'
 import {findFirst, clamp} from '../../util'
@@ -50,6 +50,8 @@ import {
   STORAGE_NAME_MAX_LENGTH,
   validateStorageName,
 } from './Storage/storage.validators'
+import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
+import {BaseChangeDetail} from '@cloudscape-design/components/input/interfaces'
 
 // Constants
 const storagePath = ['app', 'wizard', 'config', 'SharedStorage']
@@ -848,6 +850,15 @@ function StorageInstance({index}: any) {
     return {label: id, value: id}
   }
 
+  const updateStorageName = useCallback<
+    NonCancelableEventHandler<BaseChangeDetail>
+  >(
+    ({detail}) => {
+      setState([...storagePath, index, 'Name'], detail.value)
+    },
+    [index],
+  )
+
   const useExistingFooterLinks = useMemo(
     () => [
       {
@@ -887,12 +898,7 @@ function StorageInstance({index}: any) {
             label={t('wizard.storage.instance.sourceName.label')}
             errorText={storageNameErrors}
           >
-            <Input
-              value={storageName}
-              onChange={({detail}) => {
-                setState([...storagePath, index, 'Name'], detail.value)
-              }}
-            />
+            <Input value={storageName} onChange={updateStorageName} />
           </FormField>
           <FormField
             label={t('wizard.storage.instance.mountPoint.label')}

--- a/frontend/src/old-pages/Configure/Storage/__tests__/validateStorageName.test.ts
+++ b/frontend/src/old-pages/Configure/Storage/__tests__/validateStorageName.test.ts
@@ -10,7 +10,7 @@ describe('Given a storage name', () => {
     })
   })
 
-  describe("when it's less than 30 chars", () => {
+  describe("when it's less than or equal to 30 chars", () => {
     it('should be validated', () => {
       expect(validateStorageName(new Array(30).join('a'))).toEqual([true])
     })
@@ -31,7 +31,7 @@ describe('Given a storage name', () => {
     })
   })
 
-  describe('when zero or more bad characters are given', () => {
+  describe('when one or more bad characters are given', () => {
     it('should fail the validation', () => {
       expect(validateStorageName(';')).toEqual([false, 'forbidden_chars'])
       expect(validateStorageName('``')).toEqual([false, 'forbidden_chars'])

--- a/frontend/src/old-pages/Configure/Storage/__tests__/validateStorageName.test.ts
+++ b/frontend/src/old-pages/Configure/Storage/__tests__/validateStorageName.test.ts
@@ -16,6 +16,12 @@ describe('Given a storage name', () => {
     })
   })
 
+  describe("when it's blank", () => {
+    it('should fail the validation', () => {
+      expect(validateStorageName('')).toEqual([false, 'empty'])
+    })
+  })
+
   describe("when the name is 'default'", () => {
     it('should fail the validation', () => {
       expect(validateStorageName('default')).toEqual([

--- a/frontend/src/old-pages/Configure/Storage/__tests__/validateStorageName.test.ts
+++ b/frontend/src/old-pages/Configure/Storage/__tests__/validateStorageName.test.ts
@@ -1,0 +1,41 @@
+import {validateStorageName} from '../storage.validators'
+
+describe('Given a storage name', () => {
+  describe("when it's more than 30 chars", () => {
+    it('should fail the validation', () => {
+      expect(validateStorageName(new Array(32).join('a'))).toEqual([
+        false,
+        'max_length',
+      ])
+    })
+  })
+
+  describe("when it's less than 30 chars", () => {
+    it('should be validated', () => {
+      expect(validateStorageName(new Array(30).join('a'))).toEqual([true])
+    })
+  })
+
+  describe("when the name is 'default'", () => {
+    it('should fail the validation', () => {
+      expect(validateStorageName('default')).toEqual([
+        false,
+        'forbidden_keyword',
+      ])
+    })
+  })
+
+  describe('when zero or more bad characters are given', () => {
+    it('should fail the validation', () => {
+      expect(validateStorageName(';')).toEqual([false, 'forbidden_chars'])
+      expect(validateStorageName('``')).toEqual([false, 'forbidden_chars'])
+      expect(validateStorageName('#')).toEqual([false, 'forbidden_chars'])
+    })
+  })
+
+  describe('when no bad characters are given', () => {
+    it('should be validated', () => {
+      expect(validateStorageName('efs_4')).toEqual([true])
+    })
+  })
+})

--- a/frontend/src/old-pages/Configure/Storage/storage.validators.ts
+++ b/frontend/src/old-pages/Configure/Storage/storage.validators.ts
@@ -1,0 +1,16 @@
+type ErrorKind = 'forbidden_keyword' | 'forbidden_chars' | 'max_length'
+
+export const STORAGE_NAME_MAX_LENGTH = 30
+
+export function validateStorageName(name: string): [boolean, ErrorKind?] {
+  if (name.length > STORAGE_NAME_MAX_LENGTH) {
+    return [false, 'max_length']
+  }
+  if (name === 'default') {
+    return [false, 'forbidden_keyword']
+  }
+  if (!/^([\w\+\-\=\.\_\:\@/]{0,256})$/.test(name)) {
+    return [false, 'forbidden_chars']
+  }
+  return [true]
+}

--- a/frontend/src/old-pages/Configure/Storage/storage.validators.ts
+++ b/frontend/src/old-pages/Configure/Storage/storage.validators.ts
@@ -1,8 +1,15 @@
-type ErrorKind = 'forbidden_keyword' | 'forbidden_chars' | 'max_length'
+type ErrorKind =
+  | 'forbidden_keyword'
+  | 'forbidden_chars'
+  | 'max_length'
+  | 'empty'
 
 export const STORAGE_NAME_MAX_LENGTH = 30
 
 export function validateStorageName(name: string): [boolean, ErrorKind?] {
+  if (!name) {
+    return [false, 'empty']
+  }
   if (name.length > STORAGE_NAME_MAX_LENGTH) {
     return [false, 'max_length']
   }


### PR DESCRIPTION
## Description

Add the ability to override the name of a shared storage.

## How Has This Been Tested?
<img width="935" alt="Screenshot 2023-02-20 at 16 18 35" src="https://user-images.githubusercontent.com/3091286/220151785-eba85e1c-dd18-440f-8d88-b688535ccabe.png">
<img width="308" alt="Screenshot 2023-02-20 at 16 18 47" src="https://user-images.githubusercontent.com/3091286/220151790-c9dd5ed8-1f0d-4444-b1b9-9f13f9c4814e.png">

## PR Quality Checklist
- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
