### PR TITLE
Provide a reasonable default for table page size

### DIFF
--- a/frontend/src/old-pages/Clusters/Accounting.tsx
+++ b/frontend/src/old-pages/Clusters/Accounting.tsx
@@ -43,6 +43,7 @@ import {
 import InfoLink from '../../components/InfoLink'
 import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
 import {useTranslation} from 'react-i18next'
+import {extendCollectionsOptions} from '../../shared/extendCollectionsOptions'
 
 // Key:Value pair (label / children)
 const ValueWithLabel = ({label, children}: any) => (
@@ -437,25 +438,27 @@ export default function ClusterAccounting() {
     collectionProps,
     filterProps,
     paginationProps,
-  } = useCollection(jobs || [], {
-    filtering: {
-      empty: <EmptyState title="No jobs" subtitle="No jobs to display." />,
-      noMatch: (
-        <EmptyState
-          title="No matches"
-          subtitle="No jobs match the filters."
-          action={
-            <Button onClick={() => actions.setFiltering('')}>
-              Clear filter
-            </Button>
-          }
-        />
-      ),
-    },
-    pagination: {pageSize: 10},
-    sorting: {},
-    selection: {},
-  })
+  } = useCollection(
+    jobs || [],
+    extendCollectionsOptions({
+      filtering: {
+        empty: <EmptyState title="No jobs" subtitle="No jobs to display." />,
+        noMatch: (
+          <EmptyState
+            title="No matches"
+            subtitle="No jobs match the filters."
+            action={
+              <Button onClick={() => actions.setFiltering('')}>
+                Clear filter
+              </Button>
+            }
+          />
+        ),
+      },
+      sorting: {},
+      selection: {},
+    }),
+  )
 
   const selectJob = (job_id: any) => {
     setState(['clusters', 'index', clusterName, 'accounting', 'dialog'], true)

--- a/frontend/src/old-pages/Clusters/Clusters.tsx
+++ b/frontend/src/old-pages/Clusters/Clusters.tsx
@@ -41,6 +41,7 @@ import Layout from '../Layout'
 import {useHelpPanel} from '../../components/help-panel/HelpPanel'
 import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
 import InfoLink from '../../components/InfoLink'
+import {extendCollectionsOptions} from '../../shared/extendCollectionsOptions'
 
 export function onClustersUpdate(
   selectedClusterName: ClusterName,
@@ -98,35 +99,37 @@ function ClusterList({clusters}: {clusters: ClusterInfoSummary[]}) {
     collectionProps,
     filterProps,
     paginationProps,
-  } = useCollection(clusters || [], {
-    filtering: {
-      empty: (
-        <EmptyState
-          title={t('cluster.list.filtering.empty.title')}
-          subtitle={t('cluster.list.filtering.empty.subtitle')}
-          action={
-            <Button onClick={configure}>
-              {t('cluster.list.filtering.empty.action')}
-            </Button>
-          }
-        />
-      ),
-      noMatch: (
-        <EmptyState
-          title={t('cluster.list.filtering.noMatch.title')}
-          subtitle={t('cluster.list.filtering.noMatch.subtitle')}
-          action={
-            <Button onClick={() => actions.setFiltering('')}>
-              {t('cluster.list.filtering.noMatch.action')}
-            </Button>
-          }
-        />
-      ),
-    },
-    pagination: {pageSize: 10},
-    sorting: {},
-    selection: {},
-  })
+  } = useCollection(
+    clusters || [],
+    extendCollectionsOptions({
+      filtering: {
+        empty: (
+          <EmptyState
+            title={t('cluster.list.filtering.empty.title')}
+            subtitle={t('cluster.list.filtering.empty.subtitle')}
+            action={
+              <Button onClick={configure}>
+                {t('cluster.list.filtering.empty.action')}
+              </Button>
+            }
+          />
+        ),
+        noMatch: (
+          <EmptyState
+            title={t('cluster.list.filtering.noMatch.title')}
+            subtitle={t('cluster.list.filtering.noMatch.subtitle')}
+            action={
+              <Button onClick={() => actions.setFiltering('')}>
+                {t('cluster.list.filtering.noMatch.action')}
+              </Button>
+            }
+          />
+        ),
+      },
+      sorting: {},
+      selection: {},
+    }),
+  )
 
   return (
     <Table

--- a/frontend/src/old-pages/Clusters/Filesystems.tsx
+++ b/frontend/src/old-pages/Clusters/Filesystems.tsx
@@ -30,6 +30,7 @@ import {EC2Instance} from '../../types/instances'
 import {Region} from '../../types/base'
 import {Storages} from '../Configure/Storage.types'
 import {useTranslation} from 'react-i18next'
+import {extendCollectionsOptions} from '../../shared/extendCollectionsOptions'
 
 function StorageId({storage}: any) {
   const {t} = useTranslation()
@@ -125,30 +126,32 @@ export default function Filesystems() {
     collectionProps,
     filterProps,
     paginationProps,
-  } = useCollection(storage, {
-    filtering: {
-      empty: (
-        <EmptyState
-          title={t('cluster.storage.noFilesystems')}
-          subtitle={t('cluster.storage.noFilesystemsToDisplay')}
-        />
-      ),
-      noMatch: (
-        <EmptyState
-          title={t('cluster.storage.filter.noMatches')}
-          subtitle={t('cluster.storage.filter.noFilesystems')}
-          action={
-            <Button onClick={() => actions.setFiltering('')}>
-              {t('cluster.storage.filter.clear')}
-            </Button>
-          }
-        />
-      ),
-    },
-    pagination: {pageSize: 10},
-    sorting: {},
-    selection: {},
-  })
+  } = useCollection(
+    storage,
+    extendCollectionsOptions({
+      filtering: {
+        empty: (
+          <EmptyState
+            title={t('cluster.storage.noFilesystems')}
+            subtitle={t('cluster.storage.noFilesystemsToDisplay')}
+          />
+        ),
+        noMatch: (
+          <EmptyState
+            title={t('cluster.storage.filter.noMatches')}
+            subtitle={t('cluster.storage.filter.noFilesystems')}
+            action={
+              <Button onClick={() => actions.setFiltering('')}>
+                {t('cluster.storage.filter.clear')}
+              </Button>
+            }
+          />
+        ),
+      },
+      sorting: {},
+      selection: {},
+    }),
+  )
 
   return (
     <>

--- a/frontend/src/old-pages/Clusters/Instances.tsx
+++ b/frontend/src/old-pages/Clusters/Instances.tsx
@@ -32,6 +32,7 @@ import {useCollection} from '@cloudscape-design/collection-hooks'
 import {InstanceStatusIndicator} from '../../components/Status'
 import EmptyState from '../../components/EmptyState'
 import DateView from '../../components/date/DateView'
+import {extendCollectionsOptions} from '../../shared/extendCollectionsOptions'
 
 function InstanceActions({instance}: {instance?: Instance}) {
   const {t} = useTranslation()
@@ -149,30 +150,32 @@ export default function ClusterInstances() {
     collectionProps,
     filterProps,
     paginationProps,
-  } = useCollection(instances || [], {
-    filtering: {
-      empty: (
-        <EmptyState
-          title={t('cluster.instances.filtering.empty.title')}
-          subtitle={t('cluster.instances.filtering.empty.subtitle')}
-        />
-      ),
-      noMatch: (
-        <EmptyState
-          title={t('cluster.instances.filtering.noMatch.title')}
-          subtitle={t('cluster.instances.filtering.noMatch.subtitle')}
-          action={
-            <Button onClick={() => actions.setFiltering('')}>
-              {t('cluster.instances.filtering.clearFilter')}
-            </Button>
-          }
-        />
-      ),
-    },
-    pagination: {pageSize: 10},
-    sorting: {},
-    selection: {},
-  })
+  } = useCollection(
+    instances || [],
+    extendCollectionsOptions({
+      filtering: {
+        empty: (
+          <EmptyState
+            title={t('cluster.instances.filtering.empty.title')}
+            subtitle={t('cluster.instances.filtering.empty.subtitle')}
+          />
+        ),
+        noMatch: (
+          <EmptyState
+            title={t('cluster.instances.filtering.noMatch.title')}
+            subtitle={t('cluster.instances.filtering.noMatch.subtitle')}
+            action={
+              <Button onClick={() => actions.setFiltering('')}>
+                {t('cluster.instances.filtering.clearFilter')}
+              </Button>
+            }
+          />
+        ),
+      },
+      sorting: {},
+      selection: {},
+    }),
+  )
 
   return (
     <Table

--- a/frontend/src/old-pages/Clusters/Scheduling.tsx
+++ b/frontend/src/old-pages/Clusters/Scheduling.tsx
@@ -42,6 +42,7 @@ import {JobStatusIndicator} from '../../components/Status'
 import EmptyState from '../../components/EmptyState'
 import Loading from '../../components/Loading'
 import {useTranslation} from 'react-i18next'
+import {extendCollectionsOptions} from '../../shared/extendCollectionsOptions'
 
 // Key:Value pair (label / children)
 const ValueWithLabel = ({
@@ -316,25 +317,27 @@ export default function ClusterScheduling() {
     collectionProps,
     filterProps,
     paginationProps,
-  } = useCollection(jobs || [], {
-    filtering: {
-      empty: <EmptyState title="No jobs" subtitle="No jobs to display." />,
-      noMatch: (
-        <EmptyState
-          title="No matches"
-          subtitle="No jobs match the filters."
-          action={
-            <Button onClick={() => actions.setFiltering('')}>
-              Clear filter
-            </Button>
-          }
-        />
-      ),
-    },
-    pagination: {pageSize: 10},
-    sorting: {},
-    selection: {},
-  })
+  } = useCollection(
+    jobs || [],
+    extendCollectionsOptions({
+      filtering: {
+        empty: <EmptyState title="No jobs" subtitle="No jobs to display." />,
+        noMatch: (
+          <EmptyState
+            title="No matches"
+            subtitle="No jobs match the filters."
+            action={
+              <Button onClick={() => actions.setFiltering('')}>
+                Clear filter
+              </Button>
+            }
+          />
+        ),
+      },
+      sorting: {},
+      selection: {},
+    }),
+  )
 
   return (
     <SpaceBetween direction="vertical" size="s">

--- a/frontend/src/old-pages/Images/CustomImages/CustomImageDetails.tsx
+++ b/frontend/src/old-pages/Images/CustomImages/CustomImageDetails.tsx
@@ -38,6 +38,7 @@ import {ValueWithLabel} from '../../../components/ValueWithLabel'
 import EmptyState from '../../../components/EmptyState'
 import {truncate} from 'lodash'
 import {ReadonlyConfigView} from '../../../components/ConfigView'
+import {extendCollectionsOptions} from '../../../shared/extendCollectionsOptions'
 
 const customImagesPath = ['app', 'customImages']
 
@@ -205,34 +206,36 @@ function CustomImageTags({image}: CustomImageTagsProps) {
     collectionProps,
     filterProps,
     paginationProps,
-  } = useCollection(tags || [], {
-    filtering: {
-      empty: (
-        <EmptyState
-          title={t('customImages.imageDetails.tags.filtering.empty.title')}
-          subtitle={t(
-            'customImages.imageDetails.tags.filtering.empty.subtitle',
-          )}
-        />
-      ),
-      noMatch: (
-        <EmptyState
-          title={t('customImages.imageDetails.tags.filtering.noMatch.title')}
-          subtitle={t(
-            'customImages.imageDetails.tags.filtering.noMatch.subtitle',
-          )}
-          action={
-            <Button onClick={() => actions.setFiltering('')}>
-              {t('customImages.imageDetails.tags.filtering.noMatch.action')}
-            </Button>
-          }
-        />
-      ),
-    },
-    pagination: {pageSize: 10},
-    sorting: {},
-    selection: {},
-  })
+  } = useCollection(
+    tags || [],
+    extendCollectionsOptions({
+      filtering: {
+        empty: (
+          <EmptyState
+            title={t('customImages.imageDetails.tags.filtering.empty.title')}
+            subtitle={t(
+              'customImages.imageDetails.tags.filtering.empty.subtitle',
+            )}
+          />
+        ),
+        noMatch: (
+          <EmptyState
+            title={t('customImages.imageDetails.tags.filtering.noMatch.title')}
+            subtitle={t(
+              'customImages.imageDetails.tags.filtering.noMatch.subtitle',
+            )}
+            action={
+              <Button onClick={() => actions.setFiltering('')}>
+                {t('customImages.imageDetails.tags.filtering.noMatch.action')}
+              </Button>
+            }
+          />
+        ),
+      },
+      sorting: {},
+      selection: {},
+    }),
+  )
 
   return (
     <Table

--- a/frontend/src/old-pages/Images/CustomImages/CustomImages.tsx
+++ b/frontend/src/old-pages/Images/CustomImages/CustomImages.tsx
@@ -37,6 +37,7 @@ import {useHelpPanel} from '../../../components/help-panel/HelpPanel'
 import {TFunction, Trans, useTranslation} from 'react-i18next'
 import InfoLink from '../../../components/InfoLink'
 import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
+import {extendCollectionsOptions} from '../../../shared/extendCollectionsOptions'
 
 const imageBuildPath = ['app', 'customImages', 'imageBuild']
 
@@ -75,35 +76,37 @@ function CustomImagesList() {
     collectionProps,
     filterProps,
     paginationProps,
-  } = useCollection(images || [], {
-    filtering: {
-      empty: (
-        <EmptyState
-          title={t('customImages.list.filtering.empty.title')}
-          subtitle={t('customImages.list.filtering.empty.subtitle')}
-          action={
-            <Button onClick={buildImage}>
-              {t('customImages.list.filtering.empty.action')}
-            </Button>
-          }
-        />
-      ),
-      noMatch: (
-        <EmptyState
-          title={t('customImages.list.filtering.noMatch.title')}
-          subtitle={t('customImages.list.filtering.noMatch.subtitle')}
-          action={
-            <Button onClick={() => actions.setFiltering('')}>
-              {t('customImages.list.filtering.noMatch.action')}
-            </Button>
-          }
-        />
-      ),
-    },
-    pagination: {pageSize: 10},
-    sorting: {},
-    selection: {},
-  })
+  } = useCollection(
+    images || [],
+    extendCollectionsOptions({
+      filtering: {
+        empty: (
+          <EmptyState
+            title={t('customImages.list.filtering.empty.title')}
+            subtitle={t('customImages.list.filtering.empty.subtitle')}
+            action={
+              <Button onClick={buildImage}>
+                {t('customImages.list.filtering.empty.action')}
+              </Button>
+            }
+          />
+        ),
+        noMatch: (
+          <EmptyState
+            title={t('customImages.list.filtering.noMatch.title')}
+            subtitle={t('customImages.list.filtering.noMatch.subtitle')}
+            action={
+              <Button onClick={() => actions.setFiltering('')}>
+                {t('customImages.list.filtering.noMatch.action')}
+              </Button>
+            }
+          />
+        ),
+      },
+      sorting: {},
+      selection: {},
+    }),
+  )
 
   return (
     <Table

--- a/frontend/src/old-pages/Images/OfficialImages/OfficialImages.tsx
+++ b/frontend/src/old-pages/Images/OfficialImages/OfficialImages.tsx
@@ -30,6 +30,7 @@ import {useHelpPanel} from '../../../components/help-panel/HelpPanel'
 import {Trans, useTranslation} from 'react-i18next'
 import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
 import InfoLink from '../../../components/InfoLink'
+import {extendCollectionsOptions} from '../../../shared/extendCollectionsOptions'
 
 type Image = {
   amiId: string
@@ -67,31 +68,33 @@ function OfficialImagesList({images}: {images: Image[]}) {
     collectionProps,
     filterProps,
     paginationProps,
-  } = useCollection(images || [], {
-    filtering: {
-      empty: (
-        <EmptyState
-          title={t('officialImages.list.filtering.empty.title')}
-          subtitle={t('officialImages.list.filtering.empty.subtitle')}
-          action={<></>}
-        />
-      ),
-      noMatch: (
-        <EmptyState
-          title={t('officialImages.list.filtering.noMatch.title')}
-          subtitle={t('officialImages.list.filtering.noMatch.subtitle')}
-          action={
-            <Button onClick={() => actions.setFiltering('')}>
-              {t('officialImages.list.filtering.noMatch.action')}
-            </Button>
-          }
-        />
-      ),
-    },
-    pagination: {pageSize: 10},
-    sorting: {},
-    selection: {},
-  })
+  } = useCollection(
+    images || [],
+    extendCollectionsOptions({
+      filtering: {
+        empty: (
+          <EmptyState
+            title={t('officialImages.list.filtering.empty.title')}
+            subtitle={t('officialImages.list.filtering.empty.subtitle')}
+            action={<></>}
+          />
+        ),
+        noMatch: (
+          <EmptyState
+            title={t('officialImages.list.filtering.noMatch.title')}
+            subtitle={t('officialImages.list.filtering.noMatch.subtitle')}
+            action={
+              <Button onClick={() => actions.setFiltering('')}>
+                {t('officialImages.list.filtering.noMatch.action')}
+              </Button>
+            }
+          />
+        ),
+      },
+      sorting: {},
+      selection: {},
+    }),
+  )
 
   return (
     <Table

--- a/frontend/src/old-pages/Users/Users.tsx
+++ b/frontend/src/old-pages/Users/Users.tsx
@@ -40,6 +40,7 @@ import {User} from '../../types/users'
 import {Trans, useTranslation} from 'react-i18next'
 import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
 import InfoLink from '../../components/InfoLink'
+import {extendCollectionsOptions} from '../../shared/extendCollectionsOptions'
 
 // Constants
 const usernamePath = ['app', 'users', 'newUser', 'Username']
@@ -105,31 +106,33 @@ export default function Users() {
     collectionProps,
     filterProps,
     paginationProps,
-  } = useCollection(users || [], {
-    filtering: {
-      empty: (
-        <EmptyState
-          title={t('users.list.filtering.empty.title')}
-          subtitle={t('users.list.filtering.empty.subtitle')}
-          action={<></>}
-        />
-      ),
-      noMatch: (
-        <EmptyState
-          title={t('users.list.filtering.noMatch.title')}
-          subtitle={t('users.list.filtering.noMatch.subtitle')}
-          action={
-            <Button onClick={() => actions.setFiltering('')}>
-              {t('users.list.filtering.noMatch.action')}
-            </Button>
-          }
-        />
-      ),
-    },
-    pagination: {pageSize: 10},
-    sorting: {},
-    selection: {},
-  })
+  } = useCollection(
+    users || [],
+    extendCollectionsOptions({
+      filtering: {
+        empty: (
+          <EmptyState
+            title={t('users.list.filtering.empty.title')}
+            subtitle={t('users.list.filtering.empty.subtitle')}
+            action={<></>}
+          />
+        ),
+        noMatch: (
+          <EmptyState
+            title={t('users.list.filtering.noMatch.title')}
+            subtitle={t('users.list.filtering.noMatch.subtitle')}
+            action={
+              <Button onClick={() => actions.setFiltering('')}>
+                {t('users.list.filtering.noMatch.action')}
+              </Button>
+            }
+          />
+        ),
+      },
+      sorting: {},
+      selection: {},
+    }),
+  )
 
   const deleteUser = useCallback(() => {
     DeleteUser(deletedUser, (returned_user: any) => {

--- a/frontend/src/shared/__tests__/extendCollectionsOptions.test.ts
+++ b/frontend/src/shared/__tests__/extendCollectionsOptions.test.ts
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {extendCollectionsOptions} from '../extendCollectionsOptions'
+
+describe('given a mixin to extend a CollectionOptions object', () => {
+  describe('when no options are provided', () => {
+    it('should return the default options', () => {
+      expect(extendCollectionsOptions()).toEqual({pagination: {pageSize: 20}})
+    })
+  })
+
+  describe('when options are provided', () => {
+    describe('when the given options override the defaults', () => {
+      it('should override the default options', () => {
+        const options = {pagination: {pageSize: 15}}
+        expect(extendCollectionsOptions(options)).toEqual({
+          pagination: {pageSize: 15},
+        })
+      })
+    })
+
+    describe('when the given options do not overlap with the defaults', () => {
+      it('should add the defaults to the given options', () => {
+        const options = {
+          filtering: {defaultFilteringText: 'some-text'},
+          pagination: {defaultPage: 2},
+        }
+        expect(extendCollectionsOptions(options)).toEqual({
+          filtering: {defaultFilteringText: 'some-text'},
+          pagination: {pageSize: 20, defaultPage: 2},
+        })
+      })
+    })
+  })
+})

--- a/frontend/src/shared/extendCollectionsOptions.ts
+++ b/frontend/src/shared/extendCollectionsOptions.ts
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {UseCollectionOptions} from '@cloudscape-design/collection-hooks'
+
+const DEFAULT_USE_COLLECTION_OPTIONS = {
+  pageSize: 20,
+}
+
+export function extendCollectionsOptions<T = any>(
+  options: UseCollectionOptions<T> = {},
+): UseCollectionOptions<T> {
+  return {
+    ...options,
+    pagination: {
+      pageSize: DEFAULT_USE_COLLECTION_OPTIONS.pageSize,
+      ...options.pagination,
+    },
+  }
+}


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR adds a centralized mechanism to set defaults to the `useCollections` hook

## Changes

- add mixin to extend the default useCollections options
- adopt defaults in every instance of `useCollections`, save Logs and StackEvents

## How Has This Been Tested?

- manually
- unit test

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
