### PR TITLE
Add support for DeletionPolicy for Efs and FsxLustre

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -725,14 +725,6 @@
             "title": "SnapshotID",
             "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-EbsSettings-SnapshotId"
           }
-        },
-        "deletionPolicy": {
-          "label": "Deletion policy",
-          "help": "Configure whether the volume should be retained, deleted, or snapshotted when a cluster is deleted.",
-          "policyLink": {
-            "title": "DeletionPolicy",
-            "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-EbsSettings-DeletionPolicy"
-          }
         }
       },
       "instance": {
@@ -762,6 +754,14 @@
           "ebsLink": {
             "title": "EBS Volume ID",
             "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-EbsSettings-VolumeId"
+          }
+        },
+        "deletionPolicy": {
+          "label": "Deletion policy",
+          "help": "Configure whether the volume should be retained, deleted, or snapshotted when a cluster is deleted.",
+          "policyLink": {
+            "title": "DeletionPolicy",
+            "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-EbsSettings-DeletionPolicy"
           }
         }
       }

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -759,8 +759,16 @@
         "deletionPolicy": {
           "label": "Deletion policy",
           "help": "Configure whether the volume should be retained, deleted, or snapshotted when a cluster is deleted.",
-          "policyLink": {
-            "title": "DeletionPolicy",
+          "fsxLink": {
+            "title": "FSx DeletionPolicy",
+            "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-FsxLustreSettings-DeletionPolicy"
+          },
+          "efsLink": {
+            "title": "EFS DeletionPolicy",
+            "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-EfsSettings-DeletionPolicy"
+          },
+          "ebsLink": {
+            "title": "EBS DeletionPolicy",
             "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-EbsSettings-DeletionPolicy"
           }
         }

--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -37,6 +37,7 @@ describe('given a feature flags provider and a list of rules', () => {
         'lustre_persistent2',
         'memory_based_scheduling',
         'slurm_queue_update_strategy',
+        'ebs_deletion_policy',
       ])
     })
   })
@@ -51,9 +52,12 @@ describe('given a feature flags provider and a list of rules', () => {
         'lustre_persistent2',
         'memory_based_scheduling',
         'slurm_queue_update_strategy',
+        'ebs_deletion_policy',
         'slurm_accounting',
         'queues_multiple_instance_types',
         'dynamic_fs_mount',
+        'efs_deletion_policy',
+        'lustre_deletion_policy',
       ])
     })
   })

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -19,11 +19,14 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
     'memory_based_scheduling',
     'multiuser_cluster',
     'slurm_queue_update_strategy',
+    'ebs_deletion_policy',
   ],
   '3.3.0': [
     'slurm_accounting',
     'queues_multiple_instance_types',
     'dynamic_fs_mount',
+    'efs_deletion_policy',
+    'lustre_deletion_policy',
   ],
   '3.4.0': ['multi_az', 'on_node_updated'],
 }

--- a/frontend/src/feature-flags/types.ts
+++ b/frontend/src/feature-flags/types.ts
@@ -20,3 +20,6 @@ export type AvailableFeature =
   | 'multi_az'
   | 'on_node_updated'
   | 'dynamic_fs_mount'
+  | 'ebs_deletion_policy'
+  | 'efs_deletion_policy'
+  | 'lustre_deletion_policy'

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -427,6 +427,13 @@ export function FsxLustreSettings({index}: any) {
           />
         </FormField>
       )}
+      {isDeletionPolicyEnabled && (
+        <DeletionPolicyFormField
+          options={supportedDeletionPolicies}
+          value={deletionPolicy}
+          onDeletionPolicyChange={onDeletionPolicyChange}
+        />
+      )}
       <SpaceBetween direction="horizontal" size="xs">
         <Checkbox checked={compression !== null} onChange={toggleCompression}>
           <Trans i18nKey="wizard.storage.Fsx.compression.label" />
@@ -448,13 +455,6 @@ export function FsxLustreSettings({index}: any) {
           }
         />
       </SpaceBetween>
-      {isDeletionPolicyEnabled && (
-        <DeletionPolicyFormField
-          options={supportedDeletionPolicies}
-          value={deletionPolicy}
-          onDeletionPolicyChange={onDeletionPolicyChange}
-        />
-      )}
     </ColumnLayout>
   )
 }
@@ -539,31 +539,13 @@ export function EfsSettings({index}: any) {
             options={performanceModes.map(strToOption)}
           />
         </FormField>
-        <SpaceBetween direction="vertical" size="xxs">
-          <CheckboxWithHelpPanel
-            checked={encrypted}
-            onChange={toggleEncrypted}
-            helpPanel={
-              <TitleDescriptionHelpPanel
-                title={t('wizard.storage.Efs.encrypted.label')}
-                description={t('wizard.storage.Efs.encrypted.help')}
-                footerLinks={encryptionFooterLinks}
-              />
-            }
-          >
-            {t('wizard.storage.Efs.encrypted.label')}
-          </CheckboxWithHelpPanel>
-          {encrypted ? (
-            <Input
-              value={kmsId}
-              placeholder={t('wizard.storage.Efs.encrypted.kmsId')}
-              onChange={({detail}) => {
-                setState(kmsPath, detail.value)
-              }}
-            />
-          ) : null}
-        </SpaceBetween>
-
+        {isDeletionPolicyEnabled && (
+          <DeletionPolicyFormField
+            options={supportedDeletionPolicies}
+            value={deletionPolicy}
+            onDeletionPolicyChange={onDeletionPolicyChange}
+          />
+        )}
         <SpaceBetween direction="vertical" size="xxs">
           <CheckboxWithHelpPanel
             helpPanel={
@@ -598,13 +580,30 @@ export function EfsSettings({index}: any) {
             />
           )}
         </SpaceBetween>
-        {isDeletionPolicyEnabled && (
-          <DeletionPolicyFormField
-            options={supportedDeletionPolicies}
-            value={deletionPolicy}
-            onDeletionPolicyChange={onDeletionPolicyChange}
-          />
-        )}
+        <SpaceBetween direction="vertical" size="xxs">
+          <CheckboxWithHelpPanel
+            checked={encrypted}
+            onChange={toggleEncrypted}
+            helpPanel={
+              <TitleDescriptionHelpPanel
+                title={t('wizard.storage.Efs.encrypted.label')}
+                description={t('wizard.storage.Efs.encrypted.help')}
+                footerLinks={encryptionFooterLinks}
+              />
+            }
+          >
+            {t('wizard.storage.Efs.encrypted.label')}
+          </CheckboxWithHelpPanel>
+          {encrypted ? (
+            <Input
+              value={kmsId}
+              placeholder={t('wizard.storage.Efs.encrypted.kmsId')}
+              onChange={({detail}) => {
+                setState(kmsPath, detail.value)
+              }}
+            />
+          ) : null}
+        </SpaceBetween>
       </ColumnLayout>
     </SpaceBetween>
   )

--- a/frontend/src/old-pages/Configure/Storage.types.ts
+++ b/frontend/src/old-pages/Configure/Storage.types.ts
@@ -33,6 +33,13 @@ export const STORAGE_TYPE_PROPS = {
 
 export type StorageType = keyof typeof STORAGE_TYPE_PROPS
 
+export type DeletionPolicy =
+  | EbsDeletionPolicy
+  | EfsDeletionPolicy
+  | FsxLustreDeletionPolicy
+
+export type EbsDeletionPolicy = 'Delete' | 'Retain' | 'Snapshot'
+
 export interface EbsSettings {
   VolumeType?: string
   Iops?: number
@@ -42,12 +49,14 @@ export interface EbsSettings {
   SnapshotId?: string
   Throughput?: number
   VolumeId?: string
-  DeletionPolicy?: string
+  DeletionPolicy?: EbsDeletionPolicy
   Raid?: {
     Type: string
     NumberOfVolumes?: number
   }
 }
+
+export type EfsDeletionPolicy = 'Delete' | 'Retain'
 
 export interface EfsSettings {
   Encrypted?: boolean
@@ -58,8 +67,10 @@ export interface EfsSettings {
   ThroughputMode?: string
   ProvisionedThroughput: number
   FileSystemId?: string
-  DeletionPolicy?: string
+  DeletionPolicy?: EfsDeletionPolicy
 }
+
+export type FsxLustreDeletionPolicy = 'Delete' | 'Retain'
 
 /**
  * Please note: Some of the properties cannot coexist
@@ -83,7 +94,7 @@ export interface FsxLustreSettings {
   AutoImportPolicy?: string
   DriveCacheType?: string
   StorageType?: string
-  DeletionPolicy?: string
+  DeletionPolicy?: FsxLustreDeletionPolicy
 }
 
 export interface FsxOnTapSettings {

--- a/frontend/src/old-pages/Configure/Storage/DeletionPolicyFormField.tsx
+++ b/frontend/src/old-pages/Configure/Storage/DeletionPolicyFormField.tsx
@@ -1,0 +1,85 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, {useCallback} from 'react'
+import {useTranslation} from 'react-i18next'
+import {FormField, Select, SelectProps} from '@cloudscape-design/components'
+import {DeletionPolicy} from '../Storage.types'
+import InfoLink from '../../../components/InfoLink'
+import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
+import {useMemo} from 'react'
+import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
+import {OptionDefinition} from '@cloudscape-design/components/internal/components/option/interfaces'
+
+interface Props {
+  options: DeletionPolicy[]
+  value: DeletionPolicy
+  onDeletionPolicyChange: (policy: DeletionPolicy) => void
+}
+
+function toOption(value: DeletionPolicy): OptionDefinition {
+  return {
+    label: value,
+    value,
+  }
+}
+
+export function DeletionPolicyFormField({
+  options,
+  value,
+  onDeletionPolicyChange,
+}: Props) {
+  const {t} = useTranslation()
+
+  const deletionPolicies: DeletionPolicy[] = options
+  const selectedOption = toOption(value)
+
+  const deletionFooterLinks = useMemo(
+    () => [
+      {
+        title: t('wizard.storage.instance.deletionPolicy.policyLink.title'),
+        href: t('wizard.storage.instance.deletionPolicy.policyLink.href'),
+      },
+    ],
+    [t],
+  )
+
+  const onChange: NonCancelableEventHandler<SelectProps.ChangeDetail> =
+    useCallback(
+      ({detail}) => {
+        onDeletionPolicyChange(detail.selectedOption.value as DeletionPolicy)
+      },
+      [onDeletionPolicyChange],
+    )
+
+  return (
+    <FormField
+      label={t('wizard.storage.instance.deletionPolicy.label')}
+      info={
+        <InfoLink
+          helpPanel={
+            <TitleDescriptionHelpPanel
+              title={t('wizard.storage.instance.deletionPolicy.label')}
+              description={t('wizard.storage.instance.deletionPolicy.help')}
+              footerLinks={deletionFooterLinks}
+            />
+          }
+        />
+      }
+    >
+      <Select
+        selectedOption={selectedOption}
+        onChange={onChange}
+        options={deletionPolicies.map(toOption)}
+      />
+    </FormField>
+  )
+}

--- a/frontend/src/old-pages/Configure/Storage/DeletionPolicyFormField.tsx
+++ b/frontend/src/old-pages/Configure/Storage/DeletionPolicyFormField.tsx
@@ -45,8 +45,16 @@ export function DeletionPolicyFormField({
   const deletionFooterLinks = useMemo(
     () => [
       {
-        title: t('wizard.storage.instance.deletionPolicy.policyLink.title'),
-        href: t('wizard.storage.instance.deletionPolicy.policyLink.href'),
+        title: t('wizard.storage.instance.deletionPolicy.fsxLink.title'),
+        href: t('wizard.storage.instance.deletionPolicy.fsxLink.href'),
+      },
+      {
+        title: t('wizard.storage.instance.deletionPolicy.efsLink.title'),
+        href: t('wizard.storage.instance.deletionPolicy.efsLink.href'),
+      },
+      {
+        title: t('wizard.storage.instance.deletionPolicy.ebsLink.title'),
+        href: t('wizard.storage.instance.deletionPolicy.ebsLink.href'),
       },
     ],
     [t],

--- a/frontend/src/old-pages/Configure/Storage/__tests__/DeletionPolicyFormField.test.tsx
+++ b/frontend/src/old-pages/Configure/Storage/__tests__/DeletionPolicyFormField.test.tsx
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import wrapper from '@cloudscape-design/components/test-utils/dom'
+import {render, RenderResult} from '@testing-library/react'
+import i18n from 'i18next'
+import {I18nextProvider, initReactI18next} from 'react-i18next'
+import {DeletionPolicy} from '../../Storage.types'
+import {DeletionPolicyFormField} from '../DeletionPolicyFormField'
+
+i18n.use(initReactI18next).init({
+  resources: {},
+  lng: 'en',
+})
+
+const MockProviders = (props: any) => (
+  <I18nextProvider i18n={i18n}>{props.children}</I18nextProvider>
+)
+
+describe('given a component to select from a range of deletion policy options', () => {
+  let screen: RenderResult
+  let mockDeletionPolicyOptions: DeletionPolicy[]
+  let mockOnChange: jest.Mock
+
+  beforeEach(() => {
+    mockDeletionPolicyOptions = ['Delete', 'Retain']
+    mockOnChange = jest.fn()
+    screen = render(
+      <MockProviders>
+        <DeletionPolicyFormField
+          options={mockDeletionPolicyOptions}
+          value={'Delete'}
+          onDeletionPolicyChange={mockOnChange}
+        />
+      </MockProviders>,
+    )
+  })
+
+  describe('when user selects an option', () => {
+    let selectedOption: DeletionPolicy = 'Retain'
+
+    beforeEach(() => {
+      const selectComponent = wrapper(screen.container).findSelect()!
+      selectComponent.openDropdown()
+      selectComponent.selectOptionByValue(selectedOption)
+    })
+
+    it('should pass the selected policy to the selection handler', () => {
+      expect(mockOnChange).toHaveBeenCalledTimes(1)
+      expect(mockOnChange).toHaveBeenCalledWith(selectedOption)
+    })
+  })
+})

--- a/frontend/src/old-pages/Configure/__tests__/storage.test.tsx
+++ b/frontend/src/old-pages/Configure/__tests__/storage.test.tsx
@@ -29,12 +29,6 @@ jest.mock('../../../store', () => {
   }
 })
 
-const mockUseFeatureFlag = jest.fn()
-
-jest.mock('../../../feature-flags/useFeatureFlag', () => ({
-  useFeatureFlag: (...args: unknown[]) => mockUseFeatureFlag(...args),
-}))
-
 i18n.use(initReactI18next).init({
   resources: {},
   lng: 'en',
@@ -177,12 +171,16 @@ describe('Given a Lustre storage component', () => {
     })
   })
 
-  describe('when lustre_deletion_policy is enabled', () => {
+  describe('when the version is at least 3.3.0', () => {
     let screen: RenderResult
 
     beforeEach(() => {
-      mockUseFeatureFlag.mockImplementation(flag => {
-        if (flag === 'lustre_deletion_policy') return true
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {
+            full: '3.3.0',
+          },
+        },
       })
       screen = render(
         <MockProviders>
@@ -213,12 +211,16 @@ describe('Given a Lustre storage component', () => {
     })
   })
 
-  describe('when lustre_deletion_policy is not enabled', () => {
+  describe('when the version is lesser than 3.3.0', () => {
     let screen: RenderResult
 
     beforeEach(() => {
-      mockUseFeatureFlag.mockImplementation(flag => {
-        if (flag === 'lustre_deletion_policy') return false
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {
+            full: '3.2.0',
+          },
+        },
       })
       screen = render(
         <MockProviders>
@@ -255,12 +257,16 @@ describe('given a component to display an Efs storage instance', () => {
     ;(setState as jest.Mock).mockClear()
   })
 
-  describe('when efs_deletion_policy is enabled', () => {
+  describe('when the version is at least 3.3.0', () => {
     let screen: RenderResult
 
     beforeEach(() => {
-      mockUseFeatureFlag.mockImplementation(flag => {
-        if (flag === 'efs_deletion_policy') return true
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {
+            full: '3.3.0',
+          },
+        },
       })
       screen = render(
         <MockProviders>
@@ -291,12 +297,16 @@ describe('given a component to display an Efs storage instance', () => {
     })
   })
 
-  describe('when efs_deletion_policy is not enabled', () => {
+  describe('when the version is lesser than 3.3.0', () => {
     let screen: RenderResult
 
     beforeEach(() => {
-      mockUseFeatureFlag.mockImplementation(flag => {
-        if (flag === 'efs_deletion_policy') return false
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {
+            full: '3.2.0',
+          },
+        },
       })
       screen = render(
         <MockProviders>
@@ -328,17 +338,21 @@ describe('given a component to display an Efs storage instance', () => {
   })
 })
 
-describe('given a component to display an Efs storage instance', () => {
+describe('given a component to display an Ebs storage instance', () => {
   beforeEach(() => {
     ;(setState as jest.Mock).mockClear()
   })
 
-  describe('when ebs_deletion_policy is enabled', () => {
+  describe('when the version is at least 3.2.0', () => {
     let screen: RenderResult
 
     beforeEach(() => {
-      mockUseFeatureFlag.mockImplementation(flag => {
-        if (flag === 'ebs_deletion_policy') return true
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {
+            full: '3.2.0',
+          },
+        },
       })
       screen = render(
         <MockProviders>
@@ -369,12 +383,16 @@ describe('given a component to display an Efs storage instance', () => {
     })
   })
 
-  describe('when ebs_deletion_policy is not enabled', () => {
+  describe('when the version is lesser than 3.2.0', () => {
     let screen: RenderResult
 
     beforeEach(() => {
-      mockUseFeatureFlag.mockImplementation(flag => {
-        if (flag === 'ebs_deletion_policy') return false
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {
+            full: '3.1.0',
+          },
+        },
       })
       screen = render(
         <MockProviders>

--- a/frontend/src/old-pages/Configure/__tests__/storage.test.tsx
+++ b/frontend/src/old-pages/Configure/__tests__/storage.test.tsx
@@ -17,7 +17,7 @@ import mock from 'jest-mock-extended/lib/Mock'
 import {Store} from '@reduxjs/toolkit'
 import {Provider} from 'react-redux'
 import {setState} from '../../../store'
-import {EfsSettings, FsxLustreSettings} from '../Storage'
+import {EbsSettings, EfsSettings, FsxLustreSettings} from '../Storage'
 
 jest.mock('../../../store', () => {
   const originalModule = jest.requireActual('../../../store')
@@ -314,6 +314,84 @@ describe('given a component to display an Efs storage instance', () => {
           'SharedStorage',
           0,
           'EfsSettings',
+          'DeletionPolicy',
+        ],
+        expect.any(String),
+      )
+    })
+
+    it('should not allow users to change the DeletionPolicy', () => {
+      expect(
+        screen.queryByLabelText('wizard.storage.instance.deletionPolicy.label'),
+      ).toBeNull()
+    })
+  })
+})
+
+describe('given a component to display an Efs storage instance', () => {
+  beforeEach(() => {
+    ;(setState as jest.Mock).mockClear()
+  })
+
+  describe('when ebs_deletion_policy is enabled', () => {
+    let screen: RenderResult
+
+    beforeEach(() => {
+      mockUseFeatureFlag.mockImplementation(flag => {
+        if (flag === 'ebs_deletion_policy') return true
+      })
+      screen = render(
+        <MockProviders>
+          <EbsSettings index={0} />
+        </MockProviders>,
+      )
+    })
+
+    it('should initialize the DeletionPolicy to Retain', () => {
+      expect(setState).toHaveBeenCalledWith(
+        [
+          'app',
+          'wizard',
+          'config',
+          'SharedStorage',
+          0,
+          'EbsSettings',
+          'DeletionPolicy',
+        ],
+        'Retain',
+      )
+    })
+
+    it('should allow users to change the DeletionPolicy', () => {
+      expect(
+        screen.queryByLabelText('wizard.storage.instance.deletionPolicy.label'),
+      ).toBeTruthy()
+    })
+  })
+
+  describe('when ebs_deletion_policy is not enabled', () => {
+    let screen: RenderResult
+
+    beforeEach(() => {
+      mockUseFeatureFlag.mockImplementation(flag => {
+        if (flag === 'ebs_deletion_policy') return false
+      })
+      screen = render(
+        <MockProviders>
+          <EbsSettings index={0} />
+        </MockProviders>,
+      )
+    })
+
+    it('should not initialize the DeletionPolicy', () => {
+      expect(setState).not.toHaveBeenCalledWith(
+        [
+          'app',
+          'wizard',
+          'config',
+          'SharedStorage',
+          0,
+          'EbsSettings',
           'DeletionPolicy',
         ],
         expect.any(String),

--- a/frontend/src/old-pages/Configure/__tests__/storage.test.tsx
+++ b/frontend/src/old-pages/Configure/__tests__/storage.test.tsx
@@ -17,7 +17,7 @@ import mock from 'jest-mock-extended/lib/Mock'
 import {Store} from '@reduxjs/toolkit'
 import {Provider} from 'react-redux'
 import {setState} from '../../../store'
-import {FsxLustreSettings} from '../Storage'
+import {EfsSettings, FsxLustreSettings} from '../Storage'
 
 jest.mock('../../../store', () => {
   const originalModule = jest.requireActual('../../../store')
@@ -236,6 +236,84 @@ describe('Given a Lustre storage component', () => {
           'SharedStorage',
           0,
           'FsxLustreSettings',
+          'DeletionPolicy',
+        ],
+        expect.any(String),
+      )
+    })
+
+    it('should not allow users to change the DeletionPolicy', () => {
+      expect(
+        screen.queryByLabelText('wizard.storage.instance.deletionPolicy.label'),
+      ).toBeNull()
+    })
+  })
+})
+
+describe('given a component to display an Efs storage instance', () => {
+  beforeEach(() => {
+    ;(setState as jest.Mock).mockClear()
+  })
+
+  describe('when efs_deletion_policy is enabled', () => {
+    let screen: RenderResult
+
+    beforeEach(() => {
+      mockUseFeatureFlag.mockImplementation(flag => {
+        if (flag === 'efs_deletion_policy') return true
+      })
+      screen = render(
+        <MockProviders>
+          <EfsSettings index={0} />
+        </MockProviders>,
+      )
+    })
+
+    it('should initialize the DeletionPolicy to Retain', () => {
+      expect(setState).toHaveBeenCalledWith(
+        [
+          'app',
+          'wizard',
+          'config',
+          'SharedStorage',
+          0,
+          'EfsSettings',
+          'DeletionPolicy',
+        ],
+        'Retain',
+      )
+    })
+
+    it('should allow users to change the DeletionPolicy', () => {
+      expect(
+        screen.queryByLabelText('wizard.storage.instance.deletionPolicy.label'),
+      ).toBeTruthy()
+    })
+  })
+
+  describe('when efs_deletion_policy is not enabled', () => {
+    let screen: RenderResult
+
+    beforeEach(() => {
+      mockUseFeatureFlag.mockImplementation(flag => {
+        if (flag === 'efs_deletion_policy') return false
+      })
+      screen = render(
+        <MockProviders>
+          <EfsSettings index={0} />
+        </MockProviders>,
+      )
+    })
+
+    it('should not initialize the DeletionPolicy', () => {
+      expect(setState).not.toHaveBeenCalledWith(
+        [
+          'app',
+          'wizard',
+          'config',
+          'SharedStorage',
+          0,
+          'EfsSettings',
           'DeletionPolicy',
         ],
         expect.any(String),


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR adds support for the `DeletionPolicy` configuration for Efs and FsxLustre storage types.

## Changes

- add `DeletionPolicyFormField`
- only show the field for versions that support the `DeletionPolicy` (Ebs: 3.2.0, Efs and FsxLustre: 3.3.0)
- support `Delete` and `Retain` for Efs and FsxLustre, support also `Snapshot` for Ebs
- default to `Retain` for every storage type
- add tests to the single storage instance

## How Has This Been Tested?

- manually, by adding all storage types and running the dry run
- manually, by changing PC version and making sure nothing is displayed
- unit/integration tests

## Screenshots

**FsxLustre**

<img width="532" alt="image" src="https://user-images.githubusercontent.com/11457067/221603590-cb3a7fcf-c914-4ed1-a22f-ad32f77af892.png">

**Efs**

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/11457067/221603662-c4e01268-0b3d-447a-9bd9-c56338b38191.png">

**Ebs**

<img width="577" alt="image" src="https://user-images.githubusercontent.com/11457067/221603733-333973d2-ca6d-4d04-b7e4-0b4783fdfe4e.png">

## References

Closes #70 

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
