### PR TITLE
Head node storage layout changes

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -522,6 +522,10 @@
        "help": "Select one or more security groups.",
        "select": "Select one or more security groups"
       },
+      "localStorage": {
+        "title": "Local storage",
+        "optional": "- optional"
+      },
       "advancedOptions": {
         "label": "Advanced options",
         "scripts": {
@@ -921,7 +925,6 @@
       "rootVolume": {
         "size": {
           "label": "Root volume size (GB)",
-          "description": "The compute node local storage.",
           "placeholder": "Enter root volume size."
         },
         "encrypted": "Encrypt root volume",

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -561,37 +561,21 @@ function RootVolume({basePath, errorsPath}: any) {
   }, [rootVolumeType, rootVolumeTypePath])
 
   return (
-    <SpaceBetween direction="vertical" size="xs">
+    <SpaceBetween direction="vertical" size="s">
       <FormField
         label={t('wizard.components.rootVolume.size.label')}
         errorText={rootVolumeErrors}
-        description={t('wizard.components.rootVolume.size.description')}
       >
         <Input
           disabled={editing}
           placeholder={t('wizard.components.rootVolume.size.placeholder')}
           value={rootVolumeSize || ''}
           inputMode="decimal"
+          type="number"
           onChange={({detail}) => setRootVolume(detail.value)}
         />
       </FormField>
-      <Checkbox
-        disabled={editing}
-        checked={rootVolumeEncrypted || false}
-        onChange={toggleEncrypted}
-      >
-        {t('wizard.components.rootVolume.encrypted')}
-      </Checkbox>
-      <div
-        key="volume-type"
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          alignItems: 'center',
-          gap: '16px',
-        }}
-      >
-        <Trans i18nKey="wizard.components.rootVolume.type.label" />:
+      <FormField label={t('wizard.components.rootVolume.type.label')}>
         <Select
           disabled={editing}
           placeholder={t('wizard.components.rootVolume.type.placeholder', {
@@ -603,7 +587,14 @@ function RootVolume({basePath, errorsPath}: any) {
           }}
           options={volumeTypes.map(strToOption)}
         />
-      </div>
+      </FormField>
+      <Checkbox
+        disabled={editing}
+        checked={rootVolumeEncrypted || false}
+        onChange={toggleEncrypted}
+      >
+        {t('wizard.components.rootVolume.encrypted')}
+      </Checkbox>
     </SpaceBetween>
   )
 }

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -433,7 +433,6 @@ function HeadNode() {
               />
             </FormField>
           </Box>
-          <RootVolume basePath={headNodePath} errorsPath={errorsPath} />
           <SsmSettings />
           <DcvSettings />
           <IMDSSecuredSettings />
@@ -510,6 +509,13 @@ function HeadNode() {
           </ExpandableSection>
         </ColumnLayout>
       </Container>
+      <ExpandableSection
+        variant="container"
+        headerCounter={t('wizard.headNode.localStorage.optional')}
+        headerText={t('wizard.headNode.localStorage.title')}
+      >
+        <RootVolume basePath={headNodePath} errorsPath={errorsPath} />
+      </ExpandableSection>
     </ColumnLayout>
   )
 }


### PR DESCRIPTION
## Description

Adapt head node storage to the new layout.

## How Has This Been Tested?
<img width="988" alt="Screenshot 2023-03-13 at 11 51 28" src="https://user-images.githubusercontent.com/3091286/224680971-27b59d5b-432d-4b67-ae31-69ee10587136.png">

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
