### PR TITLE
Fix a crash happening when showing a job with undefined properties

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -184,7 +184,8 @@
         "filteringAriaLabel": "Find jobs",
         "filteringPlaceholder": "Find jobs"
       },
-      "loadingJobs": "Loading jobs..."
+      "loadingJobs": "Loading jobs...",
+      "propertyNotAvailable": "N/A"
     },
     "logs": {
       "label": "Select a log stream from the left."

--- a/frontend/src/old-pages/Clusters/Scheduling.tsx
+++ b/frontend/src/old-pages/Clusters/Scheduling.tsx
@@ -133,6 +133,9 @@ function FileLink({path, isFile}: {path: string; isFile?: boolean}) {
   const defaultRegion = useState(['aws', 'region'])
   const region = useState(['app', 'selectedRegion']) || defaultRegion
   const headNode = useState([...clusterPath, 'headNode'])
+  const {t} = useTranslation()
+
+  if (!path) return <span>{t('cluster.scheduling.propertyNotAvailable')}</span>
 
   const linkPath = isFile ? path.slice(0, path.lastIndexOf('/')) : path
 


### PR DESCRIPTION
## Description

Fixes #109.

## Changes

Show as "Not available" the undefined job properties. I chose this approach to have a consistent layout for job properties, and highlight when a property does not exist.

## How Has This Been Tested?

Submitted a simple job to the head node and verified missing properties are shown as N/A

![Screenshot 2023-03-10 at 15 22 31](https://user-images.githubusercontent.com/3091286/224341305-067c6f56-505f-4b21-9a0a-dc0ed2fa814a.png)

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
