### PR TITLE
Improved subnet parameter description + fixed parameters structure and groupings in main CF template

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -44,16 +44,29 @@ Metadata:
         Parameters: 
           - AdminUserEmail
       - Label:
+          default: ParallelCluster UI
+        Parameters:
+          - PublicEcrImageUri
+      - Label:
           default: (Optional) External PCUI Cognito
         Parameters:
           - UserPoolId
           - UserPoolAuthDomain
           - SNSRole
       - Label:
-          default: (Optional) ParallelCluster API
+          default: ParallelCluster API
         Parameters:
           - Version
-          - PublicEcrImageUri
+      - Label:
+          default: (Optional) ImageBuilder Custom VPC
+        Parameters:
+          - ImageBuilderVpcId
+          - ImageBuilderSubnetId
+      - Label:
+          default: (Debugging only) Infrastructure S3 Bucket
+        Parameters:
+          - InfrastructureBucket
+
     ParameterLabels:
       AdminUserEmail:
         default: Admin's Email

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -28,7 +28,7 @@ Parameters:
     Type: String
     Default: ''
   ImageBuilderSubnetId:
-    Description: (Optional) Select the subnet to use for building the container images. If not selected, Subnet in the default VPC will be used.
+    Description: (Optional) Select the subnet to use for building the container images (public subnets only). If not selected, Subnet in the default VPC will be used.
     Type: String
     Default: ''
   InfrastructureBucket:


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description
This PR does two things:
- it improves the description of the subnet parameter specifying only public subnets are allowed
- it fixes a wrong grouping of CF parameters caused by some of them not being treated by the CF Interfaces

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
