### PR TITLE
Use Tiles to select Operating System

### DIFF
--- a/frontend/src/old-pages/Configure/Cluster.tsx
+++ b/frontend/src/old-pages/Configure/Cluster.tsx
@@ -43,9 +43,9 @@ import {
 } from '@cloudscape-design/components/internal/events'
 import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
 import {useHelpPanel} from '../../components/help-panel/HelpPanel'
-import {useCallback, useMemo} from 'react'
-import {OptionDefinition} from '@cloudscape-design/components/internal/components/option/interfaces'
+import {useCallback} from 'react'
 import {SelectProps} from '@cloudscape-design/components/select/interfaces'
+import {OsFormField} from './Cluster/OsFormField'
 
 // Constants
 const errorsPath = ['app', 'wizard', 'errors', 'cluster']
@@ -224,48 +224,6 @@ function initWizardState(
   )
 }
 
-function OsSelect() {
-  const {t} = useTranslation()
-  const oses: [string, string][] = [
-    ['alinux2', 'Amazon Linux 2'],
-    ['centos7', 'CentOS 7'],
-    ['ubuntu1804', 'Ubuntu 18.04'],
-    ['ubuntu2004', 'Ubuntu 20.04'],
-  ]
-  const osPath = ['app', 'wizard', 'config', 'Image', 'Os']
-  const os = useState(osPath) || 'alinux2'
-  const editing = useState(['app', 'wizard', 'editing'])
-
-  const osesOptions = useMemo(() => oses.map(itemToOption), [oses])
-
-  const selectedOs: OptionDefinition | null = useMemo(() => {
-    const selectedOsTuple = findFirst(oses, (x: any) => x[0] === os) || null
-    return itemToOption(selectedOsTuple)
-  }, [os, oses])
-
-  const handleChange = useCallback(({detail}: any) => {
-    setState(osPath, detail.selectedOption.value)
-  }, [])
-
-  return (
-    <>
-      <FormField
-        label={t('wizard.cluster.os.label')}
-        description={t('wizard.cluster.os.description')}
-      >
-        <Select
-          disabled={editing}
-          selectedOption={selectedOs}
-          onChange={handleChange}
-          // @ts-expect-error TS(2322) FIXME: Type '({ label: Element; value: string; } | undefi... Remove this comment to see the full error message
-          options={osesOptions}
-          selectedAriaLabel={t('wizard.cluster.os.selectedAriaLabel')}
-        />
-      </FormField>
-    </>
-  )
-}
-
 function VpcSelect() {
   const {t} = useTranslation()
   const vpcs = useState(['aws', 'vpcs']) || []
@@ -432,7 +390,7 @@ function Cluster() {
       <Container>
         <SpaceBetween direction="vertical" size="s">
           <RegionSelect />
-          <OsSelect />
+          <OsFormField />
           <VpcSelect />
           <CustomAMISettings
             basePath={configPath}

--- a/frontend/src/old-pages/Configure/Cluster/OsFormField.tsx
+++ b/frontend/src/old-pages/Configure/Cluster/OsFormField.tsx
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react'
+import {useTranslation} from 'react-i18next'
+import {findFirst} from '../../../util'
+import {FormField, Select} from '@cloudscape-design/components'
+import {setState, useState} from '../../../store'
+import {useCallback, useMemo} from 'react'
+import {OptionDefinition} from '@cloudscape-design/components/internal/components/option/interfaces'
+import {itemToOption} from '../Cluster'
+
+export function OsFormField() {
+  const {t} = useTranslation()
+  const oses: [string, string][] = [
+    ['alinux2', 'Amazon Linux 2'],
+    ['centos7', 'CentOS 7'],
+    ['ubuntu1804', 'Ubuntu 18.04'],
+    ['ubuntu2004', 'Ubuntu 20.04'],
+  ]
+  const osPath = ['app', 'wizard', 'config', 'Image', 'Os']
+  const os = useState(osPath) || 'alinux2'
+  const editing = useState(['app', 'wizard', 'editing'])
+
+  const osesOptions = useMemo(() => oses.map(itemToOption), [oses])
+
+  const selectedOs: OptionDefinition | null = useMemo(() => {
+    const selectedOsTuple = findFirst(oses, (x: any) => x[0] === os) || null
+    return itemToOption(selectedOsTuple)
+  }, [os, oses])
+
+  const handleChange = useCallback(({detail}: any) => {
+    setState(osPath, detail.selectedOption.value)
+  }, [])
+
+  return (
+    <>
+      <FormField
+        label={t('wizard.cluster.os.label')}
+        description={t('wizard.cluster.os.description')}
+      >
+        <Select
+          disabled={editing}
+          selectedOption={selectedOs}
+          onChange={handleChange}
+          // @ts-expect-error TS(2322) FIXME: Type '({ label: Element; value: string; } | undefi... Remove this comment to see the full error message
+          options={osesOptions}
+          selectedAriaLabel={t('wizard.cluster.os.selectedAriaLabel')}
+        />
+      </FormField>
+    </>
+  )
+}

--- a/frontend/src/old-pages/Configure/Cluster/OsFormField.tsx
+++ b/frontend/src/old-pages/Configure/Cluster/OsFormField.tsx
@@ -9,37 +9,34 @@
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as React from 'react'
+import {FormField, Tiles, TilesProps} from '@cloudscape-design/components'
+import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
+import {useCallback} from 'react'
 import {useTranslation} from 'react-i18next'
-import {findFirst} from '../../../util'
-import {FormField, Select} from '@cloudscape-design/components'
 import {setState, useState} from '../../../store'
-import {useCallback, useMemo} from 'react'
-import {OptionDefinition} from '@cloudscape-design/components/internal/components/option/interfaces'
-import {itemToOption} from '../Cluster'
+
+const osPath = ['app', 'wizard', 'config', 'Image', 'Os']
+
+const SUPPORTED_OSES_LIST: TilesProps.TilesDefinition[] = [
+  {value: 'alinux2', label: 'Amazon Linux 2'},
+  {value: 'centos7', label: 'CentOS 7'},
+  {value: 'ubuntu1804', label: 'Ubuntu 18.04'},
+  {value: 'ubuntu2004', label: 'Ubuntu 20.04'},
+]
 
 export function OsFormField() {
   const {t} = useTranslation()
-  const oses: [string, string][] = [
-    ['alinux2', 'Amazon Linux 2'],
-    ['centos7', 'CentOS 7'],
-    ['ubuntu1804', 'Ubuntu 18.04'],
-    ['ubuntu2004', 'Ubuntu 20.04'],
-  ]
-  const osPath = ['app', 'wizard', 'config', 'Image', 'Os']
-  const os = useState(osPath) || 'alinux2'
   const editing = useState(['app', 'wizard', 'editing'])
+  const selectedOsValue = useState(osPath) || 'alinux2'
 
-  const osesOptions = useMemo(() => oses.map(itemToOption), [oses])
+  const osesList = editing
+    ? SUPPORTED_OSES_LIST.map(os => ({...os, disabled: true}))
+    : SUPPORTED_OSES_LIST
 
-  const selectedOs: OptionDefinition | null = useMemo(() => {
-    const selectedOsTuple = findFirst(oses, (x: any) => x[0] === os) || null
-    return itemToOption(selectedOsTuple)
-  }, [os, oses])
-
-  const handleChange = useCallback(({detail}: any) => {
-    setState(osPath, detail.selectedOption.value)
-  }, [])
+  const handleChange: NonCancelableEventHandler<TilesProps.ChangeDetail> =
+    useCallback(({detail}) => {
+      setState(osPath, detail.value)
+    }, [])
 
   return (
     <>
@@ -47,13 +44,10 @@ export function OsFormField() {
         label={t('wizard.cluster.os.label')}
         description={t('wizard.cluster.os.description')}
       >
-        <Select
-          disabled={editing}
-          selectedOption={selectedOs}
+        <Tiles
+          items={osesList}
+          value={selectedOsValue}
           onChange={handleChange}
-          // @ts-expect-error TS(2322) FIXME: Type '({ label: Element; value: string; } | undefi... Remove this comment to see the full error message
-          options={osesOptions}
-          selectedAriaLabel={t('wizard.cluster.os.selectedAriaLabel')}
         />
       </FormField>
     </>

--- a/frontend/src/old-pages/Configure/Cluster/__tests__/OsFormField.test.tsx
+++ b/frontend/src/old-pages/Configure/Cluster/__tests__/OsFormField.test.tsx
@@ -1,0 +1,93 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Store} from '@reduxjs/toolkit'
+import {fireEvent, render, RenderResult} from '@testing-library/react'
+import i18n from 'i18next'
+import {mock} from 'jest-mock-extended'
+import {I18nextProvider, initReactI18next} from 'react-i18next'
+import {Provider} from 'react-redux'
+import {setState as mockSetState} from '../../../../store'
+import {OsFormField} from '../OsFormField'
+
+jest.mock('../../../../store', () => {
+  const originalModule = jest.requireActual('../../../../store')
+
+  return {
+    __esModule: true, // Use it when dealing with esModules
+    ...originalModule,
+    setState: jest.fn(),
+  }
+})
+
+i18n.use(initReactI18next).init({
+  resources: {},
+  lng: 'en',
+})
+
+const mockStore = mock<Store>()
+const MockProviders = (props: any) => (
+  <Provider store={mockStore}>
+    <I18nextProvider i18n={i18n}>{props.children}</I18nextProvider>
+  </Provider>
+)
+
+describe('given a component to select an Operating System', () => {
+  let screen: RenderResult
+
+  beforeEach(() => {
+    ;(mockSetState as jest.Mock).mockClear()
+  })
+
+  describe('when user selects an option', () => {
+    beforeEach(() => {
+      screen = render(
+        <MockProviders>
+          <OsFormField />
+        </MockProviders>,
+      )
+
+      fireEvent.click(screen.getByLabelText('CentOS 7'))
+    })
+
+    it('should store the OS in the cluster config', () => {
+      expect(mockSetState).toHaveBeenCalledTimes(1)
+      expect(mockSetState).toHaveBeenCalledWith(
+        ['app', 'wizard', 'config', 'Image', 'Os'],
+        'centos7',
+      )
+    })
+  })
+
+  describe('when user is editing a cluster', () => {
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        app: {wizard: {editing: true}},
+      })
+    })
+
+    describe('when user selects an option', () => {
+      beforeEach(() => {
+        screen = render(
+          <MockProviders>
+            <OsFormField />
+          </MockProviders>,
+        )
+
+        fireEvent.click(screen.getByLabelText('CentOS 7'))
+      })
+
+      it('should be disabled', () => {
+        expect(mockSetState).toHaveBeenCalledTimes(0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR adopts the [Tiles](https://cloudscape.design/components/tiles/?tabId=api) component to let users select the Operating System

## Changes

- replace `Select` with `Tiles`
- add test

## Screenshots

![image](https://user-images.githubusercontent.com/11457067/221852414-6c2d457e-cff4-492b-82a1-14b0b9940d6b.png)

## How Has This Been Tested?

- manually
- unit test

## References

- [Tiles](https://cloudscape.design/components/tiles/?tabId=api)

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
