### PR TITLE
Move cluster name field from Source to Cluster section

### DIFF
--- a/e2e/specs/wizard.spec.ts
+++ b/e2e/specs/wizard.spec.ts
@@ -11,16 +11,19 @@
 import { expect, test } from '@playwright/test';
 import { visitAndLogin } from '../test-utils/login';
 
+const CLUSTER_NAME = Math.random().toString(20).substring(8)
+
 test.describe('Given an endpoint where AWS ParallelCluster UI is deployed', () => {
   test('a user should be able to login, navigate till the end of the cluster creation wizard, and perform a dry-run successfully', async ({ page }) => {
     await visitAndLogin(page)
   
     await page.getByRole('button', { name: 'Create cluster' }).first().click();
-    await expect(page.getByRole('heading', { name: 'Cluster name' })).toBeVisible()
-    await page.getByRole('textbox', { name: 'Enter your cluster name' }).fill("testcluster");
+    
+    await expect(page.getByRole('heading', { name: 'Source' })).toBeVisible()
     await page.getByRole('button', { name: 'Next' }).click();
     
     await expect(page.getByRole('heading', { name: 'Cluster', exact: true })).toBeVisible()
+    await page.getByPlaceholder('Enter your cluster name').fill(CLUSTER_NAME);
     await page.getByRole('button', { name: 'Select a VPC' }).click();
     await page.getByText(/vpc-.*/).first().click();
     await page.getByRole('button', { name: 'Next' }).click();

--- a/e2e/specs/wizard.template.spec.ts
+++ b/e2e/specs/wizard.template.spec.ts
@@ -12,6 +12,7 @@ import { expect, FileChooser, test } from '@playwright/test';
 import { visitAndLogin } from '../test-utils/login';
 
 const TEMPLATE_PATH = './fixtures/wizard.template.yaml'
+const CLUSTER_NAME = Math.random().toString(20).substring(8)
 
 test.describe('environment: @demo', () => {
   test.describe('given a cluster configuration template created with single instance type', () => {
@@ -20,15 +21,17 @@ test.describe('environment: @demo', () => {
         await visitAndLogin(page)
 
         await page.getByRole('button', { name: 'Create cluster' }).first().click();
-        await page.getByPlaceholder('Enter your cluster name').fill('sdasdasd');
 
+        await expect(page.getByRole('heading', { name: 'Source' })).toBeVisible()
+        
         page.on("filechooser", (fileChooser: FileChooser) => {
           fileChooser.setFiles([TEMPLATE_PATH]);
         })
         await page.getByRole('radio', { name: 'Existing template' }).click();
         await page.getByRole('button', { name: 'Next' }).click();
-
+        
         await expect(page.getByRole('heading', { name: 'Cluster', exact: true })).toBeVisible()
+        await page.getByPlaceholder('Enter your cluster name').fill(CLUSTER_NAME);
         await page.getByRole('button', { name: 'Next' }).click();
 
         await expect(page.getByRole('heading', { name: 'Head node' })).toBeVisible()

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -320,18 +320,10 @@
       "title": "Source",
       "description": "Choose a cluster name and configuration source.",
       "validation": {
-        "cannotBeBlank": "Cluster name must not be blank.",
-        "alreadyExists": "Cluster with name {{clusterName}} already exists. Choose a unique name.",
-        "doesntMatchRegex": "Cluster name '{{clusterName}}' doesn't match the the required format. Enter a name that starts with an alphabetical character and has up to 60 characters. If Slurm accounting is configured, the name can have up to 40 characters. Valid characters: A-Z, a-z, 0-9, and - (hyphen)",
         "specifySourceCopy": "You must select a cluster to copy from."
       },
       "clusterSelect": {
         "placeholder": "Select a cluster."
-      },
-      "clusterName": {
-        "label": "Cluster name",
-        "description": "The name must start with an alphabetical character and can have up to 60 characters. If Slurm accounting is configured, the name can have up to 40 characters. Valid characters: A-Z, a-z, 0-9, and - (hyphen).",
-        "placeholder": "Enter your cluster name"
       },
       "configurationSource": {
         "label": "Source",
@@ -385,6 +377,14 @@
       "validation": {
         "VpcSelect": "You must select a VPC.",
         "customAmiSelect": "You must select an AMI ID if you add a custom AMI."
+      },
+      "clusterName": {
+        "label": "Name",
+        "description": "The name must start with an alphabetical character. Valid characters: A-Z, a-z, 0-9, and - (hyphen).",
+        "placeholder": "Enter your cluster name",
+        "cannotBeBlank": "Cluster name must not be blank.",
+        "alreadyExists": "Cluster with name {{clusterName}} already exists. Choose a unique name.",
+        "doesntMatchRegex": "Cluster name '{{clusterName}}' doesn't match the the required format. Enter a name that starts with an alphabetical character and has up to 60 characters. If Slurm accounting is configured, the name can have up to 40 characters. Valid characters: A-Z, a-z, 0-9, and - (hyphen)"
       },
       "region": {
         "label": "Region",

--- a/frontend/src/old-pages/Configure/Cluster.tsx
+++ b/frontend/src/old-pages/Configure/Cluster.tsx
@@ -52,6 +52,8 @@ import {
   SlurmSettings,
 } from './SlurmSettings/SlurmSettings'
 import InfoLink from '../../components/InfoLink'
+import {ClusterNameField} from './Cluster/ClusterNameField'
+import {validateClusterNameAndSetErrors} from './Cluster/clusterName.validators'
 
 // Constants
 const errorsPath = ['app', 'wizard', 'errors', 'cluster']
@@ -96,6 +98,11 @@ function clusterValidate() {
     valid = false
   } else {
     clearState([...errorsPath, 'multiUser'])
+  }
+
+  const clusterNameValid = validateClusterNameAndSetErrors()
+  if (!clusterNameValid) {
+    valid = false
   }
 
   const accountingValid = slurmAccountingValidateAndSetErrors()
@@ -408,6 +415,7 @@ function Cluster() {
         }
       >
         <SpaceBetween direction="vertical" size="m">
+          <ClusterNameField />
           <RegionSelect />
           <OsFormField />
           <CustomAMISettings

--- a/frontend/src/old-pages/Configure/Cluster/ClusterNameField.tsx
+++ b/frontend/src/old-pages/Configure/Cluster/ClusterNameField.tsx
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {FormField, Input, InputProps} from '@cloudscape-design/components'
+import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
+import {useCallback} from 'react'
+import {useTranslation} from 'react-i18next'
+import {setState, useState} from '../../../store'
+
+const clusterNamePath = ['app', 'wizard', 'clusterName']
+const clusterNameErrorPath = [
+  'app',
+  'wizard',
+  'errors',
+  'source',
+  'clusterName',
+]
+
+export function ClusterNameField() {
+  const {t} = useTranslation()
+  const clusterName = useState(clusterNamePath) || ''
+  const clusterNameError = useState(clusterNameErrorPath)
+
+  const onChange: NonCancelableEventHandler<InputProps.ChangeDetail> =
+    useCallback(({detail}) => {
+      setState(clusterNamePath, detail.value)
+    }, [])
+
+  return (
+    <FormField
+      label={t('wizard.cluster.clusterName.label')}
+      constraintText={t('wizard.cluster.clusterName.description')}
+      errorText={clusterNameError}
+    >
+      <Input
+        onChange={onChange}
+        value={clusterName}
+        placeholder={t('wizard.cluster.clusterName.placeholder')}
+      />
+    </FormField>
+  )
+}

--- a/frontend/src/old-pages/Configure/Cluster/__tests__/clusterName.validators.test.ts
+++ b/frontend/src/old-pages/Configure/Cluster/__tests__/clusterName.validators.test.ts
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {validateClusterName} from '../clusterName.validators'
+
+describe('given a cluster name', () => {
+  const mockClusterNames = new Set(['cluster1', 'cluster2'])
+
+  describe("when it's blank", () => {
+    it('should fail the validation', () => {
+      expect(validateClusterName(mockClusterNames, '')).toEqual([
+        false,
+        'empty',
+      ])
+    })
+  })
+
+  describe('when there is another cluster with the same name', () => {
+    it('should fail the validation', () => {
+      expect(validateClusterName(mockClusterNames, 'cluster1')).toEqual([
+        false,
+        'existing_name',
+      ])
+    })
+  })
+
+  describe('when one or more bad characters are given', () => {
+    it('should fail the validation', () => {
+      expect(validateClusterName(mockClusterNames, ';')).toEqual([
+        false,
+        'forbidden_chars',
+      ])
+      expect(validateClusterName(mockClusterNames, '``')).toEqual([
+        false,
+        'forbidden_chars',
+      ])
+      expect(validateClusterName(mockClusterNames, '#')).toEqual([
+        false,
+        'forbidden_chars',
+      ])
+    })
+  })
+
+  describe('when no bad characters are given', () => {
+    it('should be validated', () => {
+      expect(
+        validateClusterName(mockClusterNames, 'some-cluster-name'),
+      ).toEqual([true])
+    })
+  })
+})

--- a/frontend/src/old-pages/Configure/Cluster/clusterName.validators.ts
+++ b/frontend/src/old-pages/Configure/Cluster/clusterName.validators.ts
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import i18next from 'i18next'
+import {clearState, getState, setState} from '../../../store'
+import {ClusterInfoSummary} from '../../../types/clusters'
+
+const clusterNamePath = ['app', 'wizard', 'clusterName']
+const clusterNameErrorPath = [
+  'app',
+  'wizard',
+  'errors',
+  'source',
+  'clusterName',
+]
+
+type ErrorKind = 'empty' | 'existing_name' | 'forbidden_chars'
+
+type ValidateResult = [true] | [false, ErrorKind]
+
+export function validateClusterName(
+  clustersList: Set<string>,
+  clusterName: string,
+): ValidateResult {
+  if (!clusterName) {
+    return [false, 'empty']
+  }
+
+  if (clustersList.has(clusterName)) {
+    return [false, 'existing_name']
+  }
+
+  if (!/^[a-zA-Z][a-zA-Z0-9-]+$/.test(clusterName)) {
+    return [false, 'forbidden_chars']
+  }
+
+  return [true]
+}
+
+export function validateClusterNameAndSetErrors() {
+  const clusterName = getState(clusterNamePath)
+  const clusters: ClusterInfoSummary[] = getState(['clusters', 'list']) || []
+  const allClusterNames = new Set(clusters.map(c => c.clusterName))
+
+  const [isValid, errorCode] = validateClusterName(allClusterNames, clusterName)
+
+  if (isValid) {
+    clearState(clusterNameErrorPath)
+    return true
+  }
+
+  switch (errorCode) {
+    case 'empty':
+      setState(
+        clusterNameErrorPath,
+        i18next.t('wizard.cluster.clusterName.cannotBeBlank'),
+      )
+      return false
+    case 'existing_name':
+      setState(
+        clusterNameErrorPath,
+        i18next.t('wizard.cluster.clusterName.alreadyExists', {clusterName}),
+      )
+      return false
+    case 'forbidden_chars':
+      setState(
+        clusterNameErrorPath,
+        i18next.t('wizard.cluster.clusterName.doesntMatchRegex', {clusterName}),
+      )
+      return false
+    default:
+      return false
+  }
+}

--- a/frontend/src/old-pages/Configure/Source.tsx
+++ b/frontend/src/old-pages/Configure/Source.tsx
@@ -71,32 +71,6 @@ function sourceValidate(suppressUpload = false) {
 
   setState([...sourceErrorsPath, 'validated'], true)
 
-  if (!clusterName || clusterName === '') {
-    setState(
-      [...sourceErrorsPath, 'clusterName'],
-      i18next.t('wizard.source.validation.cannotBeBlank'),
-    )
-    valid = false
-  } else if (clusterNames.has(clusterName)) {
-    setState(
-      [...sourceErrorsPath, 'clusterName'],
-      i18next.t('wizard.source.validation.alreadyExists', {
-        clusterName: clusterName,
-      }),
-    )
-    valid = false
-  } else if (!/^[a-zA-Z][a-zA-Z0-9-]+$/.test(clusterName)) {
-    setState(
-      [...sourceErrorsPath, 'clusterName'],
-      i18next.t('wizard.source.validation.doesntMatchRegex', {
-        clusterName: clusterName,
-      }),
-    )
-    valid = false
-  } else {
-    clearState([...sourceErrorsPath, 'clusterName'])
-  }
-
   if (
     source === 'cluster' &&
     (!sourceClusterName || sourceClusterName === '')
@@ -228,24 +202,6 @@ function Source() {
         <Loading />
       ) : (
         <SpaceBetween direction="vertical" size="m">
-          <SpaceBetween direction="vertical" size="xxs" key="cluster-name">
-            <Header
-              variant="h2"
-              description={t('wizard.source.clusterName.description')}
-            >
-              <Trans i18nKey="wizard.source.clusterName.label" />
-            </Header>
-            <FormField errorText={clusterNameError}>
-              <Input
-                onChange={({detail}) => {
-                  setState(['app', 'wizard', 'clusterName'], detail.value)
-                  validated && sourceValidate(true)
-                }}
-                value={clusterName}
-                placeholder={t('wizard.source.clusterName.placeholder')}
-              />
-            </FormField>
-          </SpaceBetween>
           <Container
             header={
               <Header


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR moves the cluster name field from the Source section to the Cluster section

## Changes

- add `ClusterNameField` and validators
- move cluster name field from `Source` to `Cluster`
- adjust e2e tests

## Screenshots

![image](https://user-images.githubusercontent.com/11457067/223404292-910c7bf0-cf05-42cd-8c0e-997a30dcd4b2.png)

![image](https://user-images.githubusercontent.com/11457067/223404344-85400424-d2af-4f61-ad18-a58cdb6640d1.png)


## How Has This Been Tested?

- manually
- unit tests
- local e2e test

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
