### PR TITLE
Move QueueUpdateStrategy and DownIdleTime time under Queues -> Slurm settings

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -578,7 +578,7 @@
         },
         "scaledownIdleTime": {
           "label": "Scale down idle time (in minutes)",
-          "description": "The amount of time (in minutes) that a queue has no jobs before the Slurm node terminates.",
+          "description": "The amount of time that a queue has no jobs before the Slurm node terminates.",
           "placeholder": "10"
         },
         "queueUpdateStrategy": {

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -798,7 +798,7 @@
       },
       "slurmMemorySettings": {
         "container": {
-          "title": "Slurm memory settings",
+          "title": "Slurm settings",
           "help": "<p>Use Slurm memory-based scheduling to specify the amount of memory per node required by a job with Slurm's --mem parameter.</p><p>Choose <strong>Refresh</strong> to view recently changed or added AWS resources.</p>",
           "memorySchedulingLink": {
             "title": "How Slurm memory-based scheduling works with AWS ParallelCluster",

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -52,8 +52,8 @@ import {
 } from './Components'
 import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
 import {
+  slurmAccountingValidateAndSetErrors,
   SlurmSettings,
-  validateSlurmSettings,
 } from './SlurmSettings/SlurmSettings'
 import InfoLink from '../../components/InfoLink'
 import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
@@ -173,7 +173,10 @@ function headNodeValidate() {
     clearState([...errorsPath, 'onUpdated'])
   }
 
-  valid = validateSlurmSettings()
+  const accountingValid = slurmAccountingValidateAndSetErrors()
+  if (!accountingValid) {
+    valid = false
+  }
 
   setState([...errorsPath, 'validated'], true)
 

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -36,14 +36,13 @@ import {setState, getState, useState, clearState} from '../../../store'
 import {
   ActionsEditor,
   CustomAMISettings,
-  LabeledIcon,
   RootVolume,
   SecurityGroups,
   IamPoliciesEditor,
   SubnetSelect,
 } from '../Components'
 import {Trans, useTranslation} from 'react-i18next'
-import {SlurmMemorySettings} from './SlurmMemorySettings'
+import {SlurmMemorySettings, validateSlurmSettings} from './SlurmMemorySettings'
 import {
   isFeatureEnabled,
   useFeatureFlag,
@@ -53,7 +52,6 @@ import * as MultiInstanceCR from './MultiInstanceComputeResource'
 import {AllocationStrategy, ComputeResource} from './queues.types'
 import {SubnetMultiSelect} from './SubnetMultiSelect'
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
-import Head from 'next/head'
 import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
 import {useHelpPanel} from '../../../components/help-panel/HelpPanel'
 
@@ -210,6 +208,17 @@ function queueValidate(queueIndex: any) {
         setState([...errorsPath, 'computeResource', i, 'type'], null)
       }
     })
+  }
+
+  const isMemoryBasedSchedulingActive = isFeatureEnabled(
+    version,
+    'memory_based_scheduling',
+  )
+  if (isMemoryBasedSchedulingActive) {
+    const settingsValid = validateSlurmSettings()
+    if (!settingsValid) {
+      valid = false
+    }
   }
 
   return valid

--- a/frontend/src/old-pages/Configure/Queues/SlurmMemorySettings.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SlurmMemorySettings.tsx
@@ -17,12 +17,18 @@ import {
   Alert,
   Checkbox,
   SpaceBetween,
+  ColumnLayout,
 } from '@cloudscape-design/components'
 import {setState, getState, useState, clearState} from '../../../store'
 import {Queue} from './queues.types'
 import {useFeatureFlag} from '../../../feature-flags/useFeatureFlag'
 import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
 import InfoLink from '../../../components/InfoLink'
+import {
+  ScaledownIdleTimeForm,
+  validateScaledownIdleTime,
+} from '../SlurmSettings/ScaledownIdleTimeForm'
+import {QueueUpdateStrategyForm} from '../SlurmSettings/QueueUpdateStrategyForm'
 
 const slurmSettingsPath = [
   'app',
@@ -36,6 +42,15 @@ const memoryBasedSchedulingEnabledPath = [
   'EnableMemoryBasedScheduling',
 ]
 const queuesPath = ['app', 'wizard', 'config', 'Scheduling', 'SlurmQueues']
+
+const scaledownIdleTimePath = [...slurmSettingsPath, 'ScaledownIdletime']
+const queueUpdateStrategyPath = [...slurmSettingsPath, 'QueueUpdateStrategy']
+
+function validateSlurmSettings() {
+  const scaledownIdleTime = getState(scaledownIdleTimePath)
+
+  return validateScaledownIdleTime(scaledownIdleTime)
+}
 
 const hasMultipleInstanceTypes = (queues: Queue[]): boolean => {
   return (
@@ -79,6 +94,24 @@ function SlurmMemorySettings() {
       : clearSlurmSettingsState()
   }
 
+  const scaledownIdleTime = useState(scaledownIdleTimePath)
+  const queueUpdateStrategy = useState(queueUpdateStrategyPath)
+
+  const onScaledownIdleTimeChange = React.useCallback(
+    (value: number | null) => {
+      if (!value) {
+        clearState(scaledownIdleTimePath)
+      } else {
+        setState(scaledownIdleTimePath, value)
+      }
+    },
+    [],
+  )
+
+  const onQueueUpdateStrategyChange = React.useCallback((value: string) => {
+    setState(queueUpdateStrategyPath, value)
+  }, [])
+
   return (
     <Container
       header={
@@ -103,6 +136,16 @@ function SlurmMemorySettings() {
             {t('wizard.queues.slurmMemorySettings.info.body')}
           </Alert>
         ) : null}
+        <ColumnLayout columns={2}>
+          <ScaledownIdleTimeForm
+            value={scaledownIdleTime}
+            onChange={onScaledownIdleTimeChange}
+          />
+          <QueueUpdateStrategyForm
+            value={queueUpdateStrategy}
+            onChange={onQueueUpdateStrategyChange}
+          />
+        </ColumnLayout>
       </SpaceBetween>
     </Container>
   )
@@ -142,4 +185,4 @@ const SlurmMemorySettingsHelpPanel = () => {
   )
 }
 
-export {SlurmMemorySettings, hasMultipleInstanceTypes}
+export {SlurmMemorySettings, hasMultipleInstanceTypes, validateSlurmSettings}

--- a/frontend/src/old-pages/Configure/Queues/SlurmMemorySettings.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SlurmMemorySettings.tsx
@@ -91,29 +91,18 @@ function SlurmMemorySettings() {
       }
     >
       <SpaceBetween size={'s'} direction={'vertical'}>
-        <div
-          key="memory-based-scheduling-enabled"
-          style={{
-            display: 'flex',
-            flexDirection: 'row',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-          }}
+        <Checkbox
+          checked={memoryBasedSchedulingEnabled}
+          disabled={multipleInstancesTypesSelected}
+          onChange={toggleMemoryBasedSchedulingEnabled}
         >
-          <Checkbox
-            checked={memoryBasedSchedulingEnabled}
-            disabled={multipleInstancesTypesSelected}
-            onChange={toggleMemoryBasedSchedulingEnabled}
-          >
-            <Trans i18nKey="wizard.queues.slurmMemorySettings.toggle.label" />
-          </Checkbox>
-        </div>
-        <Alert
-          visible={multipleInstancesTypesSelected}
-          header={t('wizard.queues.slurmMemorySettings.info.header')}
-        >
-          {t('wizard.queues.slurmMemorySettings.info.body')}
-        </Alert>
+          <Trans i18nKey="wizard.queues.slurmMemorySettings.toggle.label" />
+        </Checkbox>
+        {multipleInstancesTypesSelected ? (
+          <Alert header={t('wizard.queues.slurmMemorySettings.info.header')}>
+            {t('wizard.queues.slurmMemorySettings.info.body')}
+          </Alert>
+        ) : null}
       </SpaceBetween>
     </Container>
   )

--- a/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
@@ -12,14 +12,9 @@
 import * as React from 'react'
 import i18next from 'i18next'
 import {Trans, useTranslation} from 'react-i18next'
-import {Container, Header, ColumnLayout} from '@cloudscape-design/components'
-import {setState, getState, clearState, useState} from '../../../store'
+import {Container, Header} from '@cloudscape-design/components'
+import {setState, getState, clearState} from '../../../store'
 import {SlurmAccountingForm} from './SlurmAccountingForm'
-import {
-  ScaledownIdleTimeForm,
-  validateScaledownIdleTime,
-} from './ScaledownIdleTimeForm'
-import {QueueUpdateStrategyForm} from './QueueUpdateStrategyForm'
 import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
 import InfoLink from '../../../components/InfoLink'
 
@@ -38,9 +33,6 @@ const passwordPath = [...slurmSettingsPath, 'Database', 'PasswordSecretArn']
 const uriErrorPath = [...errorsPath, 'database', 'uri']
 const usernameErrorPath = [...errorsPath, 'database', 'username']
 const passwordErrorPath = [...errorsPath, 'database', 'password']
-
-const scaledownIdleTimePath = [...slurmSettingsPath, 'ScaledownIdletime']
-const queueUpdateStrategyPath = [...slurmSettingsPath, 'QueueUpdateStrategy']
 
 function slurmAccountingValidateAndSetErrors(): boolean {
   const errorMask: Array<boolean> = [uriPath, usernamePath, passwordPath].map(
@@ -84,36 +76,8 @@ function slurmAccountingSetErrors(
   )
 }
 
-function validateSlurmSettings() {
-  const scaledownIdleTime = getState(scaledownIdleTimePath)
-
-  const validSettings = [
-    slurmAccountingValidateAndSetErrors(),
-    validateScaledownIdleTime(scaledownIdleTime),
-  ]
-
-  return validSettings.filter(Boolean).length === validSettings.length
-}
-
 function SlurmSettings() {
   const {t} = useTranslation()
-  const scaledownIdleTime = useState(scaledownIdleTimePath)
-  const queueUpdateStrategy = useState(queueUpdateStrategyPath)
-
-  const onScaledownIdleTimeChange = React.useCallback(
-    (value: number | null) => {
-      if (!value) {
-        clearState(scaledownIdleTimePath)
-      } else {
-        setState(scaledownIdleTimePath, value)
-      }
-    },
-    [],
-  )
-
-  const onQueueUpdateStrategyChange = React.useCallback((value: string) => {
-    setState(queueUpdateStrategyPath, value)
-  }, [])
 
   return (
     <Container
@@ -140,16 +104,6 @@ function SlurmSettings() {
         passwordPath={passwordPath}
         passwordErrorPath={passwordErrorPath}
       />
-      <ColumnLayout columns={2}>
-        <ScaledownIdleTimeForm
-          value={scaledownIdleTime}
-          onChange={onScaledownIdleTimeChange}
-        />
-        <QueueUpdateStrategyForm
-          value={queueUpdateStrategy}
-          onChange={onQueueUpdateStrategyChange}
-        />
-      </ColumnLayout>
     </Container>
   )
 }
@@ -184,7 +138,6 @@ const SlurmSettingsHelpPanel = () => {
 
 export {
   SlurmSettings,
-  validateSlurmSettings,
   slurmAccountingValidateAndSetErrors,
   slurmAccountingValidateField,
   slurmAccountingSetErrors,


### PR DESCRIPTION
## Changes

- fixes an issue with the Head node page validation
- moved the Slurm  properties under the Queues section

## How Has This Been Tested?

![Screenshot 2023-02-24 at 13 32 07](https://user-images.githubusercontent.com/3091286/221179802-0d476a33-ea9f-417b-ab94-721588956394.png)

The produced config has also the selected parameters with the right values

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
