### PR TITLE
Fixed broken 'delete stack' due to EcrPrivateRepository being not empty

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -484,7 +484,7 @@ Resources:
               paginator = ecr.get_paginator('list_images')
               response_iterator = paginator.paginate(repositoryName=repository_name, filter={'tagStatus': 'TAGGED'})
               for response in response_iterator:
-                  image_digests.update([image_id['imageDigest'] for image_id in response['imageIds'] if f"{version}-" in image_id['imageTag']])
+                  image_digests.update([image_id['imageDigest'] for image_id in response['imageIds']])
               return list({'imageDigest': image_digest} for image_digest in image_digests)
 
           def get_imagebuilder_images(ecr_image_pipeline_arn):


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description
Previously the `EcrImageDeletionLambda` wasn't able to delete all images in the private ecr repository because an `if` condition inside a list comprehension didn't include all images, so only a subset (possibly empty) of the images id were targetet.
Now, all images get deleted, and the CloudFormation resource (ECR private repo) can be safely removed.

This PR fixes #33 
<!-- Summary of what this PR introduces and possibly why -->
## How Has This Been Tested?
- manually
<!-- The tests you ran to verify your changes -->

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
