### PR TITLE
Show instance type metadata in dropdown selection in Head node wizard Page

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -906,6 +906,11 @@
       }
     },
     "components": {
+      "instanceSelect": {
+        "placeholder": "Choose an instance type",
+        "ariaLabel": "Instance selector",
+        "noMatches": "No matches"
+      },
       "customAmi": {
         "ariaLabel": "Custom Amazon Machine Image (AMI)",
         "label": "Custom Amazon Machine Image (AMI)",

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -909,7 +909,11 @@
       "instanceSelect": {
         "placeholder": "Choose an instance type",
         "ariaLabel": "Instance selector",
-        "noMatches": "No matches"
+        "noMatches": "No matches",
+        "instanceType": {
+          "vCpus": "{{vCpus}} vCpus",
+          "memory": "{{memory}} GiB memory"
+        }
       },
       "customAmi": {
         "ariaLabel": "Custom Amazon Machine Image (AMI)",

--- a/frontend/src/old-pages/Configure/Components.types.ts
+++ b/frontend/src/old-pages/Configure/Components.types.ts
@@ -1,0 +1,24 @@
+export type Extension = {
+  name: string
+  path: string
+  description: string
+  args: {name: string; default?: string}[]
+}
+
+export type ActionsEditorProps = {
+  basePath: string[]
+  errorsPath: string[]
+}
+
+export type InstanceType = {
+  type: string
+  tags: string[]
+}
+
+export type InstanceGroup = InstanceType[]
+
+export type InstanceTypeOption = {
+  label: string
+  value: string
+  tags: string[]
+}

--- a/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
@@ -18,6 +18,7 @@ import {
   MultiInstanceComputeResource,
   QueueValidationErrors,
 } from './queues.types'
+import {InstanceType} from '../Components.types'
 
 const queuesPath = ['app', 'wizard', 'config', 'Scheduling', 'SlurmQueues']
 const queuesErrorsPath = ['app', 'wizard', 'errors', 'queues']
@@ -94,10 +95,10 @@ export function ComputeResource({
       Object.keys(instanceGroups).map(groupName => {
         return {
           label: groupName,
-          options: instanceGroups[groupName].map(([value, label]) => ({
-            label: value,
-            description: label,
-            value: value,
+          options: instanceGroups[groupName].map((instance: InstanceType) => ({
+            label: instance.type,
+            tags: instance.tags,
+            value: instance.type,
           })),
         }
       }),


### PR DESCRIPTION
## Description

Currently instance type selection in Head node wizard page is implemented leveraging [Autosuggest](https://cloudscape.design/components/autosuggest/?tabId=playground) Cloudscape component.

This PR replaces the `Autosuggest` component with a `Select` component, in order to show instance metadata such as memory, virtual cores and Gpu info upon selection.

## How Has This Been Tested?

* Manually tests on local environment

## References

* https://cloudscape.design/components/select/?tabId=playground

## Screenshots

<img width="1728" alt="Screenshot 2023-03-13 at 12 08 21" src="https://user-images.githubusercontent.com/25930133/224685546-8ef586e6-ae11-43c0-8c03-392186283d74.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
