### PR TITLE
Increase maximum allowed payload size

### DIFF
--- a/api/validation/schemas.py
+++ b/api/validation/schemas.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields, validate, INCLUDE, validates_schema, ValidationError
+from marshmallow import Schema, fields, validate, INCLUDE, validates_schema
 
 from api.validation.validators import aws_region_validator, is_alphanumeric_with_hyphen, \
     valid_api_log_levels_predicate, size_not_exceeding
@@ -131,4 +131,4 @@ class PCProxyBodySchema(Schema):
     def request_body_not_exceeding(self, data, **kwargs):
         size_not_exceeding(data, self.max_size)
 
-PCProxyBody = PCProxyBodySchema(max_size=8192,unknown=INCLUDE)
+PCProxyBody = PCProxyBodySchema(max_size=1000000,unknown=INCLUDE)

--- a/api/validation/validators.py
+++ b/api/validation/validators.py
@@ -31,4 +31,4 @@ def size_not_exceeding(data, size):
     bytes_ = bytes(json.dumps(data), 'utf-8')
     byte_size = len(bytes_)
     if byte_size > size:
-        raise ValidationError(f'Request body exceeded max size of {size}')
+        raise ValidationError(f'Request body exceeded max size of {size} bytes')


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR increases the maximum allowed payload size in calls towards PC.

This allows for bigger YAML configuration file

The limit has been set to 1MB, which respects the following:
- allows for huge configuration files
- respects [AWS Lambda payload limit](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html) (6 MB)
- respects [CloudFormation template size limit](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html) (1 MB)

## Changes

- increase limit from 8kib to 1MB
- explicit unit of measurement in the error message

## How Has This Been Tested?

- manually, by importing a YAML file that previously had been rejected by the current limit (size ~9kb)
- discarded unit tests, since I ended up testing the library and our configuration, with the downsize of running 1MB of mocked data in our test suites

## References

- [AWS Lambda payload limit](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html)
- [CloudFormation template size limit](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html)

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
