### PR TITLE
Allow HiddenFileUpload to be controlled via props

### DIFF
--- a/frontend/src/components/HiddenFileUpload.tsx
+++ b/frontend/src/components/HiddenFileUpload.tsx
@@ -8,20 +8,11 @@
 // or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
-import * as React from 'react'
 
-// UI Elements
-import {Button} from '@cloudscape-design/components'
+import React from 'react'
+import {getState, setState} from '../store'
 
-// State
-import {setState, getState} from '../store'
-import {useTranslation} from 'react-i18next'
-
-function DeprecatedHiddenUploader({
-  callbackPath,
-  handleData,
-  handleCancel,
-}: any) {
+export function HiddenUploader({callbackPath, handleData, handleCancel}: any) {
   const hiddenFileInput = React.useRef(null)
   const handleClick = React.useCallback(
     event => {
@@ -55,36 +46,3 @@ function DeprecatedHiddenUploader({
     />
   )
 }
-
-function FileUploadButton(props: any) {
-  const {t} = useTranslation()
-  const hiddenFileInput = React.useRef(null)
-  const handleClick = (event: any) => {
-    // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
-    hiddenFileInput.current.click()
-  }
-  const handleChange = (event: any) => {
-    var file = event.target.files[0]
-    var reader = new FileReader()
-    reader.onload = function (e) {
-      // @ts-expect-error TS(2531) FIXME: Object is possibly 'null'.
-      props.handleData(e.target.result)
-    }
-    reader.readAsText(file)
-  }
-  return (
-    <div>
-      <Button onClick={handleClick}>
-        {t('components.FileUploadButton.label')}
-      </Button>
-      <input
-        type="file"
-        ref={hiddenFileInput}
-        onChange={handleChange}
-        style={{display: 'none'}}
-      />
-    </div>
-  )
-}
-
-export {FileUploadButton as default, DeprecatedHiddenUploader}

--- a/frontend/src/components/__tests__/HiddenFileUpload.test.tsx
+++ b/frontend/src/components/__tests__/HiddenFileUpload.test.tsx
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {render, RenderResult} from '@testing-library/react'
+import {HiddenFileUpload} from '../HiddenFileUpload'
+
+/**
+ * This test is here to make sure that
+ * users of the component can reset the `open` prop
+ * after the file selector dialog has been opened.
+ *
+ * This is needed as there is no way to intercept
+ * actual cancel event on the brower's file picker
+ *
+ * The test can be removed when this quirk has been resolved.
+ */
+
+describe('given a hidden file input field', () => {
+  let screen: RenderResult
+  let mockOnDismiss: jest.Mock
+  let mockOnChange: jest.Mock
+
+  describe('when open is set to true', () => {
+    beforeEach(() => {
+      mockOnDismiss = jest.fn()
+      mockOnChange = jest.fn()
+
+      screen = render(
+        <HiddenFileUpload
+          open={true}
+          onDismiss={mockOnDismiss}
+          onChange={mockOnChange}
+        />,
+      )
+    })
+    it('should call the onDismiss handler', () => {
+      expect(mockOnDismiss).toHaveBeenCalledTimes(1)
+    })
+  })
+  describe('when open is set to false', () => {
+    beforeEach(() => {
+      mockOnDismiss = jest.fn()
+      mockOnChange = jest.fn()
+
+      screen = render(
+        <HiddenFileUpload
+          open={false}
+          onDismiss={mockOnDismiss}
+          onChange={mockOnChange}
+        />,
+      )
+    })
+
+    it('should not call any handler', () => {
+      expect(mockOnDismiss).toHaveBeenCalledTimes(0)
+    })
+  })
+})

--- a/frontend/src/old-pages/Configure/Source.tsx
+++ b/frontend/src/old-pages/Configure/Source.tsx
@@ -34,7 +34,7 @@ import {
 } from '@cloudscape-design/components'
 
 // Components
-import {HiddenUploader} from '../../components/FileChooser'
+import {DeprecatedHiddenUploader} from '../../components/FileChooser'
 import Loading from '../../components/Loading'
 
 // Types
@@ -294,7 +294,7 @@ function Source() {
                   },
                 ]}
               />
-              <HiddenUploader
+              <DeprecatedHiddenUploader
                 callbackPath={['app', 'wizard', 'source', 'upload']}
                 handleData={handleUpload}
               />


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR improves the hidden file uploader so that it can be controlled via props. This is part of a bigger effort to change way the cluster creation can be started by the user.

Follow up PRs will be linked to this

## Changes

- deprecate existing `HiddenUploader` so not to break the `Source` page with this PR
- refactor `HiddenFileUpload` to be controlled via props

## How Has This Been Tested?

- manually
- unit test
- a proper test checking that the `onChange` handler is being called after upload file is missing, this is due to the difficulty to simulate a file upload while also controlling the behaviour of the `onload` event of the `FileReader`
   - this is partially mitigated by [existing e2e tests](https://github.com/aws/aws-parallelcluster-ui/blob/main/e2e/specs/wizard.template.spec.ts)

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
