### PR TITLE
Refactor design of Queues wizard page

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -798,6 +798,8 @@
       },
       "validation": {
         "emptyName": "Queue name cannot be null",
+        "maxLengthName": "Name can be at most {{maxChars}} characters",
+        "forbiddenCharsName": "Name must start with a lowercase letter and can only contain lowercase letters, numbers and hyphens",
         "instanceTypeUnique": "Instance types must be unique within a queue.",
         "instanceTypeMissing": "Select at least one instance type.",
         "selectSubnet": "You must select a subnet.",
@@ -806,10 +808,6 @@
         "rootVolumeMinimum": "You must use an integer >= 35GB for root volume size.",
         "scriptWithArgs": "You must specify a script path if you specify args.",
         "customAmiSelect": "You must select an AMI ID if you use a custom AMI."
-      },
-      "container": {
-        "title": "Queues",
-        "description": "Configure up to {{limit}} queues (Slurm partitions)."
       },
       "slurmMemorySettings": {
         "container": {
@@ -847,6 +845,9 @@
         "header": {
           "title": "Compute resources",
           "description": "Configure up to {{limit}} compute resources."
+        },
+        "removeComputeResourceButton": {
+          "label": "Remove resource"
         },
         "addComputeResource": "Add compute resource",
         "staticNodes": "Static nodes",

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -780,7 +780,7 @@
     },
     "queues": {
       "title": "Queues",
-      "description": "Configure the cluster queues.",
+      "description": "Configure up to {{limit}} cluster queues.",
       "help": {
         "main": "<p>Configure your cluster queues for job scheduling.</p><p>Add and remove queues and queue compute resources.</p><p>Choose <strong>Refresh</strong> to view recently changed or added AWS resources.</p>",
         "schedulerLink": {

--- a/frontend/src/old-pages/Configure/Cluster.tsx
+++ b/frontend/src/old-pages/Configure/Cluster.tsx
@@ -221,7 +221,7 @@ function initWizardState(
     [...configPath, 'Scheduling', 'SlurmQueues'],
     [
       {
-        Name: 'queue0',
+        Name: 'queue-0',
         AllocationStrategy: isMultipleInstanceTypesActive
           ? 'lowest-price'
           : undefined,

--- a/frontend/src/old-pages/Configure/Configure.tsx
+++ b/frontend/src/old-pages/Configure/Configure.tsx
@@ -29,7 +29,12 @@ import {
   headNodeValidate,
 } from './HeadNode'
 import {Storage, StorageHelpPanel, storageValidate} from './Storage'
-import {Queues, QueuesHelpPanel, queuesValidate} from './Queues/Queues'
+import {
+  MAX_QUEUES,
+  Queues,
+  QueuesHelpPanel,
+  queuesValidate,
+} from './Queues/Queues'
 import {
   Create,
   CreateReviewHelpPanel,
@@ -260,7 +265,7 @@ function Configure() {
           },
           {
             title: t('wizard.queues.title'),
-            description: t('wizard.queues.description'),
+            description: t('wizard.queues.description', {limit: MAX_QUEUES}),
             content: <Queues />,
             info: <InfoLink helpPanel={<QueuesHelpPanel />} />,
           },

--- a/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
@@ -201,9 +201,18 @@ export function ComputeResource({
   return (
     <div className="compute-resource">
       <div style={{display: 'flex', flexDirection: 'column', gap: '10px'}}>
-        <Box margin={{top: 'xs'}} textAlign="right">
-          {index > 0 && <Button onClick={remove}>Remove Resource</Button>}
-        </Box>
+        <ColumnLayout columns={2}>
+          <h4>{computeResource.Name}</h4>
+          <Box margin={{top: 'xs'}} textAlign="right">
+            {index > 0 && (
+              <Button onClick={remove}>
+                {t(
+                  'wizard.queues.computeResource.removeComputeResourceButton.label',
+                )}
+              </Button>
+            )}
+          </Box>
+        </ColumnLayout>
         <ColumnLayout columns={2}>
           <div style={{display: 'flex', flexDirection: 'row', gap: '20px'}}>
             <FormField label={t('wizard.queues.computeResource.staticNodes')}>
@@ -294,7 +303,7 @@ export function createComputeResource(
   crIndex: number,
 ): MultiInstanceComputeResource {
   return {
-    Name: `queue${queueIndex}-compute-resource-${crIndex}`,
+    Name: `queue-${queueIndex}-cr-${crIndex}`,
     Instances: [
       {
         InstanceType: defaultInstanceType,
@@ -311,7 +320,7 @@ export function updateComputeResourcesNames(
 ): MultiInstanceComputeResource[] {
   return computeResources.map((cr, i) => ({
     ...cr,
-    Name: `${newQueueName}-compute-resource-${i}`,
+    Name: `${newQueueName}-cr-${i}`,
   }))
 }
 

--- a/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
@@ -74,16 +74,24 @@ describe('Given a list of queues', () => {
   })
 
   describe("when they're 10 or more", () => {
+    const queues = new Array(11).fill(null).map((_, index) => ({
+      Name: `queue-${index}`,
+      ComputeResources: [],
+      ComputeSettings: {
+        LocalStorage: {
+          RootVolume: {
+            VolumeType: 'gp3',
+          },
+        },
+      },
+    }))
     beforeEach(() => {
       mockStore.getState.mockReturnValue({
         app: {
           wizard: {
             config: {
               Scheduling: {
-                SlurmQueues: new Array(11).map(index => ({
-                  Name: `queue-${index}`,
-                  ComputeResources: [],
-                })),
+                SlurmQueues: queues,
               },
             },
           },
@@ -104,16 +112,24 @@ describe('Given a list of queues', () => {
   })
 
   describe("when they're less than 10", () => {
+    const queues = new Array(5).fill(null).map((_, index) => ({
+      Name: `queue-${index}`,
+      ComputeResources: [],
+      ComputeSettings: {
+        LocalStorage: {
+          RootVolume: {
+            VolumeType: 'gp3',
+          },
+        },
+      },
+    }))
     beforeEach(() => {
       mockStore.getState.mockReturnValue({
         app: {
           wizard: {
             config: {
               Scheduling: {
-                SlurmQueues: new Array(5).map(index => ({
-                  Name: `queue-${index}`,
-                  ComputeResources: [],
-                })),
+                SlurmQueues: queues,
               },
             },
           },
@@ -143,7 +159,7 @@ describe('Given a list of queues', () => {
                 SlurmQueues: [
                   {
                     Name: 'queue-0',
-                    ComputeResources: new Array(5).map(index => ({
+                    ComputeResources: new Array(5).fill(null).map(index => ({
                       Name: `cr-${index}`,
                     })),
                   },
@@ -180,7 +196,7 @@ describe('Given a list of queues', () => {
                 SlurmQueues: [
                   {
                     Name: 'queue-0',
-                    ComputeResources: new Array(2).map(index => ({
+                    ComputeResources: new Array(2).fill(null).map(index => ({
                       Name: `cr-${index}`,
                     })),
                   },

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -297,7 +297,7 @@ function ComputeResources({queue, index, canUseEFA}: any) {
           </SpaceBetween>
         }
       >
-        Compute resources
+        {t('wizard.queues.computeResource.header.title')}
       </Header>
       <ColumnLayout borders="horizontal">
         {queue.ComputeResources.map((computeResource: any, i: any) => (

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -65,7 +65,7 @@ const queuesPath = ['app', 'wizard', 'config', 'Scheduling', 'SlurmQueues']
 const queuesErrorsPath = ['app', 'wizard', 'errors', 'queues']
 
 const MAX_COMPUTE_RESOURCES = 5
-const MAX_QUEUES = 10
+export const MAX_QUEUES = 10
 
 function itemToOption([value, label]: string[]) {
   return {
@@ -117,9 +117,8 @@ function queueValidate(queueIndex: any) {
       errorMessage = i18next.t(queueNameErrorsMapping[error], {
         maxChars: QUEUE_NAME_MAX_LENGTH,
       })
-      console.log(errorMessage)
     } else {
-      errorMessage = i18next.t(queueNameErrorsMapping[error!])
+      errorMessage = i18next.t(queueNameErrorsMapping[error])
     }
     setState([...errorsPath, 'name'], errorMessage)
     valid = false
@@ -296,6 +295,9 @@ function ComputeResources({queue, index, canUseEFA}: any) {
             </Button>
           </SpaceBetween>
         }
+        description={t('wizard.queues.computeResource.header.description', {
+          limit: MAX_COMPUTE_RESOURCES,
+        })}
       >
         {t('wizard.queues.computeResource.header.title')}
       </Header>
@@ -431,7 +433,6 @@ function Queue({index}: any) {
     [index],
   )
 
-  const adapter = useComputeResourceAdapter()
   const defaultAllocationStrategy = useDefaultAllocationStrategy()
 
   const addQueue = () => {
@@ -442,7 +443,9 @@ function Queue({index}: any) {
         {
           Name: `queue-${queues.length}`,
           ...defaultAllocationStrategy,
-          ComputeResources: [adapter.createComputeResource(queues.length, 0)],
+          ComputeResources: [
+            computeResourceAdapter.createComputeResource(queues.length, 0),
+          ],
         },
       ],
     )
@@ -457,15 +460,14 @@ function Queue({index}: any) {
               variant="h2"
               actions={
                 <SpaceBetween direction="horizontal" size="xs">
-                  {index === 0 && (
+                  {index === 0 ? (
                     <Button
                       disabled={queues.length >= MAX_QUEUES}
                       onClick={addQueue}
                     >
                       {t('wizard.queues.addQueueButton.label')}
                     </Button>
-                  )}
-                  {index > 0 && (
+                  ) : (
                     <Button onClick={remove}>
                       {t('wizard.queues.removeQueueButton.label')}
                     </Button>
@@ -478,7 +480,7 @@ function Queue({index}: any) {
           }
         >
           <ColumnLayout borders="horizontal">
-            <Box>
+            <SpaceBetween direction="vertical" size="xs">
               <Box margin={{bottom: 'xs'}}>
                 <SpaceBetween direction="horizontal" size="xs">
                   <FormField
@@ -563,7 +565,7 @@ function Queue({index}: any) {
                   <Trans i18nKey="wizard.queues.placementGroup.label" />
                 </Checkbox>
               </Box>
-            </Box>
+            </SpaceBetween>
             <ComputeResources
               queue={queue}
               index={index}

--- a/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
@@ -146,9 +146,18 @@ export function ComputeResource({index, queueIndex, computeResource}: any) {
   return (
     <div className="compute-resource">
       <div style={{display: 'flex', flexDirection: 'column', gap: '10px'}}>
-        <Box margin={{top: 'xs'}} textAlign="right">
-          {index > 0 && <Button onClick={remove}>Remove Resource</Button>}
-        </Box>
+        <ColumnLayout columns={2}>
+          <h4>{computeResource.Name}</h4>
+          <Box margin={{top: 'xs'}} textAlign="right">
+            {index > 0 && (
+              <Button onClick={remove}>
+                {t(
+                  'wizard.queues.computeResource.removeComputeResourceButton.label',
+                )}
+              </Button>
+            )}
+          </Box>
+        </ColumnLayout>
         <ColumnLayout columns={2}>
           <div style={{display: 'flex', flexDirection: 'row', gap: '20px'}}>
             <FormField label={t('wizard.queues.computeResource.staticNodes')}>

--- a/frontend/src/old-pages/Configure/Queues/__tests__/hasMultipleInstanceTypes.test.tsx
+++ b/frontend/src/old-pages/Configure/Queues/__tests__/hasMultipleInstanceTypes.test.tsx
@@ -88,7 +88,7 @@ describe('Given a function to validate if mutiple instance types have been selec
   describe('if default values are selected', () => {
     const queues: Queue[] = [
       {
-        Name: 'queue0',
+        Name: 'queue-0',
         AllocationStrategy: 'capacity-optimized',
         ComputeResources: [
           {

--- a/frontend/src/old-pages/Configure/Queues/__tests__/validateQueueName.test.ts
+++ b/frontend/src/old-pages/Configure/Queues/__tests__/validateQueueName.test.ts
@@ -1,16 +1,39 @@
 import {validateQueueName} from '../queues.validators'
 
 describe('Given a queue name', () => {
-  describe("when it's defined", () => {
-    it('should be validated', () => {
-      const queueName = 'Queue 0'
-      expect(validateQueueName(queueName)).toEqual([true])
-    })
-  })
-
   describe("when it's blank", () => {
     it('should fail the validation', () => {
       expect(validateQueueName('')).toEqual([false, 'empty'])
+    })
+  })
+
+  describe("when it's more than 25 chars", () => {
+    it('should fail the validation', () => {
+      expect(validateQueueName(new Array(27).join('a'))).toEqual([
+        false,
+        'max_length',
+      ])
+    })
+  })
+
+  describe("when it's less than or equal to 25 chars", () => {
+    it('should be validated', () => {
+      expect(validateQueueName(new Array(25).join('a'))).toEqual([true])
+    })
+  })
+
+  describe('when one or more bad characters are given', () => {
+    it('should fail the validation', () => {
+      expect(validateQueueName('_')).toEqual([false, 'forbidden_chars'])
+      expect(validateQueueName('=')).toEqual([false, 'forbidden_chars'])
+      expect(validateQueueName('A')).toEqual([false, 'forbidden_chars'])
+      expect(validateQueueName('#')).toEqual([false, 'forbidden_chars'])
+    })
+  })
+
+  describe('when no bad characters are given', () => {
+    it('should be validated', () => {
+      expect(validateQueueName('queue-0')).toEqual([true])
     })
   })
 })

--- a/frontend/src/old-pages/Configure/Queues/queues.validators.tsx
+++ b/frontend/src/old-pages/Configure/Queues/queues.validators.tsx
@@ -1,5 +1,8 @@
+export const QUEUE_NAME_MAX_LENGTH = 25
 export const queueNameErrorsMapping = {
   empty: 'wizard.queues.validation.emptyName',
+  max_length: 'wizard.queues.validation.maxLengthName',
+  forbidden_chars: 'wizard.queues.validation.forbiddenCharsName',
 }
 type QueueNameErrorKind = keyof typeof queueNameErrorsMapping
 
@@ -8,6 +11,12 @@ export function validateQueueName(
 ): [boolean, QueueNameErrorKind?] {
   if (!name) {
     return [false, 'empty']
+  }
+  if (name.length > QUEUE_NAME_MAX_LENGTH) {
+    return [false, 'max_length']
+  }
+  if (!/^([a-z][a-z0-9-]+)$/.test(name)) {
+    return [false, 'forbidden_chars']
   }
   return [true]
 }

--- a/frontend/src/old-pages/Configure/Queues/queues.validators.tsx
+++ b/frontend/src/old-pages/Configure/Queues/queues.validators.tsx
@@ -8,7 +8,7 @@ type QueueNameErrorKind = keyof typeof queueNameErrorsMapping
 
 export function validateQueueName(
   name: string,
-): [boolean, QueueNameErrorKind?] {
+): [true] | [false, QueueNameErrorKind] {
   if (!name) {
     return [false, 'empty']
   }


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description
This PR refactors the design of Queues wizard page. Now each queue has its own dedicated container, and compute resources are not wrapped in an additional container.

Furthemore:
* `Add queue` button has been moved to the top-right part of the container
* Compute resources names are now displayed in the wizard
* Added Queue name validation

## How Has This Been Tested?

* Manual tests on local environment
* Unit tests

## References

* https://cloudscape.design/components/column-layout/

## Screenshots

<img width="1724" alt="Screenshot 2023-03-02 at 14 25 18" src="https://user-images.githubusercontent.com/25930133/222444794-0b92e780-caea-4a20-8ba6-9ab375b35a5f.png">


## PR Quality Checklist

- [x] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
