### PR TITLE
Adjust queue name design

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -795,6 +795,7 @@
         }
       },
       "validation": {
+        "emptyName": "Queue name cannot be null",
         "instanceTypeUnique": "Instance types must be unique within a queue.",
         "instanceTypeMissing": "Select at least one instance type.",
         "selectSubnet": "You must select a subnet.",
@@ -868,6 +869,9 @@
       },
       "placementGroup": {
         "label": "Use placement group"
+      },
+      "name": {
+        "label": "Queue name"
       },
       "subnet": {
         "label": {

--- a/frontend/src/old-pages/Configure/Queues/__tests__/validateQueueName.test.ts
+++ b/frontend/src/old-pages/Configure/Queues/__tests__/validateQueueName.test.ts
@@ -1,0 +1,16 @@
+import {validateQueueName} from '../queues.validators'
+
+describe('Given a queue name', () => {
+  describe("when it's defined", () => {
+    it('should be validated', () => {
+      const queueName = 'Queue 0'
+      expect(validateQueueName(queueName)).toEqual([true])
+    })
+  })
+
+  describe("when it's blank", () => {
+    it('should fail the validation', () => {
+      expect(validateQueueName('')).toEqual([false, 'empty'])
+    })
+  })
+})

--- a/frontend/src/old-pages/Configure/Queues/queues.validators.tsx
+++ b/frontend/src/old-pages/Configure/Queues/queues.validators.tsx
@@ -1,0 +1,13 @@
+export const queueNameErrorsMapping = {
+  empty: 'wizard.queues.validation.emptyName',
+}
+type QueueNameErrorKind = keyof typeof queueNameErrorsMapping
+
+export function validateQueueName(
+  name: string,
+): [boolean, QueueNameErrorKind?] {
+  if (!name) {
+    return [false, 'empty']
+  }
+  return [true]
+}


### PR DESCRIPTION
## Description
This PR adjust the design of the queue name form field in the Queues page of the wizard. Furthermore, it adds a validator to check that the field is not empty.

## How Has This Been Tested?

* Unit tests
* Manual tests

## References
* https://cloudscape.design/components/form-field

## Screenshots

<img width="1721" alt="Screenshot 2023-02-28 at 15 51 29" src="https://user-images.githubusercontent.com/25930133/221894364-74fcd116-1e2d-4d74-a9ba-cf677fff52c3.png">

## PR Quality Checklist

- [x] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
