### PR TITLE
Add possibility to select more than one storage at a time

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -598,7 +598,6 @@
       "title": "Storage",
       "description": "Configure shared storage for your cluster.",
       "container": {
-        "title": "Configure up to 20 shared storage resources.",
         "noStorageSelected": "No shared storage options selected.",
         "storageType": "Storage type",
         "storageTypePlaceholder": "Select a file system type",

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -27,8 +27,8 @@ import {
   InputProps,
   Select,
   SpaceBetween,
-  TextContent,
   Checkbox,
+  Alert,
 } from '@cloudscape-design/components'
 
 // State
@@ -1062,6 +1062,8 @@ function Storage() {
   const isFsxOpenZsfActive = useFeatureFlag('fsx_openzsf')
   const canEditFilesystems = useDynamicStorage()
 
+  const hasAddedStorage = storages?.length > 0
+
   useHelpPanel(<StorageHelpPanel />)
 
   const storageMaxes: Record<string, number> = {
@@ -1141,20 +1143,14 @@ function Storage() {
   }
 
   return (
-    <Container>
-      <SpaceBetween direction="vertical" size="m">
-        <TextContent>{t('wizard.storage.container.title')}</TextContent>
-        <div style={{display: 'flex', flexDirection: 'column', gap: '20px'}}>
-          {storages ? (
-            storages.map((_: any, i: any) => (
-              <StorageInstance key={i} index={i} />
-            ))
-          ) : (
-            <TextContent>
+    <SpaceBetween direction="vertical" size="xl">
+      <Container>
+        <SpaceBetween direction="vertical" size="m">
+          {!hasAddedStorage && (
+            <Alert statusIconAriaLabel="Info">
               {t('wizard.storage.container.noStorageSelected')}
-            </TextContent>
+            </Alert>
           )}
-
           {canEditFilesystems && storageTypes.length > 0 && (
             <SpaceBetween size="s">
               <FormField label={t('wizard.storage.container.storageType')}>
@@ -1179,9 +1175,14 @@ function Storage() {
               </Button>
             </SpaceBetween>
           )}
-        </div>
-      </SpaceBetween>
-    </Container>
+        </SpaceBetween>
+      </Container>
+      {hasAddedStorage
+        ? storages.map((_: any, i: any) => (
+            <StorageInstance key={i} index={i} />
+          ))
+        : null}
+    </SpaceBetween>
   )
 }
 

--- a/frontend/src/old-pages/Configure/Storage.types.ts
+++ b/frontend/src/old-pages/Configure/Storage.types.ts
@@ -115,12 +115,12 @@ export interface FsxLustreStorage extends CommonSharedStorageDetails {
 }
 
 export interface FsxOnTapStorage extends CommonSharedStorageDetails {
-  StorageType: 'FsxOnTap'
-  FsxOnTapSettings?: FsxOnTapSettings
+  StorageType: 'FsxOntap'
+  FsxOntapSettings?: FsxOnTapSettings
 }
 
 export interface FsxOpenZfsStorage extends CommonSharedStorageDetails {
-  StorageType: 'FsxOpenZsf'
+  StorageType: 'FsxOpenZfs'
   FsxOpenZfsSettings?: FsxOpenZfsSettings
 }
 

--- a/frontend/src/old-pages/Configure/Storage/AddStorageForm.tsx
+++ b/frontend/src/old-pages/Configure/Storage/AddStorageForm.tsx
@@ -1,0 +1,73 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react'
+import {useTranslation} from 'react-i18next'
+import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
+import {
+  Button,
+  FormField,
+  SpaceBetween,
+  Multiselect,
+  MultiselectProps,
+} from '@cloudscape-design/components'
+import {StorageType} from '../Storage.types'
+import {useMemo} from 'react'
+import {StorageTypeOption, itemToOption} from '../Storage'
+
+interface Props {
+  storageTypes: StorageTypeOption[]
+  onSubmit: (storageTypes: StorageType[]) => void
+}
+
+const INITIAL_SELECTED_STORAGES: MultiselectProps.Option[] = []
+
+export function AddStorageForm({storageTypes, onSubmit}: Props) {
+  const {t} = useTranslation()
+  const [selectedStorages, setSelectedStorages] = React.useState<
+    MultiselectProps.Option[]
+  >(INITIAL_SELECTED_STORAGES)
+  const isAddStorageDisabled = selectedStorages.length < 1
+  const storageTypesToDisplay = useMemo(
+    () => storageTypes.map(itemToOption),
+    [storageTypes],
+  )
+
+  const onAddStorageClick = React.useCallback(() => {
+    const selectedStorageTypes = selectedStorages.map(
+      selectedStorage => selectedStorage.value as StorageType,
+    )
+    onSubmit(selectedStorageTypes)
+    setSelectedStorages(INITIAL_SELECTED_STORAGES)
+  }, [onSubmit, selectedStorages])
+
+  const onSelectChange: NonCancelableEventHandler<MultiselectProps.MultiselectChangeDetail> =
+    React.useCallback(({detail: {selectedOptions}}) => {
+      setSelectedStorages([...selectedOptions])
+    }, [])
+
+  return (
+    <SpaceBetween size="s">
+      <FormField label={t('wizard.storage.container.storageType')}>
+        <Multiselect
+          tokenLimit={0}
+          placeholder={t('wizard.storage.container.storageTypePlaceholder')}
+          selectedOptions={selectedStorages}
+          onChange={onSelectChange}
+          options={storageTypesToDisplay}
+        />
+      </FormField>
+      <Button onClick={onAddStorageClick} disabled={isAddStorageDisabled}>
+        {t('wizard.storage.container.addStorage')}
+      </Button>
+    </SpaceBetween>
+  )
+}

--- a/frontend/src/old-pages/Configure/Storage/__tests__/AddStorageForm.test.tsx
+++ b/frontend/src/old-pages/Configure/Storage/__tests__/AddStorageForm.test.tsx
@@ -1,0 +1,89 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import wrapper from '@cloudscape-design/components/test-utils/dom'
+import {render, RenderResult} from '@testing-library/react'
+import i18n from 'i18next'
+import {I18nextProvider, initReactI18next} from 'react-i18next'
+import {StorageTypeOption} from '../../Storage'
+import {AddStorageForm} from '../AddStorageForm'
+
+i18n.use(initReactI18next).init({
+  resources: {},
+  lng: 'en',
+})
+
+const MockProviders = (props: any) => (
+  <I18nextProvider i18n={i18n}>{props.children}</I18nextProvider>
+)
+
+describe('given a component to select from a range of storage type options', () => {
+  let screen: RenderResult
+  let mockStorageTypes: StorageTypeOption[]
+  let mockOnSubmit: jest.Mock
+
+  beforeEach(() => {
+    mockStorageTypes = [
+      ['Efs', 'Efs'],
+      ['Ebs', 'Ebs'],
+    ]
+    mockOnSubmit = jest.fn()
+    screen = render(
+      <MockProviders>
+        <AddStorageForm
+          storageTypes={mockStorageTypes}
+          onSubmit={mockOnSubmit}
+        />
+      </MockProviders>,
+    )
+  })
+
+  describe('when no storage type has been selected yet', () => {
+    it('should disable the submit button', () => {
+      screen
+        .getByRole('button', {name: 'wizard.storage.container.addStorage'})
+        .click()
+      expect(mockOnSubmit).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('when user submits a storage type', () => {
+    beforeEach(() => {
+      const multiSelectComponent = wrapper(screen.container).findMultiselect()!
+      multiSelectComponent.openDropdown()
+      multiSelectComponent.selectOptionByValue('Efs')
+    })
+
+    it('should pass the selected storage to the submission handler', () => {
+      screen
+        .getByRole('button', {name: 'wizard.storage.container.addStorage'})
+        .click()
+      expect(mockOnSubmit).toHaveBeenCalledTimes(1)
+      expect(mockOnSubmit).toHaveBeenCalledWith(['Efs'])
+    })
+  })
+
+  describe('when user submits more than one storage type', () => {
+    beforeEach(() => {
+      const multiSelectComponent = wrapper(screen.container).findMultiselect()!
+      multiSelectComponent.openDropdown()
+      multiSelectComponent.selectOptionByValue('Efs')
+      multiSelectComponent.selectOptionByValue('Ebs')
+    })
+    it('should pass all the selected storages to the submission handler', () => {
+      screen
+        .getByRole('button', {name: 'wizard.storage.container.addStorage'})
+        .click()
+      expect(mockOnSubmit).toHaveBeenCalledTimes(1)
+      expect(mockOnSubmit).toHaveBeenCalledWith(['Efs', 'Ebs'])
+    })
+  })
+})

--- a/frontend/src/old-pages/Configure/Storage/__tests__/buildStorageEntries.test.ts
+++ b/frontend/src/old-pages/Configure/Storage/__tests__/buildStorageEntries.test.ts
@@ -1,0 +1,107 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Storages, StorageType, UIStorageSettings} from '../../Storage.types'
+import {buildStorageEntries} from '../buildStorageEntries'
+
+describe('given a function to convert user storage selections to the internal state representations', () => {
+  let mockStorages: Storages
+  let mockUiStorageSettings: UIStorageSettings
+  let mockSelectedStorageTypes: StorageType[]
+
+  describe('and the current storage configuration', () => {
+    describe('and a list of selected storage types', () => {
+      beforeEach(() => {
+        mockSelectedStorageTypes = ['Ebs', 'Efs']
+      })
+
+      describe('when no storage has been selected yet', () => {
+        beforeEach(() => {
+          mockStorages = []
+          mockUiStorageSettings = []
+        })
+
+        it('should return the storage entries', () => {
+          const [storageEntries] = buildStorageEntries(
+            mockStorages,
+            mockUiStorageSettings,
+            mockSelectedStorageTypes,
+          )
+          expect(storageEntries).toEqual([
+            {
+              StorageType: 'Ebs',
+              Name: 'Ebs0',
+              MountDir: '/shared',
+            },
+            {
+              StorageType: 'Efs',
+              Name: 'Efs1',
+              MountDir: '/shared',
+            },
+          ])
+        })
+        it('should return the storage ui configuration', () => {
+          const [_, uiStorageSettingsEntries] = buildStorageEntries(
+            mockStorages,
+            mockUiStorageSettings,
+            mockSelectedStorageTypes,
+          )
+          expect(uiStorageSettingsEntries).toEqual([
+            {useExisting: false},
+            {useExisting: false},
+          ])
+        })
+      })
+      describe('when some storage had already been selected', () => {
+        beforeEach(() => {
+          mockStorages = [
+            {
+              StorageType: 'Ebs',
+              Name: 'Ebs0',
+              MountDir: '/shared',
+            },
+          ]
+          mockUiStorageSettings = [{useExisting: false}]
+        })
+
+        it('should return the storage entries with unique names', () => {
+          const [storageEntries] = buildStorageEntries(
+            mockStorages,
+            mockUiStorageSettings,
+            mockSelectedStorageTypes,
+          )
+          expect(storageEntries).toEqual([
+            {
+              StorageType: 'Ebs',
+              Name: 'Ebs1',
+              MountDir: '/shared',
+            },
+            {
+              StorageType: 'Efs',
+              Name: 'Efs2',
+              MountDir: '/shared',
+            },
+          ])
+        })
+        it('should update the storage ui configuration', () => {
+          const [_, uiStorageSettingsEntries] = buildStorageEntries(
+            mockStorages,
+            mockUiStorageSettings,
+            mockSelectedStorageTypes,
+          )
+          expect(uiStorageSettingsEntries).toEqual([
+            {useExisting: false},
+            {useExisting: false},
+          ])
+        })
+      })
+    })
+  })
+})

--- a/frontend/src/old-pages/Configure/Storage/__tests__/mapStorageToUiSettings.test.ts
+++ b/frontend/src/old-pages/Configure/Storage/__tests__/mapStorageToUiSettings.test.ts
@@ -79,15 +79,15 @@ const FsxLustreWithoutExternalVolume: FsxLustreStorage = {
 
 const FsxOnTapWithExternalVolume: FsxOnTapStorage = {
   ...commonStorageValues,
-  StorageType: 'FsxOnTap',
-  FsxOnTapSettings: {
+  StorageType: 'FsxOntap',
+  FsxOntapSettings: {
     VolumeId: 'some-id',
   },
 }
 
 const FsxOpenZfsWithExternalVolume: FsxOpenZfsStorage = {
   ...commonStorageValues,
-  StorageType: 'FsxOpenZsf',
+  StorageType: 'FsxOpenZfs',
   FsxOpenZfsSettings: {
     VolumeId: 'some-id',
   },

--- a/frontend/src/old-pages/Configure/Storage/buildStorageEntries.ts
+++ b/frontend/src/old-pages/Configure/Storage/buildStorageEntries.ts
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {canCreateStorage} from '../Storage'
+import {Storages, UIStorageSettings, StorageType} from '../Storage.types'
+
+export function buildStorageEntries(
+  storages: Storages,
+  uiStorageSettings: UIStorageSettings,
+  selectedStorageTypes: StorageType[],
+): [Storages, UIStorageSettings] {
+  const storageEntries: Storages = []
+  const uiSettingsEntries: UIStorageSettings = []
+
+  const firstIndex = storages.length
+
+  selectedStorageTypes.forEach((storageType: StorageType, index: number) => {
+    const storageIndex = firstIndex + index
+    const useExisting = !canCreateStorage(
+      storageType,
+      storages,
+      uiStorageSettings,
+    )
+
+    const storageEntry: Storages[0] = {
+      Name: `${storageType}${storageIndex}`,
+      StorageType: storageType,
+      MountDir: '/shared',
+    }
+    const uiSettingsEntry = {
+      useExisting,
+    }
+
+    storageEntries.push(storageEntry)
+    uiSettingsEntries.push(uiSettingsEntry)
+  })
+
+  return [storageEntries, uiSettingsEntries]
+}

--- a/frontend/src/old-pages/Configure/Storage/storage.mapper.ts
+++ b/frontend/src/old-pages/Configure/Storage/storage.mapper.ts
@@ -18,9 +18,9 @@ function mapStorageToUiSetting(storage: Storage): UIStorageSettings[0] {
       return {useExisting: !!storage.EfsSettings?.FileSystemId}
     case 'FsxLustre':
       return {useExisting: !!storage.FsxLustreSettings?.FileSystemId}
-    case 'FsxOnTap':
-      return {useExisting: !!storage.FsxOnTapSettings?.VolumeId}
-    case 'FsxOpenZsf':
+    case 'FsxOntap':
+      return {useExisting: !!storage.FsxOntapSettings?.VolumeId}
+    case 'FsxOpenZfs':
       return {useExisting: !!storage.FsxOpenZfsSettings?.VolumeId}
   }
 }


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR adds the possibility to add more than one storage at a time.

In addition, it updates the UI, by showing each Storage instance in its own container

## Changes

- fix typo in storage types
- use `Alert` for the empty state
- move storage instances list below the add storage form
- add `AddStorageForm` and `buildStorageEntries` to support selection of multiple storage types

## Screenshots

**New empty state**

![image](https://user-images.githubusercontent.com/11457067/220330782-9a824cdb-8bd8-4f4a-9f82-19e6f64d3750.png)

**Multiselect**

![image](https://user-images.githubusercontent.com/11457067/220330820-4d4b12ba-8f93-4d8a-8b46-792e46b94deb.png)

**Updated UI for Storage instances list**

![image](https://user-images.githubusercontent.com/11457067/220330847-2c4ab88d-9515-4080-b172-37e903629aa7.png)


## How Has This Been Tested?

- manually
  - created storages, in Create mode
  - edited existing storages, in Edit mode
- unit tests

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
