### PR TITLE
Move Slurm accounting settings under Cluster page

### DIFF
--- a/frontend/src/old-pages/Configure/Cluster.tsx
+++ b/frontend/src/old-pages/Configure/Cluster.tsx
@@ -46,6 +46,10 @@ import {useHelpPanel} from '../../components/help-panel/HelpPanel'
 import {useCallback} from 'react'
 import {SelectProps} from '@cloudscape-design/components/select/interfaces'
 import {OsFormField} from './Cluster/OsFormField'
+import {
+  slurmAccountingValidateAndSetErrors,
+  SlurmSettings,
+} from './SlurmSettings/SlurmSettings'
 
 // Constants
 const errorsPath = ['app', 'wizard', 'errors', 'cluster']
@@ -90,6 +94,11 @@ function clusterValidate() {
     valid = false
   } else {
     clearState([...errorsPath, 'multiUser'])
+  }
+
+  const accountingValid = slurmAccountingValidateAndSetErrors()
+  if (!accountingValid) {
+    valid = false
   }
 
   return valid
@@ -386,7 +395,7 @@ function Cluster() {
   }
 
   return (
-    <SpaceBetween direction="vertical" size="s">
+    <SpaceBetween direction="vertical" size="l">
       <Container>
         <SpaceBetween direction="vertical" size="s">
           <RegionSelect />
@@ -413,6 +422,7 @@ function Cluster() {
         </SpaceBetween>
       </Container>
       {multiUserEnabled && <MultiUser />}
+      <SlurmSettings />
     </SpaceBetween>
   )
 }

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -51,10 +51,6 @@ import {
   ActionsEditor,
 } from './Components'
 import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
-import {
-  slurmAccountingValidateAndSetErrors,
-  SlurmSettings,
-} from './SlurmSettings/SlurmSettings'
 import InfoLink from '../../components/InfoLink'
 import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
 import {useHelpPanel} from '../../components/help-panel/HelpPanel'
@@ -171,11 +167,6 @@ function headNodeValidate() {
     valid = false
   } else {
     clearState([...errorsPath, 'onUpdated'])
-  }
-
-  const accountingValid = slurmAccountingValidateAndSetErrors()
-  if (!accountingValid) {
-    valid = false
   }
 
   setState([...errorsPath, 'validated'], true)
@@ -522,7 +513,6 @@ function HeadNode() {
           </ExpandableSection>
         </SpaceBetween>
       </Container>
-      <SlurmSettings />
     </ColumnLayout>
   )
 }

--- a/frontend/src/old-pages/Configure/SlurmSettings/SlurmAccountingForm.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/SlurmAccountingForm.tsx
@@ -112,10 +112,6 @@ export const SlurmAccountingForm: React.FC<Props> = ({
   passwordPath,
   passwordErrorPath,
 }) => {
-  const isSlurmAccountingEnabled = useFeatureFlag('slurm_accounting')
-
-  if (!isSlurmAccountingEnabled) return null
-
   return (
     <>
       <ColumnLayout columns={2}>

--- a/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
@@ -17,6 +17,7 @@ import {setState, getState, clearState} from '../../../store'
 import {SlurmAccountingForm} from './SlurmAccountingForm'
 import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
 import InfoLink from '../../../components/InfoLink'
+import {useFeatureFlag} from '../../../feature-flags/useFeatureFlag'
 
 const slurmSettingsPath = [
   'app',
@@ -78,6 +79,10 @@ function slurmAccountingSetErrors(
 
 function SlurmSettings() {
   const {t} = useTranslation()
+
+  const isSlurmAccountingEnabled = useFeatureFlag('slurm_accounting')
+
+  if (!isSlurmAccountingEnabled) return null
 
   return (
     <Container

--- a/frontend/src/old-pages/Configure/SlurmSettings/__tests__/SlurmSettings.test.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/__tests__/SlurmSettings.test.tsx
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {render, RenderResult} from '@testing-library/react'
+import {I18nextProvider} from 'react-i18next'
+import i18n from 'i18next'
+import {initReactI18next} from 'react-i18next'
+import mock from 'jest-mock-extended/lib/Mock'
+import {Store} from '@reduxjs/toolkit'
+import {Provider} from 'react-redux'
+import {SlurmSettings} from '../SlurmSettings'
+
+i18n.use(initReactI18next).init({
+  resources: {},
+  lng: 'en',
+})
+
+const mockStore = mock<Store>()
+const MockProviders = (props: any) => (
+  <Provider store={mockStore}>
+    <I18nextProvider i18n={i18n}>{props.children}</I18nextProvider>
+  </Provider>
+)
+
+describe('given a component to configure the SlurmSettings', () => {
+  describe('when the version is at least 3.3.0', () => {
+    let screen: RenderResult
+
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {
+            full: '3.3.0',
+          },
+        },
+      })
+      screen = render(
+        <MockProviders>
+          <SlurmSettings />
+        </MockProviders>,
+      )
+    })
+
+    it('should render the form', () => {
+      expect(
+        screen.queryByText('wizard.headNode.slurmSettings.container.title'),
+      ).toBeTruthy()
+    })
+  })
+
+  describe('when the version is lesser than 3.3.0', () => {
+    let screen: RenderResult
+
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {
+            full: '3.2.0',
+          },
+        },
+      })
+      screen = render(
+        <MockProviders>
+          <SlurmSettings />
+        </MockProviders>,
+      )
+    })
+
+    it('should hide the form', () => {
+      expect(
+        screen.queryByText('wizard.headNode.slurmSettings.container.title'),
+      ).toBeNull()
+    })
+  })
+})

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -1135,7 +1135,7 @@ function Storage() {
   )
 
   return (
-    <SpaceBetween direction="vertical" size="xl">
+    <SpaceBetween direction="vertical" size="l">
       <Container>
         <SpaceBetween direction="vertical" size="m">
           {!hasAddedStorage && (


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR moves the Slurm Settings section from the HeadNode section to the Cluster section

## Changes

- move `SlurmSettings` to the Cluster section (both component and validation)
- adjust spacing between Storage instances for consistency  
- fix `SlurmSettings` container rendering empty in older versions of PC

## Screenshots

![image](https://user-images.githubusercontent.com/11457067/222111062-61e4cf71-21d2-4a93-b5d7-322ed8e5a9bc.png)

## How Has This Been Tested?

- manually, attempted a dry run
- added unit test

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
