### PR TITLE
Add modal to select a cluster to start the creation from

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -281,6 +281,20 @@
       "preferencesModalTheme": "Theme",
       "preferencesModalLightThemes": "Light themes",
       "preferencesModalDarkThemes": "Dark themes"
+    },
+    "fromClusterModal": {
+      "title": "Create Cluster From Another Cluster",
+      "description": "Use an existing cluster as starting point for the configuration of your new cluster. Only clusters whose version matches the version of AWS ParallelCluster can be selected.",
+      "actions": {
+        "cancel": "Cancel",
+        "create": "Create"
+      },
+      "clusterSelect": {
+        "placeholder": "Select a cluster",
+        "selectedAriaLabel": "Selected",
+        "empty": "No cluster available"
+      },
+      "closeAriaLabel": "Close"
     }
   },
   "wizard": {

--- a/frontend/src/old-pages/Clusters/FromClusterModal/FromClusterModal.tsx
+++ b/frontend/src/old-pages/Clusters/FromClusterModal/FromClusterModal.tsx
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  Box,
+  Button,
+  ButtonProps,
+  Modal,
+  Select,
+  SelectProps,
+  SpaceBetween,
+} from '@cloudscape-design/components'
+import {
+  CancelableEventHandler,
+  NonCancelableEventHandler,
+} from '@cloudscape-design/components/internal/events'
+import React, {useCallback} from 'react'
+import {useTranslation} from 'react-i18next'
+import {useClustersToCopyFrom} from './useClustersToCopyFrom'
+
+interface Props {
+  visible: boolean
+  onDismiss: () => void
+  onCreate: (clusterName: string) => void
+}
+
+export const FromClusterModal: React.FC<Props> = ({
+  visible,
+  onDismiss,
+  onCreate,
+}) => {
+  const {t} = useTranslation()
+  const [selectedCluster, setSelectedCluster] =
+    React.useState<SelectProps.Option | null>(null)
+  const clustersToDisplay = useClustersToCopyFrom()
+
+  const onChange: NonCancelableEventHandler<SelectProps.ChangeDetail> =
+    useCallback(({detail}) => {
+      setSelectedCluster(detail.selectedOption)
+    }, [])
+
+  const onCreateClick: CancelableEventHandler<ButtonProps.ClickDetail> =
+    useCallback(() => {
+      if (!selectedCluster?.value) {
+        return
+      }
+
+      onCreate(selectedCluster.value)
+      onDismiss()
+    }, [onCreate, onDismiss, selectedCluster])
+
+  return (
+    <Modal
+      onDismiss={onDismiss}
+      visible={visible}
+      closeAriaLabel={t('cluster.fromClusterModal.closeAriaLabel')}
+      footer={
+        <Box float="right">
+          <SpaceBetween direction="horizontal" size="xs">
+            <Button onClick={onDismiss} variant="link">
+              {t('cluster.fromClusterModal.actions.cancel')}
+            </Button>
+            <Button
+              disabled={!selectedCluster}
+              variant="primary"
+              onClick={onCreateClick}
+            >
+              {t('cluster.fromClusterModal.actions.create')}
+            </Button>
+          </SpaceBetween>
+        </Box>
+      }
+      header={t('cluster.fromClusterModal.title')}
+    >
+      <SpaceBetween size="s">
+        <Box>{t('cluster.fromClusterModal.description')}</Box>
+        <Select
+          selectedOption={selectedCluster}
+          options={clustersToDisplay}
+          onChange={onChange}
+          placeholder={t('cluster.fromClusterModal.clusterSelect.placeholder')}
+          selectedAriaLabel={t(
+            'cluster.fromClusterModal.clusterSelect.selectedAriaLabel',
+          )}
+          empty={t('cluster.fromClusterModal.clusterSelect.empty')}
+        />
+      </SpaceBetween>
+    </Modal>
+  )
+}

--- a/frontend/src/old-pages/Clusters/FromClusterModal/__tests__/useClustersToCopyFrom.test.tsx
+++ b/frontend/src/old-pages/Clusters/FromClusterModal/__tests__/useClustersToCopyFrom.test.tsx
@@ -1,0 +1,177 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Store} from '@reduxjs/toolkit'
+import {renderHook} from '@testing-library/react-hooks'
+import {mock} from 'jest-mock-extended'
+import {PropsWithChildren} from 'react'
+import {Provider} from 'react-redux'
+import {ClusterInfoSummary, ClusterStatus} from '../../../../types/clusters'
+import {useClustersToCopyFrom} from '../useClustersToCopyFrom'
+
+const mockStore = mock<Store>()
+
+const wrapper: React.FC<PropsWithChildren<any>> = ({children}) => (
+  <Provider store={mockStore}>{children}</Provider>
+)
+
+describe('given a hook to list the clusters that can be copied from', () => {
+  describe("when no cluster is available in the user's account", () => {
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        clusters: {
+          list: null,
+        },
+      })
+    })
+    it('should return an empty list', () => {
+      const {result} = renderHook(() => useClustersToCopyFrom(), {wrapper})
+
+      expect(result.current).toEqual([])
+    })
+  })
+
+  describe('when the list of clusters is available', () => {
+    describe('when one of the clusters is in DeleteInProgress', () => {
+      beforeEach(() => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            version: {
+              full: '3.5.0',
+            },
+          },
+          clusters: {
+            list: [
+              {
+                version: '3.5.0',
+                clusterName: 'some-name-delete-in-progress',
+                clusterStatus: ClusterStatus.DeleteInProgress,
+              },
+              {
+                version: '3.5.0',
+                clusterName: 'some-name',
+                clusterStatus: ClusterStatus.CreateComplete,
+              },
+            ] as ClusterInfoSummary[],
+          },
+        })
+      })
+      it('should filter out that cluster', () => {
+        const {result} = renderHook(() => useClustersToCopyFrom(), {wrapper})
+
+        expect(result.current).toEqual([
+          {
+            label: 'some-name',
+            value: 'some-name',
+          },
+        ])
+      })
+    })
+
+    describe('when one of the clusters was created with a different PC version', () => {
+      describe('when major and minor are the same', () => {
+        beforeEach(() => {
+          mockStore.getState.mockReturnValue({
+            app: {
+              version: {
+                full: '3.5.0',
+              },
+            },
+            clusters: {
+              list: [
+                {
+                  clusterName: 'some-name',
+                  version: '3.5.1',
+                },
+              ] as ClusterInfoSummary[],
+            },
+          })
+        })
+        it('should keep that cluster', () => {
+          const {result} = renderHook(() => useClustersToCopyFrom(), {wrapper})
+
+          expect(result.current).toEqual([
+            {
+              label: 'some-name',
+              value: 'some-name',
+            },
+          ])
+        })
+      })
+      describe('when the major is different', () => {
+        beforeEach(() => {
+          mockStore.getState.mockReturnValue({
+            app: {
+              version: {
+                full: '3.5.0',
+              },
+            },
+            clusters: {
+              list: [
+                {
+                  clusterName: 'some-name',
+                  version: '3.5.0',
+                },
+                {
+                  clusterName: 'some-name-different-major',
+                  version: '2.5.0',
+                },
+              ] as ClusterInfoSummary[],
+            },
+          })
+        })
+        it('should filter out that cluster', () => {
+          const {result} = renderHook(() => useClustersToCopyFrom(), {wrapper})
+
+          expect(result.current).toEqual([
+            {
+              label: 'some-name',
+              value: 'some-name',
+            },
+          ])
+        })
+      })
+      describe('when the minor is different', () => {
+        beforeEach(() => {
+          mockStore.getState.mockReturnValue({
+            app: {
+              version: {
+                full: '3.5.0',
+              },
+            },
+            clusters: {
+              list: [
+                {
+                  clusterName: 'some-name',
+                  version: '3.5.0',
+                },
+                {
+                  clusterName: 'some-name-different-minor',
+                  version: '3.6.0',
+                },
+              ] as ClusterInfoSummary[],
+            },
+          })
+        })
+        it('should filter out that cluster', () => {
+          const {result} = renderHook(() => useClustersToCopyFrom(), {wrapper})
+
+          expect(result.current).toEqual([
+            {
+              label: 'some-name',
+              value: 'some-name',
+            },
+          ])
+        })
+      })
+    })
+  })
+})

--- a/frontend/src/old-pages/Clusters/FromClusterModal/useClustersToCopyFrom.ts
+++ b/frontend/src/old-pages/Clusters/FromClusterModal/useClustersToCopyFrom.ts
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {SelectProps} from '@cloudscape-design/components'
+import {useMemo} from 'react'
+import {useState} from '../../../store'
+import {ClusterInfoSummary, ClusterStatus} from '../../../types/clusters'
+
+function itemToOption(item: ClusterInfoSummary): SelectProps.Option {
+  return {
+    label: item.clusterName,
+    value: item.clusterName,
+  }
+}
+
+function matchUpToMinor(semVer1: string, semVer2: string) {
+  const [major1, minor1] = semVer1.split('.')
+  const [major2, minor2] = semVer2.split('.')
+
+  if (major1 !== major2) return false
+  if (minor1 !== minor2) return false
+
+  return true
+}
+
+function canCopyFromCluster(
+  cluster: ClusterInfoSummary,
+  currentVersion: string,
+) {
+  if (cluster.clusterStatus === ClusterStatus.DeleteInProgress) {
+    return false
+  }
+
+  if (!matchUpToMinor(cluster.version, currentVersion)) {
+    return false
+  }
+
+  return true
+}
+
+export function useClustersToCopyFrom() {
+  const apiVersion = useState(['app', 'version', 'full'])
+  const clusters: ClusterInfoSummary[] = useState(['clusters', 'list'])
+
+  return useMemo(() => {
+    if (!clusters) {
+      return []
+    }
+
+    return clusters
+      .filter(cluster => canCopyFromCluster(cluster, apiVersion))
+      .map(itemToOption)
+  }, [apiVersion, clusters])
+}


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR adds a modal that allows users select a cluster to start the creation from. The modal is not being used as of yet, it will be adopted in a future PR.

## Changes

- add modal component
- filter out clusters that have been created with a PC version that differs in major or minor

## Screenshot
![image](https://user-images.githubusercontent.com/11457067/222759485-4d0a5f79-571f-4a45-99fb-f6c02b10d4d1.png)

## How Has This Been Tested?

- manually
- unit test
- no test has been created for the Modal component, since `Select`s inside a `Modal` cannot be selected neither with classic testing-lib queries nor with CloudScape testing-utils

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
