### PR TITLE
Moved subnet dropdown to a new "Networking" container

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -543,9 +543,13 @@
         "label": "Instance metadata service (IMDS) secured",
         "help": "IMDS secured restricts access to IMDS (and thus instance credentials) to users with superuser permissions. For more information, see <0>How instance metadata service version 2 works</0> in the <i>Amazon EC2 User Guide for Linux Instances</i>."
       },
-      "subnetId": {
-        "label": "Subnet ID",
-        "description": "Subnet ID for head node."
+      "networking": {
+        "header": "Networking",
+        "subnetId": {
+          "label": "Subnet ID",
+          "description": "Subnet ID for head node.",
+          "alert": "If you don't have a default VPC or subnet, Amazon ParallelCluster UI will use defaults for your cluster."
+        }
       },
       "securityGroups": {
        "label": "Additional security groups",

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -19,12 +19,14 @@ import safeGet from 'lodash/get'
 
 // UI Elements
 import {
+  Alert,
   Box,
   Checkbox,
   ColumnLayout,
   Container,
   ExpandableSection,
   FormField,
+  Header,
   Input,
   Select,
   SpaceBetween,
@@ -438,17 +440,6 @@ function HeadNode() {
               />
             </FormField>
           </Box>
-          <FormField
-            label={t('wizard.headNode.subnetId.label')}
-            errorText={subnetErrors}
-            description={t('wizard.headNode.subnetId.description')}
-          >
-            <SubnetSelect
-              disabled={editing}
-              value={subnetValue}
-              onChange={(subnetId: any) => setState(subnetPath, subnetId)}
-            />
-          </FormField>
           <KeypairSelect />
           <RootVolume basePath={headNodePath} errorsPath={errorsPath} />
           <SsmSettings />
@@ -511,6 +502,30 @@ function HeadNode() {
               <IamPoliciesEditor basePath={headNodePath} />
             </ExpandableSection>
           </ExpandableSection>
+        </SpaceBetween>
+      </Container>
+
+      <Container
+        header={
+          <Header variant="h2">{t('wizard.headNode.networking.header')}</Header>
+        }
+      >
+        <SpaceBetween direction="vertical" size="s">
+          <Box>
+            <FormField
+              label={t('wizard.headNode.networking.subnetId.label')}
+              errorText={subnetErrors}
+              description={t('wizard.headNode.networking.subnetId.description')}
+            ></FormField>
+            <SubnetSelect
+              disabled={editing}
+              value={subnetValue}
+              onChange={(subnetId: any) => setState(subnetPath, subnetId)}
+            />
+          </Box>
+          <Alert statusIconAriaLabel="Info">
+            {t('wizard.headNode.networking.subnetId.alert')}
+          </Alert>
         </SpaceBetween>
       </Container>
     </ColumnLayout>


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description
This PR literally moves the subnet id dropdown to a new container Networking according to our figma.
And also adds an Alert.

The Alert is not inside a Box since it apparently made no difference.
<!-- List of relevant changes introduced -->
![new-networking-container](https://user-images.githubusercontent.com/6314859/223698374-3e0ca1e3-c58d-45f9-80de-acddac01ba5f.png)

## How Has This Been Tested?
- manually 
- unit tests
## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
