### PR TITLE
Increase queues limits

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -798,7 +798,7 @@
       },
       "container": {
         "title": "Queues",
-        "description": "Configure up to 5 queues (Slurm partitions)."
+        "description": "Configure up to 10 queues (Slurm partitions)."
       },
       "slurmMemorySettings": {
         "container": {
@@ -835,7 +835,7 @@
       "computeResource": {
         "header": {
           "title": "Compute resources",
-          "description": "Configure up to 3 compute resources."
+          "description": "Configure up to 5 compute resources."
         },
         "addComputeResource": "Add compute resource",
         "staticNodes": "Static nodes",

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -798,7 +798,7 @@
       },
       "container": {
         "title": "Queues",
-        "description": "Configure up to 10 queues (Slurm partitions)."
+        "description": "Configure up to {{limit}} queues (Slurm partitions)."
       },
       "slurmMemorySettings": {
         "container": {
@@ -835,7 +835,7 @@
       "computeResource": {
         "header": {
           "title": "Compute resources",
-          "description": "Configure up to 5 compute resources."
+          "description": "Configure up to {{limit}} compute resources."
         },
         "addComputeResource": "Add compute resource",
         "staticNodes": "Static nodes",

--- a/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
@@ -73,7 +73,7 @@ describe('Given a list of queues', () => {
     })
   })
 
-  describe("when they're more than 10", () => {
+  describe("when they're 10 or more", () => {
     beforeEach(() => {
       mockStore.getState.mockReturnValue({
         app: {
@@ -103,7 +103,7 @@ describe('Given a list of queues', () => {
     })
   })
 
-  describe("when they're 10 or less", () => {
+  describe("when they're less than 10", () => {
     beforeEach(() => {
       mockStore.getState.mockReturnValue({
         app: {
@@ -133,7 +133,7 @@ describe('Given a list of queues', () => {
     })
   })
 
-  describe('when the compute resources of a queue are more than 5', () => {
+  describe('when the compute resources of a queue are 5', () => {
     beforeEach(() => {
       mockStore.getState.mockReturnValue({
         app: {
@@ -170,7 +170,7 @@ describe('Given a list of queues', () => {
     })
   })
 
-  describe('when the compute resources of a queue are 5 or less', () => {
+  describe('when the compute resources of a queue are less then 5', () => {
     beforeEach(() => {
       mockStore.getState.mockReturnValue({
         app: {

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -250,7 +250,9 @@ function ComputeResources({queue, index, canUseEFA}: any) {
     <Container>
       <Header
         variant="h3"
-        description={t('wizard.queues.computeResource.header.description')}
+        description={t('wizard.queues.computeResource.header.description', {
+          limit: MAX_COMPUTE_RESOURCES,
+        })}
       >
         {t('wizard.queues.computeResource.header.title')}
       </Header>
@@ -579,7 +581,9 @@ function Queues() {
         header={
           <Header
             variant="h2"
-            description={t('wizard.queues.container.description')}
+            description={t('wizard.queues.container.description', {
+              limit: MAX_QUEUES,
+            })}
           >
             {t('wizard.queues.container.title')}
           </Header>

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -59,6 +59,9 @@ import {useHelpPanel} from '../../../components/help-panel/HelpPanel'
 const queuesPath = ['app', 'wizard', 'config', 'Scheduling', 'SlurmQueues']
 const queuesErrorsPath = ['app', 'wizard', 'errors', 'queues']
 
+const MAX_COMPUTE_RESOURCES = 5
+const MAX_QUEUES = 10
+
 function itemToOption([value, label]: string[]) {
   return {
     value: value,
@@ -401,7 +404,9 @@ function Queue({index}: any) {
             actions={
               <SpaceBetween direction="horizontal" size="xs">
                 <Button
-                  disabled={queue.ComputeResources.length >= 3}
+                  disabled={
+                    queue.ComputeResources.length >= MAX_COMPUTE_RESOURCES
+                  }
                   onClick={addComputeResource}
                 >
                   {t('wizard.queues.computeResource.addComputeResource')}
@@ -582,7 +587,7 @@ function Queues() {
       >
         <QueuesView />
         <Box float="right">
-          <Button disabled={queues.length >= 5} onClick={addQueue}>
+          <Button disabled={queues.length >= MAX_QUEUES} onClick={addQueue}>
             {t('wizard.queues.addQueueButton.label')}
           </Button>
         </Box>

--- a/frontend/src/old-pages/Configure/useWizardNavigation.ts
+++ b/frontend/src/old-pages/Configure/useWizardNavigation.ts
@@ -2,7 +2,7 @@ import {getState, setState, updateState, useState} from '../../store'
 // @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'js-y... Remove this comment to see the full error message
 import jsyaml from 'js-yaml'
 
-const pages = ['source', 'cluster', 'headNode', 'storage', 'queues', 'create']
+const pages = ['source', 'cluster', 'headNode', 'queues', 'storage', 'create']
 
 export const useWizardNavigation = (validate: (page: string) => boolean) => {
   const currentPage = useState(['app', 'wizard', 'page']) || 'source'


### PR DESCRIPTION
## Changes

- increases queues limits to 10 and compute resources to 5
- fixes a bug introduced after #67 

## How Has This Been Tested?

Validated with a dry run after adding 10 queues and 5 compute resources on the first queue

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
