### PR TITLE
Handle revision in --tag parameter for prod release script + remove default strategy for tagging

### DIFF
--- a/.github/workflows/production_release.yml
+++ b/.github/workflows/production_release.yml
@@ -74,7 +74,7 @@ jobs:
           role-to-assume: ${{ secrets.ACTION_PRODUCTION_RELEASE_ROLE }}
 
       - name: Build and upload Docker image
-        run: ./scripts/build_and_release_image.sh
+        run: ./scripts/build_and_release_image.sh --tag ${{ github.ref_name }}
       
       - name: Upload infrastructure files to S3
         run: ./infrastructure/release_infrastructure.sh

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -81,7 +81,7 @@ Conditions:
 Mappings:
   ParallelClusterUI:
     Constants:
-      Version: 2023.02 # format YYYY.MM[.REVISION]
+      Version: 2023.02.0 # format YYYY.MM.REVISION
       ShortVersion: 2023.02 # format YYYY.MM
 
 Resources:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,5 +19,5 @@ If the rollback script is launched by mistake, the rollforward script helps to r
 bash ./rollforward_awslambda_image.sh
 ```
 
-**NOTE:** The rollforward script should be used only if the rollback script is launched by mistake, the normal procedure to publish a new release after a rollback is by launching the `build_and_release_image.sh` after fixing the code
+**NOTE:** The rollforward script should be used only if the rollback script is launched by mistake, the normal procedure to publish a new release after a rollback is by launching the `build_and_release_image.sh --tag YYYY.MM.REVISION` after fixing the code
 

--- a/scripts/build_and_release_image.sh
+++ b/scripts/build_and_release_image.sh
@@ -24,11 +24,6 @@ case $key in
     shift
     shift
     ;;
-    --revision)
-    REVISION=$2
-    shift
-    shift
-    ;;
     *)
     print_usage
     exit 1
@@ -46,10 +41,10 @@ elif ! [[ $TAG =~ [0-9]{4}\.(0[1-9]|1[0-2])\.[0-9]+ ]]; then
   exit 1
 fi
 
-if ! [ -z $REVISION ]; then
-  TAG="${TAG}.${REVISION}"
-  echo "Using provided revision, tag: $TAG" 1>&2
-fi
+### TEST
+echo "Tag passed: $TAG"
+exit 0
+### TEST
 
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin "${ECR_ENDPOINT}"
 

--- a/scripts/build_and_release_image.sh
+++ b/scripts/build_and_release_image.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 set -e
 
-USAGE="$(basename "$0") [-h] [--tag YYYY.MM (defaults to current year and month)] [--revision REVISION]"
-
-get_default_pcui_version() {
-  date +%Y.%m
-}
+USAGE="$(basename "$0") [-h] --tag YYYY.MM.REVISION"
 
 print_usage() {
   echo "$USAGE" 1>&2
@@ -43,10 +39,10 @@ done
 ECR_ENDPOINT="public.ecr.aws/pcm"
 
 if [ -z $TAG ]; then
-  TAG=`get_default_pcui_version`
-  echo "Using default versioning strategy, tag: $TAG" 1>&2
-elif ! [[ $TAG =~ [0-9]{4}\.(0[1-9]|1[0-2]) ]]; then
-  echo '`--tag` parameter must be a valid year and month combo of the following format `YYYY.MM`, exiting' 1>&2
+  echo 'No `--tag` parameter specified, exiting' 1>&2
+  exit 1
+elif ! [[ $TAG =~ [0-9]{4}\.(0[1-9]|1[0-2])\.[0-9]+ ]]; then
+  echo '`--tag` parameter must be a valid year, month and revision number combo of the following format `YYYY.MM.REVISION`, exiting' 1>&2
   exit 1
 fi
 

--- a/scripts/build_and_release_image.sh
+++ b/scripts/build_and_release_image.sh
@@ -41,11 +41,6 @@ elif ! [[ $TAG =~ [0-9]{4}\.(0[1-9]|1[0-2])\.[0-9]+ ]]; then
   exit 1
 fi
 
-### TEST
-echo "Tag passed: $TAG"
-exit 0
-### TEST
-
 aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin "${ECR_ENDPOINT}"
 
 pushd frontend


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description
This PR removes the need to specify a REVISION separately and expects a new format for the (now mandatory) `--tag` parameter, which used to be optional.
It is now mandatory because the default tagging strategy is considered dangerous and is now removed with this PR.

<!-- Summary of what this PR introduces and possibly why -->

## Changes
- `production_release.yaml` action
- `build_and_release_image.sh` script
- `scripts/README.md` updated with current usage
<!-- List of relevant changes introduced -->

## How Has This Been Tested?
- manually on a different branch with custom triggers and test code
<!-- The tests you ran to verify your changes -->

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
