### PR TITLE
Move keypair selection in a dedicated container in Headnode wizard page

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -513,6 +513,9 @@
           "alert": "If you don't have a default VPC or subnet, Amazon ParallelCluster UI will use defaults for your cluster."
         }
       },
+      "security": {
+        "header": "Security configuration and permissions"
+      },
       "securityGroups": {
        "label": "Additional security groups",
        "help": "Select a security group.",

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -436,7 +436,6 @@ function HeadNode() {
               />
             </FormField>
           </Box>
-          <KeypairSelect />
           <RootVolume basePath={headNodePath} errorsPath={errorsPath} />
           <SsmSettings />
           <DcvSettings />
@@ -502,6 +501,14 @@ function HeadNode() {
             </Alert>
           </Box>
         </SpaceBetween>
+      </Container>
+
+      <Container
+        header={
+          <Header variant="h2">{t('wizard.headNode.security.header')}</Header>
+        }
+      >
+        <KeypairSelect />
       </Container>
     </ColumnLayout>
   )


### PR DESCRIPTION
## Description

Moved keypair selection in a dedicated container in Headnode wizard page.

## How Has This Been Tested?
* Manually tested on local environment
* Dry-run cluster creation successful

## Screenshots

<img width="1719" alt="Screenshot 2023-03-09 at 16 33 31" src="https://user-images.githubusercontent.com/25930133/224074241-2d6ffc6f-2503-4cbe-914c-7ec316eb248f.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
