### PR TITLE
Arrange cluster properties layout

### DIFF
--- a/frontend/src/components/ValueWithLabel.tsx
+++ b/frontend/src/components/ValueWithLabel.tsx
@@ -8,11 +8,7 @@ export const ValueWithLabel = ({
 }: PropsWithChildren<{label: string; info?: ReactElement}>) => (
   <div>
     <SpaceBetween direction="horizontal" size="s">
-      <Box
-        variant="awsui-key-label"
-        margin={{bottom: 'xxxs'}}
-        color="text-label"
-      >
+      <Box variant="awsui-key-label" color="text-label">
         {label}
       </Box>
       {info}

--- a/frontend/src/old-pages/Clusters/Properties.tsx
+++ b/frontend/src/old-pages/Clusters/Properties.tsx
@@ -75,6 +75,23 @@ export default function ClusterProperties() {
       <Container header={<Header variant="h3">Properties</Header>}>
         <ColumnLayout columns={3} variant="text-grid">
           <SpaceBetween size="l">
+            {cluster.clusterStatus !== ClusterStatus.CreateFailed && (
+              <ValueWithLabel
+                label={t('cluster.properties.configurationLabel')}
+              >
+                <Link
+                  href="#"
+                  onFollow={() =>
+                    setState(
+                      ['app', 'clusters', 'clusterConfig', 'dialog'],
+                      true,
+                    )
+                  }
+                >
+                  {t('cluster.properties.configurationLink')}
+                </Link>
+              </ValueWithLabel>
+            )}
             {headNode && headNode.publicIpAddress && (
               <ValueWithLabel
                 label={t('cluster.properties.sshcommand.label')}
@@ -130,51 +147,6 @@ export default function ClusterProperties() {
                 </div>
               </ValueWithLabel>
             )}
-            {cluster.clusterStatus !== ClusterStatus.CreateFailed && (
-              <ValueWithLabel
-                label={t('cluster.properties.configurationLabel')}
-              >
-                <Link
-                  href="#"
-                  onFollow={() =>
-                    setState(
-                      ['app', 'clusters', 'clusterConfig', 'dialog'],
-                      true,
-                    )
-                  }
-                >
-                  {t('cluster.properties.configurationLink')}
-                </Link>
-              </ValueWithLabel>
-            )}
-          </SpaceBetween>
-          <SpaceBetween size="l">
-            <ValueWithLabel label={t('cluster.properties.statusLabel')}>
-              <ClusterStatusIndicator cluster={cluster} />
-            </ValueWithLabel>
-            <ValueWithLabel
-              label={t('cluster.properties.computeFleetStatusLabel')}
-            >
-              <ComputeFleetStatusIndicator
-                status={cluster.computeFleetStatus}
-              />
-            </ValueWithLabel>
-            <ValueWithLabel label={t('cluster.properties.creationTimeLabel')}>
-              <DateView date={cluster.creationTime} />
-            </ValueWithLabel>
-          </SpaceBetween>
-          <SpaceBetween size="l">
-            <ValueWithLabel
-              label={t('cluster.properties.lastUpdatedTimeLabel')}
-            >
-              <DateView date={cluster.lastUpdatedTime} />
-            </ValueWithLabel>
-            <ValueWithLabel label={t('cluster.properties.regionLabel')}>
-              {cluster.region}
-            </ValueWithLabel>
-            <ValueWithLabel label={t('cluster.properties.versionLabel')}>
-              {cluster.version}
-            </ValueWithLabel>
             {headNode &&
               headNode.publicIpAddress &&
               headNode.publicIpAddress !== '' &&
@@ -230,6 +202,34 @@ export default function ClusterProperties() {
                   </Box>
                 </ValueWithLabel>
               )}
+          </SpaceBetween>
+          <SpaceBetween size="l">
+            <ValueWithLabel label={t('cluster.properties.statusLabel')}>
+              <ClusterStatusIndicator cluster={cluster} />
+            </ValueWithLabel>
+            <ValueWithLabel
+              label={t('cluster.properties.computeFleetStatusLabel')}
+            >
+              <ComputeFleetStatusIndicator
+                status={cluster.computeFleetStatus}
+              />
+            </ValueWithLabel>
+            <ValueWithLabel label={t('cluster.properties.versionLabel')}>
+              {cluster.version}
+            </ValueWithLabel>
+          </SpaceBetween>
+          <SpaceBetween size="l">
+            <ValueWithLabel label={t('cluster.properties.regionLabel')}>
+              {cluster.region}
+            </ValueWithLabel>
+            <ValueWithLabel label={t('cluster.properties.creationTimeLabel')}>
+              <DateView date={cluster.creationTime} />
+            </ValueWithLabel>
+            <ValueWithLabel
+              label={t('cluster.properties.lastUpdatedTimeLabel')}
+            >
+              <DateView date={cluster.lastUpdatedTime} />
+            </ValueWithLabel>
           </SpaceBetween>
         </ColumnLayout>
       </Container>


### PR DESCRIPTION
## Description

Arrange cluster properties layout for a better alignment of the content displayed.

My initial idea was to leverage just the `ColumnLayout` and let Cloudscape arrange the properties, but, after reading the [key-value pairs guidelines](https://cloudscape.design/components/key-value-pairs/) I used the current layout and changed just the ordering of properties to make it coherent.

There will still be blanks in the layout, especially if the cluster is private, but there's no way to use the `variant=text-grid` with a random number of elements in `ColumnLayout`.

## How Has This Been Tested?

Created a cluster with a public IP to show all the available properties.

<img width="1443" alt="Screenshot 2023-03-06 at 11 34 26" src="https://user-images.githubusercontent.com/3091286/223095397-6c8e0153-3e58-49e7-a42a-75eae3e3f496.png">


## References

https://cloudscape.design/components/key-value-pairs/

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
