### PR TITLE
Disabled multithreading options when an hpc instance is selected

### DIFF
--- a/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
@@ -233,6 +233,116 @@ describe('Given a queue', () => {
       expect(queueValidate).toHaveBeenCalledWith(queueIndex)
     })
   })
+
+  describe('when an HPC instance is selected', () => {
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        aws: {
+          subnets: [],
+        },
+        app: {
+          version: {
+            full: '3.4.0',
+          },
+          wizard: {
+            config: {
+              Scheduling: {
+                SlurmQueues: [
+                  {
+                    Name: `queue-0`,
+                    ComputeResources: [
+                      {
+                        Instances: [{InstanceType: 'hpc6a.48xlarge'}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      })
+    })
+    it('should not let the user select multithreading options', () => {
+      const {getByText} = render(
+        <MockProviders store={mockStore}>
+          <Queues />
+        </MockProviders>,
+      )
+
+      const multithreadingCheckbox = getByText('Turn off multithreading')
+      fireEvent.click(multithreadingCheckbox)
+      expect(setState).not.toHaveBeenCalledWith(
+        [
+          'app',
+          'wizard',
+          'config',
+          'Scheduling',
+          'SlurmQueues',
+          0,
+          'ComputeResources',
+          0,
+          'DisableSimultaneousMultithreading',
+        ],
+        true,
+      )
+    })
+  })
+
+  describe('when an HPC instance is not selected', () => {
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        aws: {
+          subnets: [],
+        },
+        app: {
+          version: {
+            full: '3.4.0',
+          },
+          wizard: {
+            config: {
+              Scheduling: {
+                SlurmQueues: [
+                  {
+                    Name: `queue-0`,
+                    ComputeResources: [
+                      {
+                        Instances: [{InstanceType: 'c5n.large'}],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      })
+    })
+    it('should let the user select multithreading options', () => {
+      const {getByText} = render(
+        <MockProviders store={mockStore}>
+          <Queues />
+        </MockProviders>,
+      )
+
+      const multithreadingCheckbox = getByText('Turn off multithreading')
+      fireEvent.click(multithreadingCheckbox)
+      expect(setState).toHaveBeenCalledWith(
+        [
+          'app',
+          'wizard',
+          'config',
+          'Scheduling',
+          'SlurmQueues',
+          0,
+          'ComputeResources',
+          0,
+          'DisableSimultaneousMultithreading',
+        ],
+        true,
+      )
+    })
+  })
 })
 
 describe('Given a list of compute resources', () => {


### PR DESCRIPTION
## Description

Since multi-threading is not enabled for HPC instances, the corresponding queues options are now disabled.

## How Has This Been Tested?

- Selected two instances for compute resources, one is a `hpc6a.48xlarge`
- "Turn off multithreading" is disabled and cannot be selected
- the setting is not present in the final config

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
