### PR TITLE
IMDS secured set as True by default for new cluster creation

### DIFF
--- a/frontend/src/old-pages/Configure/Configure.tsx
+++ b/frontend/src/old-pages/Configure/Configure.tsx
@@ -95,6 +95,7 @@ function clearWizardState(
     clearState(['app', 'wizard', 'vpc'])
     clearState(['app', 'wizard', 'multiUser'])
     clearState(['app', 'wizard', 'validated'])
+    clearState(['app', 'wizard', 'persistentImdsSecured'])
     clearState(loadingPath)
   }
   clearState(['app', 'wizard', 'errors'])

--- a/frontend/src/old-pages/Configure/Configure.tsx
+++ b/frontend/src/old-pages/Configure/Configure.tsx
@@ -95,7 +95,6 @@ function clearWizardState(
     clearState(['app', 'wizard', 'vpc'])
     clearState(['app', 'wizard', 'multiUser'])
     clearState(['app', 'wizard', 'validated'])
-    clearState(['app', 'wizard', 'persistentImdsSecured'])
     clearState(loadingPath)
   }
   clearState(['app', 'wizard', 'errors'])

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -540,4 +540,9 @@ const HeadNodePropertiesHelpPanel = () => {
   )
 }
 
-export {HeadNode, headNodeValidate, HeadNodePropertiesHelpPanel}
+export {
+  HeadNode,
+  headNodeValidate,
+  HeadNodePropertiesHelpPanel,
+  IMDSSecuredSettings,
+}

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -62,6 +62,7 @@ import {useHelpPanel} from '../../components/help-panel/HelpPanel'
 const headNodePath = ['app', 'wizard', 'config', 'HeadNode']
 const errorsPath = ['app', 'wizard', 'errors', 'headNode']
 const keypairPath = [...headNodePath, 'Ssh', 'KeyName']
+const imdsSecuredPath = [...headNodePath, 'Imds', 'Secured']
 
 function headNodeValidate() {
   const subnetPath = [...headNodePath, 'Networking', 'SubnetId']
@@ -368,37 +369,18 @@ function DcvSettings() {
   )
 }
 
-const imdsSecuredPath = [...headNodePath, 'Imds', 'Secured']
-const persistentImdsSecuredPath = ['app', 'wizard', 'persistentImdsSecured']
-function clearImdsSecuredState() {
-  clearState(imdsSecuredPath)
-  if (Object.keys(getState([...headNodePath, 'Imds'])).length === 0) {
-    clearState([...headNodePath, 'Imds'])
-  }
-}
-
-function handleImdsSecuredState(imdsSecured: boolean) {
-  setState(persistentImdsSecuredPath, imdsSecured)
-  if (imdsSecured) {
-    setState(imdsSecuredPath, imdsSecured)
-  } else {
-    clearImdsSecuredState()
-  }
-}
-
 function IMDSSecuredSettings() {
   const {t} = useTranslation()
-  const initialImdsSecured = useState(persistentImdsSecuredPath)
-  const [imdsSecured, setImdsSecured] = React.useState(
-    initialImdsSecured ?? true,
-  )
+  const imdsSecured = useState(imdsSecuredPath) ?? true
 
-  handleImdsSecuredState(imdsSecured)
+  console.log('WAS', useState(imdsSecuredPath))
+  React.useEffect(() => {
+    console.log('SETTING TO', imdsSecured)
+    setState(imdsSecuredPath, imdsSecured)
+  }, [])
 
   const toggleImdsSecured = React.useCallback(() => {
-    const toggledImdsSecured = !imdsSecured
-    setImdsSecured(toggledImdsSecured)
-    handleImdsSecuredState(toggledImdsSecured)
+    setState(imdsSecuredPath, !imdsSecured)
   }, [imdsSecured])
 
   return (

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -373,9 +373,7 @@ function IMDSSecuredSettings() {
   const {t} = useTranslation()
   const imdsSecured = useState(imdsSecuredPath) ?? true
 
-  console.log('WAS', useState(imdsSecuredPath))
   React.useEffect(() => {
-    console.log('SETTING TO', imdsSecured)
     setState(imdsSecuredPath, imdsSecured)
   }, [])
 

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -368,20 +368,37 @@ function DcvSettings() {
   )
 }
 
+const imdsSecuredPath = [...headNodePath, 'Imds', 'Secured']
+const persistentImdsSecuredPath = ['app', 'wizard', 'persistentImdsSecured']
+function clearImdsSecuredState() {
+  clearState(imdsSecuredPath)
+  if (Object.keys(getState([...headNodePath, 'Imds'])).length === 0) {
+    clearState([...headNodePath, 'Imds'])
+  }
+}
+
+function handleImdsSecuredState(imdsSecured: boolean) {
+  setState(persistentImdsSecuredPath, imdsSecured)
+  if (imdsSecured) {
+    setState(imdsSecuredPath, imdsSecured)
+  } else {
+    clearImdsSecuredState()
+  }
+}
+
 function IMDSSecuredSettings() {
   const {t} = useTranslation()
-  const imdsSecuredPath = [...headNodePath, 'Imds', 'Secured']
-  const imdsSecured = useState(imdsSecuredPath) || false
+  const initialImdsSecured = useState(persistentImdsSecuredPath)
+  const [imdsSecured, setImdsSecured] = React.useState(
+    initialImdsSecured ?? true,
+  )
+
+  handleImdsSecuredState(imdsSecured)
 
   const toggleImdsSecured = React.useCallback(() => {
     const toggledImdsSecured = !imdsSecured
-    if (toggledImdsSecured) {
-      setState(imdsSecuredPath, toggledImdsSecured)
-    } else {
-      clearState(imdsSecuredPath)
-      if (Object.keys(getState([...headNodePath, 'Imds'])).length === 0)
-        clearState([...headNodePath, 'Imds'])
-    }
+    setImdsSecured(toggledImdsSecured)
+    handleImdsSecuredState(toggledImdsSecured)
   }, [imdsSecured])
 
   return (

--- a/frontend/src/old-pages/Configure/__tests__/IMDSSecuredSettings.test.tsx
+++ b/frontend/src/old-pages/Configure/__tests__/IMDSSecuredSettings.test.tsx
@@ -1,0 +1,114 @@
+import i18n from 'i18next'
+import {I18nextProvider, initReactI18next} from 'react-i18next'
+import {mock} from 'jest-mock-extended'
+import {Store} from '@reduxjs/toolkit'
+import {Provider} from 'react-redux'
+import {fireEvent, render, RenderResult} from '@testing-library/react'
+import {setState as mockSetState} from '../../../store'
+import {IMDSSecuredSettings} from '../HeadNode'
+
+jest.mock('../../../store', () => {
+  const originalModule = jest.requireActual('../../../store')
+
+  return {
+    __esModule: true, // Use it when dealing with esModules
+    ...originalModule,
+    setState: jest.fn(),
+  }
+})
+
+i18n.use(initReactI18next).init({
+  resources: {},
+  lng: 'en',
+})
+
+const mockStore = mock<Store>()
+const MockProviders = (props: any) => (
+  <Provider store={mockStore}>
+    <I18nextProvider i18n={i18n}>{props.children}</I18nextProvider>
+  </Provider>
+)
+
+describe('given a component to configure IMDS secured setting', () => {
+  let screen: RenderResult
+
+  describe('when no value is already present for IMDS secured', () => {
+    beforeEach(() => {
+      ;(mockSetState as jest.Mock).mockClear()
+      screen = render(
+        <MockProviders>
+          <IMDSSecuredSettings />
+        </MockProviders>,
+      )
+    })
+
+    describe('when no action is performed on the checkbox', () => {
+      it('should be set to true', () => {
+        expect(mockSetState).toHaveBeenCalledTimes(1)
+        expect(mockSetState).toHaveBeenCalledWith(
+          ['app', 'wizard', 'config', 'HeadNode', 'Imds', 'Secured'],
+          true,
+        )
+      })
+    })
+
+    describe('when the checkbox is clicked only once', () => {
+      it('should be set to false', () => {
+        fireEvent.click(
+          screen.getByLabelText('wizard.headNode.imdsSecured.set'),
+        )
+
+        expect(mockSetState).toHaveBeenCalledTimes(2)
+        expect(mockSetState).toHaveBeenCalledWith(
+          ['app', 'wizard', 'config', 'HeadNode', 'Imds', 'Secured'],
+          false,
+        )
+      })
+    })
+  })
+
+  describe('when the cluster config already had a value of `false` for IMDS secured', () => {
+    beforeEach(() => {
+      ;(mockSetState as jest.Mock).mockClear()
+      mockStore.getState.mockReturnValue({
+        app: {
+          wizard: {
+            config: {
+              HeadNode: {Imds: {Secured: false}},
+            },
+          },
+        },
+      })
+
+      screen = render(
+        <MockProviders>
+          <IMDSSecuredSettings />
+        </MockProviders>,
+      )
+    })
+
+    describe('when no action is performed on the checkbox', () => {
+      it('should be set to false', () => {
+        expect(mockSetState).toHaveBeenCalledTimes(1)
+        expect(mockSetState).toHaveBeenCalledWith(
+          ['app', 'wizard', 'config', 'HeadNode', 'Imds', 'Secured'],
+          false,
+        )
+      })
+    })
+
+    describe('when the checkbox is clicked once', () => {
+      it('should be set to true', () => {
+        fireEvent.click(
+          screen.getByLabelText('wizard.headNode.imdsSecured.set'),
+        )
+
+        expect(mockSetState).toHaveBeenCalledTimes(2)
+        expect(mockSetState).toHaveBeenCalledWith(
+          ['app', 'wizard', 'config', 'HeadNode', 'Imds', 'Secured'],
+          true,
+        )
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description
This PR changes the default for the "set IMDS secured" checkbox by saving the chosen value in a separate place and clearing it when the wizard need the be cleared.

## How Has This Been Tested?
- manually
- unit tests
<!-- The tests you ran to verify your changes -->

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
