### PR TITLE
Custom actions editor layout changes

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -523,16 +523,13 @@
         "label": "Advanced options",
         "scripts": {
           "onStart": {
-            "label": "Run script on node start",
-            "description": "The script runs on head node start, before node configuration."
+            "label": "Run script on node start"
           },
           "onConfigured": {
-            "label": "Run script on node configured",
-            "description": "The script runs after node configuration."
+            "label": "Run script on node configured"
           },
           "onUpdated": {
-            "label": "Run script on node updated",
-            "description": "The script runs after an update, after node configuration."
+            "label": "Run script on node updated"
           }
         },
         "iamPolicies": {
@@ -937,12 +934,10 @@
       },
       "actionsEditor": {
         "onStart": {
-          "label": "Run script on node start",
-          "description": "The script runs on head node start, before node configuration."
+          "label": "Run script on node start"
         },
         "onConfigured": {
-          "label": "Run script on node configured",
-          "description": "The script runs after node configuration."
+          "label": "Run script on node configured"
         },
         "addArgument": "Add argument",
         "argument": "Argument"

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -943,7 +943,9 @@
         "onConfigured": {
           "label": "Run script on node configured",
           "description": "The script runs after node configuration."
-        }
+        },
+        "addArgument": "Add argument",
+        "argument": "Argument"
       }
     }
   },

--- a/frontend/src/css-properties.d.ts
+++ b/frontend/src/css-properties.d.ts
@@ -1,0 +1,7 @@
+import 'react'
+
+declare module 'react' {
+  interface CSSProperties {
+    [key: `--${string}`]: string | number
+  }
+}

--- a/frontend/src/old-pages/Configure/Components.module.css
+++ b/frontend/src/old-pages/Configure/Components.module.css
@@ -1,0 +1,5 @@
+.spaceBetweenCentered {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing);
+}

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -421,16 +421,12 @@ function ActionsEditor({basePath, errorsPath}: ActionsEditorProps) {
     <SpaceBetween direction="vertical" size="s">
       <ActionEditor
         label={t('wizard.components.actionsEditor.onStart.label')}
-        description={t('wizard.components.actionsEditor.onStart.description')}
-        errorPath={onStartErrors}
+        error={onStartErrors}
         path={onStartPath}
       />
       <ActionEditor
         label={t('wizard.components.actionsEditor.onConfigured.label')}
-        description={t(
-          'wizard.components.actionsEditor.onConfigured.description',
-        )}
-        errorPath={onConfiguredErrors}
+        error={onConfiguredErrors}
         path={onConfiguredPath}
       />
     </SpaceBetween>
@@ -453,26 +449,17 @@ function HeadNodeActionsEditor({basePath, errorsPath}: ActionsEditorProps) {
     <SpaceBetween direction="vertical" size="s">
       <ActionEditor
         label={t('wizard.headNode.advancedOptions.scripts.onStart.label')}
-        description={t(
-          'wizard.headNode.advancedOptions.scripts.onStart.description',
-        )}
-        errorPath={onStartErrors}
+        error={onStartErrors}
         path={onStartPath}
       />
       <ActionEditor
         label={t('wizard.headNode.advancedOptions.scripts.onConfigured.label')}
-        description={t(
-          'wizard.headNode.advancedOptions.scripts.onConfigured.description',
-        )}
-        errorPath={onConfiguredErrors}
+        error={onConfiguredErrors}
         path={onConfiguredPath}
       />
       <ActionEditor
         label={t('wizard.headNode.advancedOptions.scripts.onUpdated.label')}
-        description={t(
-          'wizard.headNode.advancedOptions.scripts.onConfigured.description',
-        )}
-        errorPath={onUpdatedErrors}
+        error={onUpdatedErrors}
         path={onUpdatedPath}
       />
     </SpaceBetween>

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -371,7 +371,6 @@ function ActionEditor({
 
   const toggleCheckbox = useCallback(() => {
     clearState(path)
-    clearEmptyNest(path, 3)
     setEnabled(!enabled)
   }, [enabled, setEnabled, path])
 
@@ -782,6 +781,7 @@ export {
   InstanceSelect,
   LabeledIcon,
   ActionsEditor,
+  ActionEditor,
   HeadNodeActionsEditor,
   CustomAMISettings,
   RootVolume,

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -345,7 +345,15 @@ function ArgEditor({path, i}: any) {
   )
 }
 
-function ActionEditor({label, errorPath, path}: any) {
+function ActionEditor({
+  label,
+  error,
+  path,
+}: {
+  label: string
+  error: string
+  path: string[]
+}) {
   const script = useState([...path, 'Script']) || ''
   const {t} = useTranslation()
   const args = useState([...path, 'Args']) || []
@@ -378,7 +386,7 @@ function ActionEditor({label, errorPath, path}: any) {
             className={styles.spaceBetweenCentered}
             style={{'--spacing': spaceScaledXs}}
           >
-            <FormField errorText={errorPath}>
+            <FormField errorText={error}>
               <Input
                 placeholder="/home/ec2-user/start.sh"
                 value={script}

--- a/frontend/src/old-pages/Configure/__tests__/Components.test.tsx
+++ b/frontend/src/old-pages/Configure/__tests__/Components.test.tsx
@@ -1,0 +1,94 @@
+import {Store} from '@reduxjs/toolkit'
+import {fireEvent, render} from '@testing-library/react'
+import {mock} from 'jest-mock-extended'
+import {I18nextProvider} from 'react-i18next'
+import {Provider} from 'react-redux'
+import i18n from '../../../i18n'
+import {ActionEditor} from '../Components'
+
+jest.mock('../../../store', () => {
+  const originalModule = jest.requireActual('../../../store')
+
+  return {
+    __esModule: true, // Use it when dealing with esModules
+    ...originalModule,
+    clearState: jest.fn(),
+  }
+})
+import {clearState} from '../../../store'
+
+const mockStore = mock<Store>()
+const MockProviders = (props: any) => (
+  <Provider store={mockStore}>
+    <I18nextProvider i18n={i18n}>{props.children}</I18nextProvider>
+  </Provider>
+)
+
+describe('Given an action editor', () => {
+  describe('when a script has already been given', () => {
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        actions: {
+          Args: ['--test'],
+          Script: '/home.sh',
+        },
+      })
+    })
+
+    it('should show the script field and parameters', () => {
+      const {getByDisplayValue} = render(
+        <MockProviders store={mockStore}>
+          <ActionEditor
+            error=""
+            label="Run script on node start"
+            path={['actions']}
+          />
+        </MockProviders>,
+      )
+
+      expect(getByDisplayValue('/home.sh')).toBeDefined()
+      expect(getByDisplayValue('--test')).toBeDefined()
+    })
+
+    describe('when deselecting the script', () => {
+      it('should remove it from the cluster config', () => {
+        const {getByText} = render(
+          <MockProviders store={mockStore}>
+            <ActionEditor
+              error=""
+              label="Run script on node start"
+              path={['actions']}
+            />
+          </MockProviders>,
+        )
+
+        fireEvent.click(getByText('Run script on node start'))
+        expect(clearState).toHaveBeenCalledWith(['actions'])
+      })
+    })
+  })
+
+  describe('when a script has not already been given', () => {
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        actions: {
+          Args: ['--test'],
+        },
+      })
+    })
+
+    it('should not show any fields or parameters', () => {
+      const {getByDisplayValue} = render(
+        <MockProviders store={mockStore}>
+          <ActionEditor
+            error=""
+            label="Run script on node start"
+            path={['actions']}
+          />
+        </MockProviders>,
+      )
+
+      expect(() => getByDisplayValue('--test')).toThrowError()
+    })
+  })
+})


### PR DESCRIPTION
## Description

Align the layout of the custom actions editor.

## Changes

- add support for passing custom CSS variables
- add a CSS class to implement a SpaceBetween with horizontally aligned items
- actions editor layout changes

## How Has This Been Tested?

- Local dry run after filling custom actions

![Screenshot 2023-03-09 at 18 25 21](https://user-images.githubusercontent.com/3091286/224108454-5c64c25e-75be-4574-8f06-3cf12bb86f9f.png)

## PR Quality Checklist

- [x] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
