### PR TITLE
Add e2e spec for creating a cluster from another cluster

### DIFF
--- a/e2e/specs/wizard.fromcluster.spec.ts
+++ b/e2e/specs/wizard.fromcluster.spec.ts
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { test } from '@playwright/test';
+import { visitAndLogin } from '../test-utils/login';
+import { fillClusterSection, fillHeadNodeSection, fillQueuesSection, fillStorageSection, performDryRun } from '../test-utils/wizard';
+
+const CLUSTER_TO_COPY_FROM = 'DO-NOT-DELETE'
+
+test.describe('Given an endpoint where AWS ParallelCluster UI is deployed', () => {
+  test('a user should be able to login, navigate till the end of the cluster creation wizard, and perform a dry-run successfully', async ({ page }) => {
+    await visitAndLogin(page)
+  
+    await page.getByRole('button', { name: 'Create cluster' }).first().click();
+    await page.getByRole('menuitem', { name: 'From another cluster' }).click();
+    
+    await page.getByRole('button', { name: 'Select a cluster' }).click();
+    await page.getByRole('option', { name: CLUSTER_TO_COPY_FROM }).click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Create' }).click();
+
+    await fillClusterSection(page, false)
+    
+    await fillHeadNodeSection(page)
+  
+    await fillQueuesSection(page)
+
+    await fillStorageSection(page)
+  
+    await performDryRun(page)
+  });
+})

--- a/e2e/specs/wizard.fromcluster.spec.ts
+++ b/e2e/specs/wizard.fromcluster.spec.ts
@@ -14,25 +14,28 @@ import { fillClusterSection, fillHeadNodeSection, fillQueuesSection, fillStorage
 
 const CLUSTER_TO_COPY_FROM = 'DO-NOT-DELETE'
 
-test.describe('Given an endpoint where AWS ParallelCluster UI is deployed', () => {
-  test('a user should be able to login, navigate till the end of the cluster creation wizard, and perform a dry-run successfully', async ({ page }) => {
-    await visitAndLogin(page)
-  
-    await page.getByRole('button', { name: 'Create cluster' }).first().click();
-    await page.getByRole('menuitem', { name: 'From another cluster' }).click();
-    
-    await page.getByRole('button', { name: 'Select a cluster' }).click();
-    await page.getByRole('option', { name: CLUSTER_TO_COPY_FROM }).click();
-    await page.getByRole('dialog').getByRole('button', { name: 'Create' }).click();
+test.describe('environment: @demo', () => {
+  test.describe('given an already existing cluster', () => {
+    test.describe('when the cluster is picked as source to start the creation wizard', () => {
+      test('user can perform a dry-run successfully', async ({ page }) => {
+        await visitAndLogin(page)
 
-    await fillClusterSection(page, false)
-    
-    await fillHeadNodeSection(page)
-  
-    await fillQueuesSection(page)
+        await page.getByRole('button', { name: 'Create cluster' }).first().click();
+        await page.getByRole('menuitem', { name: 'From another cluster' }).click();
 
-    await fillStorageSection(page)
-  
-    await performDryRun(page)
-  });
-})
+        await page.getByRole('button', { name: 'Select a cluster' }).click();
+        await page.getByRole('option', { name: CLUSTER_TO_COPY_FROM }).click();
+        await page.getByRole('dialog').getByRole('button', { name: 'Create' }).click();
+
+        await fillClusterSection(page, false)
+
+        await fillHeadNodeSection(page)
+
+        await fillQueuesSection(page)
+
+        await fillStorageSection(page)
+
+        await performDryRun(page)
+      });
+    })
+  })

--- a/e2e/specs/wizard.fromcluster.spec.ts
+++ b/e2e/specs/wizard.fromcluster.spec.ts
@@ -10,7 +10,7 @@
 
 import { test } from '@playwright/test';
 import { visitAndLogin } from '../test-utils/login';
-import { fillClusterSection, fillHeadNodeSection, fillQueuesSection, fillStorageSection, performDryRun } from '../test-utils/wizard';
+import { fillWizard } from '../test-utils/wizard';
 
 const CLUSTER_TO_COPY_FROM = 'DO-NOT-DELETE'
 
@@ -27,15 +27,8 @@ test.describe('environment: @demo', () => {
         await page.getByRole('option', { name: CLUSTER_TO_COPY_FROM }).click();
         await page.getByRole('dialog').getByRole('button', { name: 'Create' }).click();
 
-        await fillClusterSection(page, false)
-
-        await fillHeadNodeSection(page)
-
-        await fillQueuesSection(page)
-
-        await fillStorageSection(page)
-
-        await performDryRun(page)
+        await fillWizard(page)
       });
     })
   })
+})

--- a/e2e/specs/wizard.spec.ts
+++ b/e2e/specs/wizard.spec.ts
@@ -10,7 +10,7 @@
 
 import { test } from '@playwright/test';
 import { visitAndLogin } from '../test-utils/login';
-import { fillClusterSection, fillHeadNodeSection, fillQueuesSection, fillStorageSection, performDryRun } from '../test-utils/wizard';
+import { fillWizard } from '../test-utils/wizard';
 
 test.describe('Given an endpoint where AWS ParallelCluster UI is deployed', () => {
   test('a user should be able to login, navigate till the end of the cluster creation wizard, and perform a dry-run successfully', async ({ page }) => {
@@ -19,14 +19,6 @@ test.describe('Given an endpoint where AWS ParallelCluster UI is deployed', () =
     await page.getByRole('button', { name: 'Create cluster' }).first().click();
     await page.getByRole('menuitem', { name: 'Use interface' }).click();
     
-    await fillClusterSection(page)
-    
-    await fillHeadNodeSection(page)
-  
-    await fillQueuesSection(page)
-
-    await fillStorageSection(page)
-  
-    await performDryRun(page)
+    await fillWizard(page, {vpc: /vpc-.*/})
   });
 })

--- a/e2e/specs/wizard.spec.ts
+++ b/e2e/specs/wizard.spec.ts
@@ -8,10 +8,9 @@
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 import { visitAndLogin } from '../test-utils/login';
-
-const CLUSTER_NAME = 'c' + Math.random().toString(20).substring(8)
+import { fillClusterSection, fillHeadNodeSection, fillQueuesSection, fillStorageSection, performDryRun } from '../test-utils/wizard';
 
 test.describe('Given an endpoint where AWS ParallelCluster UI is deployed', () => {
   test('a user should be able to login, navigate till the end of the cluster creation wizard, and perform a dry-run successfully', async ({ page }) => {
@@ -20,24 +19,14 @@ test.describe('Given an endpoint where AWS ParallelCluster UI is deployed', () =
     await page.getByRole('button', { name: 'Create cluster' }).first().click();
     await page.getByRole('menuitem', { name: 'Use interface' }).click();
     
-    await expect(page.getByRole('heading', { name: 'Cluster', exact: true })).toBeVisible()
-    await page.getByPlaceholder('Enter your cluster name').fill(CLUSTER_NAME);
-    await page.getByRole('button', { name: 'Select a VPC' }).click();
-    await page.getByText(/vpc-.*/).first().click();
-    await page.getByRole('button', { name: 'Next' }).click();
+    await fillClusterSection(page)
     
-    await expect(page.getByRole('heading', { name: 'Head node', exact: true })).toBeVisible()
-    await page.getByRole('button', { name: 'Next' }).click();
+    await fillHeadNodeSection(page)
   
-    await expect(page.getByRole('heading', { name: 'Queues' }).first()).toBeVisible()
-    await page.getByRole('button', { name: 'Next' }).click();
+    await fillQueuesSection(page)
 
-    await expect(page.getByRole('heading', { name: 'Storage' })).toBeVisible()
-    await page.getByRole('button', { name: 'Next' }).click();
+    await fillStorageSection(page)
   
-    await expect(page.getByRole('heading', { name: 'Create' })).toBeVisible()
-    await page.getByRole('button', { name: 'Dry run' }).click();
-  
-    await expect(page.getByText('Request would have succeeded, but DryRun flag is set.')).toBeVisible()
+    await performDryRun(page)
   });
 })

--- a/e2e/specs/wizard.template.spec.ts
+++ b/e2e/specs/wizard.template.spec.ts
@@ -10,7 +10,7 @@
 
 import { FileChooser, test } from '@playwright/test';
 import { visitAndLogin } from '../test-utils/login';
-import { fillClusterSection, fillHeadNodeSection, fillQueuesSection, fillStorageSection, performDryRun } from '../test-utils/wizard';
+import { fillWizard } from '../test-utils/wizard';
 
 const TEMPLATE_PATH = './fixtures/wizard.template.yaml'
 
@@ -27,15 +27,7 @@ test.describe('environment: @demo', () => {
         })
         await page.getByRole('menuitem', { name: 'Upload a template' }).click();
         
-        await fillClusterSection(page, false)
-    
-        await fillHeadNodeSection(page)
-      
-        await fillQueuesSection(page)
-
-        await fillStorageSection(page)
-      
-        await performDryRun(page)
+        await fillWizard(page)
       });
     });
   });

--- a/e2e/specs/wizard.template.spec.ts
+++ b/e2e/specs/wizard.template.spec.ts
@@ -8,11 +8,11 @@
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { expect, FileChooser, test } from '@playwright/test';
+import { FileChooser, test } from '@playwright/test';
 import { visitAndLogin } from '../test-utils/login';
+import { fillClusterSection, fillHeadNodeSection, fillQueuesSection, fillStorageSection, performDryRun } from '../test-utils/wizard';
 
 const TEMPLATE_PATH = './fixtures/wizard.template.yaml'
-const CLUSTER_NAME = 'c' + Math.random().toString(20).substring(8)
 
 test.describe('environment: @demo', () => {
   test.describe('given a cluster configuration template created with single instance type', () => {
@@ -27,24 +27,15 @@ test.describe('environment: @demo', () => {
         })
         await page.getByRole('menuitem', { name: 'Upload a template' }).click();
         
-        await expect(page.getByRole('heading', { name: 'Cluster', exact: true })).toBeVisible()
-        await page.getByPlaceholder('Enter your cluster name').fill(CLUSTER_NAME);
-        await page.getByText(/vpc-.*/).waitFor({state: 'visible'})
-        await page.getByRole('button', { name: 'Next' }).click();
+        await fillClusterSection(page, false)
+    
+        await fillHeadNodeSection(page)
+      
+        await fillQueuesSection(page)
 
-        await expect(page.getByRole('heading', { name: 'Head node', exact: true })).toBeVisible()
-        await page.getByRole('button', { name: 'Next' }).click();
-
-        await expect(page.getByRole('heading', { name: 'Queues' }).first()).toBeVisible()
-        await page.getByRole('button', { name: 'Next' }).click();
-
-        await expect(page.getByRole('heading', { name: 'Storage' })).toBeVisible()
-        await page.getByRole('button', { name: 'Next' }).click();
-
-        await expect(page.getByRole('heading', { name: 'Create' })).toBeVisible()
-        await page.getByRole('button', { name: 'Dry run' }).click();
-
-        await expect(page.getByText('Request would have succeeded, but DryRun flag is set.')).toBeVisible()
+        await fillStorageSection(page)
+      
+        await performDryRun(page)
       });
     });
   });

--- a/e2e/test-utils/login.ts
+++ b/e2e/test-utils/login.ts
@@ -1,7 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Page } from "@playwright/test";
 import { ENVIRONMENT_CONFIG } from "../configs/environment";
 import { LOGIN_CONFIG } from "../configs/login";
 
-export async function visitAndLogin(page) {
+export async function visitAndLogin(page: Page) {
   await page.goto(ENVIRONMENT_CONFIG.URL);
   await page.getByRole('textbox', { name: 'name@host.com' }).fill(LOGIN_CONFIG.username);
   await page.getByRole('textbox', { name: 'Password' }).fill(LOGIN_CONFIG.password);

--- a/e2e/test-utils/wizard.ts
+++ b/e2e/test-utils/wizard.ts
@@ -11,16 +11,36 @@
 
 import { expect, Page } from "@playwright/test";
 
-const CLUSTER_NAME = 'c' + Math.random().toString(20).substring(8)
+const DEFAULT_CONFIG: Config = {
+  clusterName: 'c' + Math.random().toString(20).substring(8)
+}
 
-export async function fillClusterSection(page: Page, selectVPC = true) {
+interface Config {
+  clusterName: string;
+  vpc?: RegExp | string
+}
+
+export async function fillWizard(page: Page, config: Partial<Config> = {}) {
+  const configWithDefaults = {
+    ...DEFAULT_CONFIG,
+    ...config,
+  }
+
+  await fillClusterSection(page, configWithDefaults)
+  await fillHeadNodeSection(page, configWithDefaults)
+  await fillQueuesSection(page, configWithDefaults)
+  await fillStorageSection(page, configWithDefaults)
+  await performDryRun(page, configWithDefaults)
+}
+
+export async function fillClusterSection(page: Page, config: Config) {
   await expect(page.getByRole('heading', { name: 'Cluster', exact: true })).toBeVisible()
   
-  await page.getByPlaceholder('Enter your cluster name').fill(CLUSTER_NAME);
+  await page.getByPlaceholder('Enter your cluster name').fill(config.clusterName);
 
-  if (selectVPC) {
+  if (config.vpc) {
     await page.getByRole('button', { name: 'Select a VPC' }).click();
-    await page.getByText(/vpc-.*/).first().click();
+    await page.getByText(config.vpc).first().click();
   } else {
     await page.getByText(/vpc-.*/).waitFor({state: 'visible'})
   }
@@ -28,26 +48,26 @@ export async function fillClusterSection(page: Page, selectVPC = true) {
   await page.getByRole('button', { name: 'Next' }).click();
 }
 
-export async function fillHeadNodeSection(page: Page) {
+export async function fillHeadNodeSection(page: Page, config: Config) {
   await expect(page.getByRole('heading', { name: 'Head node', exact: true })).toBeVisible()
   
   await page.getByRole('button', { name: 'Next' }).click();
 }
 
-export async function fillQueuesSection(page: Page) {
-  await expect(page.getByRole('heading', { name: 'Queues' }).first()).toBeVisible()
+export async function fillQueuesSection(page: Page, config: Config) {
+  await expect(page.getByRole('heading', { name: 'Queues', exact: true }).first()).toBeVisible()
   
   await page.getByRole('button', { name: 'Next' }).click();
 }
 
-export async function fillStorageSection(page: Page) {
-  await expect(page.getByRole('heading', { name: 'Storage' })).toBeVisible()
+export async function fillStorageSection(page: Page, config: Config) {
+  await expect(page.getByRole('heading', { name: 'Storage', exact: true })).toBeVisible()
   
   await page.getByRole('button', { name: 'Next' }).click();
 }
 
-export async function performDryRun(page: Page) {
-  await expect(page.getByRole('heading', { name: 'Create' })).toBeVisible()
+export async function performDryRun(page: Page, config: Config) {
+  await expect(page.getByRole('heading', { name: 'Create', exact: true })).toBeVisible()
     
   await page.getByRole('button', { name: 'Dry run' }).click();
   

--- a/e2e/test-utils/wizard.ts
+++ b/e2e/test-utils/wizard.ts
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, Page } from "@playwright/test";
+
+const CLUSTER_NAME = 'c' + Math.random().toString(20).substring(8)
+
+export async function fillClusterSection(page: Page, selectVPC = true) {
+  await expect(page.getByRole('heading', { name: 'Cluster', exact: true })).toBeVisible()
+  
+  await page.getByPlaceholder('Enter your cluster name').fill(CLUSTER_NAME);
+
+  if (selectVPC) {
+    await page.getByRole('button', { name: 'Select a VPC' }).click();
+    await page.getByText(/vpc-.*/).first().click();
+  } else {
+    await page.getByText(/vpc-.*/).waitFor({state: 'visible'})
+  }
+  
+  await page.getByRole('button', { name: 'Next' }).click();
+}
+
+export async function fillHeadNodeSection(page: Page) {
+  await expect(page.getByRole('heading', { name: 'Head node' })).toBeVisible()
+  
+  await page.getByRole('button', { name: 'Next' }).click();
+}
+
+export async function fillQueuesSection(page: Page) {
+  await expect(page.getByRole('heading', { name: 'Queues' }).first()).toBeVisible()
+  
+  await page.getByRole('button', { name: 'Next' }).click();
+}
+
+export async function fillStorageSection(page: Page) {
+  await expect(page.getByRole('heading', { name: 'Storage' })).toBeVisible()
+  
+  await page.getByRole('button', { name: 'Next' }).click();
+}
+
+export async function performDryRun(page: Page) {
+  await expect(page.getByRole('heading', { name: 'Create' })).toBeVisible()
+    
+  await page.getByRole('button', { name: 'Dry run' }).click();
+  
+  await expect(page.getByText('Request would have succeeded, but DryRun flag is set.')).toBeVisible()
+}

--- a/e2e/test-utils/wizard.ts
+++ b/e2e/test-utils/wizard.ts
@@ -29,7 +29,7 @@ export async function fillClusterSection(page: Page, selectVPC = true) {
 }
 
 export async function fillHeadNodeSection(page: Page) {
-  await expect(page.getByRole('heading', { name: 'Head node' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Head node', exact: true })).toBeVisible()
   
   await page.getByRole('button', { name: 'Next' }).click();
 }


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR adds an e2e spec to test the cluster creation wizard when starting from an existing cluster.

## Changes

- add e2e test utils to fill in the wizard sections
- add spec for the "From cluster" scenario

## How Has This Been Tested?

- running the e2e locally

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
