### PR TITLE
Add the Create cluster button dropdown

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -229,6 +229,7 @@
       "actions": {
         "cancel": "Cancel",
         "create": "Create cluster",
+        "createFromWizard": "Use interface",
         "edit": "Edit",
         "start": "Start fleet",
         "stop": "Stop fleet",

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -231,6 +231,7 @@
         "create": "Create cluster",
         "createFromWizard": "Use interface",
         "createFromTemplate": "Upload a template",
+        "createFromCluster": "From another cluster",
         "edit": "Edit",
         "start": "Start fleet",
         "stop": "Stop fleet",

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -230,6 +230,7 @@
         "cancel": "Cancel",
         "create": "Create cluster",
         "createFromWizard": "Use interface",
+        "createFromTemplate": "Upload a template",
         "edit": "Edit",
         "start": "Start fleet",
         "stop": "Stop fleet",

--- a/frontend/src/old-pages/Clusters/CreateButtonDropdown/CreateButtonDropdown.tsx
+++ b/frontend/src/old-pages/Clusters/CreateButtonDropdown/CreateButtonDropdown.tsx
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  ButtonDropdown,
+  ButtonDropdownProps,
+} from '@cloudscape-design/components'
+import {CancelableEventHandler} from '@cloudscape-design/components/internal/events'
+import React, {useMemo} from 'react'
+import {useTranslation} from 'react-i18next'
+import {NavigateFunction, useNavigate} from 'react-router-dom'
+
+interface Props {
+  openWizard: (navigate: NavigateFunction) => void
+}
+
+export const CreateButtonDropdown: React.FC<Props> = ({openWizard}) => {
+  const {t} = useTranslation()
+
+  const navigate = useNavigate()
+
+  const onCreateClick: CancelableEventHandler<ButtonDropdownProps.ItemClickDetails> =
+    React.useCallback(
+      ({detail}) => {
+        switch (detail.id) {
+          case 'wizard':
+            openWizard(navigate)
+            return
+        }
+      },
+      [navigate, openWizard],
+    )
+
+  const createDropdownItems: ButtonDropdownProps.Item[] = useMemo(
+    () => [
+      {
+        id: 'wizard',
+        text: t('cluster.list.actions.createFromWizard'),
+      },
+    ],
+    [t],
+  )
+
+  return (
+    <>
+      <ButtonDropdown
+        variant="primary"
+        items={createDropdownItems}
+        onItemClick={onCreateClick}
+      >
+        {t('cluster.list.actions.create')}
+      </ButtonDropdown>
+    </>
+  )
+}

--- a/frontend/src/old-pages/Clusters/CreateButtonDropdown/__tests__/CreateButtonDropdown.test.tsx
+++ b/frontend/src/old-pages/Clusters/CreateButtonDropdown/__tests__/CreateButtonDropdown.test.tsx
@@ -1,0 +1,51 @@
+import wrapper from '@cloudscape-design/components/test-utils/dom'
+import {Store} from '@reduxjs/toolkit'
+import {render, RenderResult} from '@testing-library/react'
+import i18n from 'i18next'
+import {mock} from 'jest-mock-extended'
+import {I18nextProvider, initReactI18next} from 'react-i18next'
+import {Provider} from 'react-redux'
+import {BrowserRouter} from 'react-router-dom'
+import {CreateButtonDropdown} from '../CreateButtonDropdown'
+
+i18n.use(initReactI18next).init({
+  resources: {},
+  lng: 'en',
+})
+
+const mockStore = mock<Store>()
+
+const MockProviders = (props: any) => (
+  <BrowserRouter>
+    <Provider store={mockStore}>
+      <I18nextProvider i18n={i18n}>{props.children}</I18nextProvider>
+    </Provider>
+  </BrowserRouter>
+)
+
+describe('given a dropdown button to create a cluster', () => {
+  let screen: RenderResult
+  let mockOpenWizard: jest.Mock
+
+  beforeEach(() => {
+    mockOpenWizard = jest.fn()
+
+    screen = render(
+      <MockProviders>
+        <CreateButtonDropdown openWizard={mockOpenWizard} />
+      </MockProviders>,
+    )
+  })
+
+  describe('when user selects the option to create a cluster using the wizard', () => {
+    beforeEach(() => {
+      const buttonDropdown = wrapper(screen.container).findButtonDropdown()!
+      buttonDropdown.openDropdown()
+      buttonDropdown.findItemById('wizard')?.click()
+    })
+
+    it('should open the cluster creation wizard', () => {
+      expect(mockOpenWizard).toHaveBeenCalledTimes(1)
+    })
+  })
+})


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR adds the Create cluster button dropdown, to be adopted in a future PR.

It follows the work done with #90 and #84 

## Changes

- add `CreateButtonDropdown` component
- connect the dropdown options to the `HiddenFileUpload` and the `FromClusterModal`

## Screenshot

![image](https://user-images.githubusercontent.com/11457067/223448399-51f3535a-1917-4ad2-875d-c35bf25fc213.png)

## How Has This Been Tested?

- manually
- unit test
- file upload will be tested with e2e tests once the `CreateButtonDropdown` will be adopted

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
