### PR TITLE
Use a Multiselect for selecting security groups

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -516,8 +516,8 @@
       },
       "securityGroups": {
        "label": "Additional security groups",
-       "help": "Select a security group.",
-       "select": "Select a security group"
+       "help": "Select one or more security groups.",
+       "select": "Select one or more security groups"
       },
       "advancedOptions": {
         "label": "Advanced options",

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -40,6 +40,7 @@ import {
   InputProps,
   TextContent,
   CheckboxProps,
+  Multiselect,
 } from '@cloudscape-design/components'
 
 // Components
@@ -461,13 +462,8 @@ function SecurityGroups({basePath}: any) {
   const {t} = useTranslation()
   const sgPath = [...basePath, 'Networking', 'AdditionalSecurityGroups']
   const selectedSgs = useState(sgPath) || []
-  const sgSelected = useState(['app', 'wizard', 'sg-selected'])
 
   const sgs = useState(['aws', 'security_groups']) || []
-  const sgMap = sgs.reduce((acc: any, s: any) => {
-    acc[s.GroupId] = s.GroupName
-    return acc
-  }, {})
 
   const itemToOption = (item: any) => {
     return {
@@ -476,51 +472,23 @@ function SecurityGroups({basePath}: any) {
       description: item.GroupName,
     }
   }
-  const removeSg = (i: any) => {
-    setState(sgPath, [...selectedSgs.slice(0, i), ...selectedSgs.slice(i + 1)])
-    if (getState(sgPath).length === 0) clearState(sgPath)
-  }
+
+  const options = sgs.map(itemToOption)
+
   return (
-    <SpaceBetween direction="vertical" size="xs">
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'center',
-          gap: '16px',
-        }}
-      >
-        <Select
-          selectedOption={
-            sgSelected &&
-            findFirst(sgs, (x: any) => x.GroupId === sgSelected.value)
-              ? itemToOption(
-                  findFirst(sgs, (x: any) => x.GroupId === sgSelected.value),
-                )
-              : {label: t('wizard.headNode.securityGroups.select')}
-          }
-          onChange={({detail}) => {
-            setState(['app', 'wizard', 'sg-selected'], detail.selectedOption)
-          }}
-          triggerVariant={'option'}
-          options={sgs.map(itemToOption)}
-        />
-        <Button
-          disabled={!sgSelected}
-          onClick={() => setState(sgPath, [...selectedSgs, sgSelected.value])}
-        >
-          Add
-        </Button>
-      </div>
-      <TokenGroup
-        onDismiss={({detail: {itemIndex}}) => {
-          removeSg(itemIndex)
-        }}
-        items={selectedSgs.map((s: any) => {
-          return {label: s, dismissLabel: `Remove ${s}`, description: sgMap[s]}
-        })}
-      />
-    </SpaceBetween>
+    <Multiselect
+      selectedOptions={options.filter((opt: any) =>
+        selectedSgs.includes(opt.value),
+      )}
+      placeholder={t('wizard.headNode.securityGroups.select')}
+      onChange={({detail}) => {
+        setState(
+          sgPath,
+          detail.selectedOptions.map(opt => opt.value),
+        )
+      }}
+      options={options}
+    />
   )
 }
 

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -41,6 +41,7 @@ import {
   TextContent,
   CheckboxProps,
   Multiselect,
+  MultiselectProps,
 } from '@cloudscape-design/components'
 
 // Components
@@ -458,35 +459,41 @@ function HeadNodeActionsEditor({basePath, errorsPath}: ActionsEditorProps) {
   )
 }
 
-function SecurityGroups({basePath}: any) {
-  const {t} = useTranslation()
-  const sgPath = [...basePath, 'Networking', 'AdditionalSecurityGroups']
-  const selectedSgs = useState(sgPath) || []
-
-  const sgs = useState(['aws', 'security_groups']) || []
-
-  const itemToOption = (item: any) => {
-    return {
-      value: item.GroupId,
-      label: item.GroupId,
-      description: item.GroupName,
-    }
+const securityGroupToOption = (item: {GroupId: string; GroupName: string}) => {
+  return {
+    value: item.GroupId,
+    label: item.GroupId,
+    description: item.GroupName,
   }
+}
 
-  const options = sgs.map(itemToOption)
+function SecurityGroups({basePath}: {basePath: string[]}) {
+  const {t} = useTranslation()
+  const securityGroupsPath = useMemo(
+    () => [...basePath, 'Networking', 'AdditionalSecurityGroups'],
+    [basePath],
+  )
+  const selectedSecurityGroups: string[] = useState(securityGroupsPath) || []
+  const availableSecurityGroups = useState(['aws', 'security_groups']) || []
+  const options = availableSecurityGroups.map(securityGroupToOption)
+  const onChange: NonCancelableEventHandler<MultiselectProps.MultiselectChangeDetail> =
+    useCallback(
+      ({detail}) => {
+        setState(
+          securityGroupsPath,
+          detail.selectedOptions.map(option => option.value),
+        )
+      },
+      [securityGroupsPath],
+    )
 
   return (
     <Multiselect
       selectedOptions={options.filter((opt: any) =>
-        selectedSgs.includes(opt.value),
+        selectedSecurityGroups.includes(opt.value),
       )}
       placeholder={t('wizard.headNode.securityGroups.select')}
-      onChange={({detail}) => {
-        setState(
-          sgPath,
-          detail.selectedOptions.map(opt => opt.value),
-        )
-      }}
+      onChange={onChange}
       options={options}
     />
   )

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -474,8 +474,11 @@ function SecurityGroups({basePath}: {basePath: string[]}) {
     [basePath],
   )
   const selectedSecurityGroups: string[] = useState(securityGroupsPath) || []
-  const availableSecurityGroups = useState(['aws', 'security_groups']) || []
-  const options = availableSecurityGroups.map(securityGroupToOption)
+  const availableSecurityGroups = useState(['aws', 'security_groups'])
+  const options = useMemo(
+    () => (availableSecurityGroups || []).map(securityGroupToOption),
+    [availableSecurityGroups],
+  )
   const onChange: NonCancelableEventHandler<MultiselectProps.MultiselectChangeDetail> =
     useCallback(
       ({detail}) => {


### PR DESCRIPTION
## Description

Use Cloudscape Multiselect component to simplify the selection of security groups.

Fixes #38 

## How Has This Been Tested?

Validated setting 2 security groups on the head node and 1 on a queue, dry run passes
## PR Quality Checklist

- [] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
