### PR TITLE
Don't act on IMDS secured default settings when in update mode

### DIFF
--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -372,11 +372,15 @@ function DcvSettings() {
 
 function IMDSSecuredSettings() {
   const {t} = useTranslation()
-  const imdsSecured = useState(imdsSecuredPath) ?? true
+  let imdsSecured = useState(imdsSecuredPath)
+  const editing = useState(['app', 'wizard', 'editing'])
 
   React.useEffect(() => {
-    setState(imdsSecuredPath, imdsSecured)
-  }, [])
+    if (null == imdsSecured && !editing) {
+      imdsSecured = true
+      setState(imdsSecuredPath, imdsSecured)
+    }
+  }, [imdsSecured])
 
   const toggleImdsSecured = React.useCallback(() => {
     setState(imdsSecuredPath, !imdsSecured)
@@ -384,6 +388,7 @@ function IMDSSecuredSettings() {
 
   return (
     <CheckboxWithHelpPanel
+      disabled={editing}
       checked={imdsSecured}
       onChange={toggleImdsSecured}
       helpPanel={

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -377,8 +377,7 @@ function IMDSSecuredSettings() {
 
   React.useEffect(() => {
     if (null == imdsSecured && !editing) {
-      imdsSecured = true
-      setState(imdsSecuredPath, imdsSecured)
+      setState(imdsSecuredPath, true)
     }
   }, [imdsSecured])
 

--- a/frontend/src/old-pages/Configure/__tests__/IMDSSecuredSettings.test.tsx
+++ b/frontend/src/old-pages/Configure/__tests__/IMDSSecuredSettings.test.tsx
@@ -42,28 +42,12 @@ describe('given a component to configure IMDS secured setting', () => {
       )
     })
 
-    describe('when no action is performed on the checkbox', () => {
-      it('should be set to true', () => {
-        expect(mockSetState).toHaveBeenCalledTimes(1)
-        expect(mockSetState).toHaveBeenCalledWith(
-          ['app', 'wizard', 'config', 'HeadNode', 'Imds', 'Secured'],
-          true,
-        )
-      })
-    })
-
-    describe('when the checkbox is clicked only once', () => {
-      it('should be set to false', () => {
-        fireEvent.click(
-          screen.getByLabelText('wizard.headNode.imdsSecured.set'),
-        )
-
-        expect(mockSetState).toHaveBeenCalledTimes(2)
-        expect(mockSetState).toHaveBeenCalledWith(
-          ['app', 'wizard', 'config', 'HeadNode', 'Imds', 'Secured'],
-          false,
-        )
-      })
+    it('should be set to true', () => {
+      expect(mockSetState).toHaveBeenCalledTimes(1)
+      expect(mockSetState).toHaveBeenCalledWith(
+        ['app', 'wizard', 'config', 'HeadNode', 'Imds', 'Secured'],
+        true,
+      )
     })
   })
 
@@ -88,7 +72,7 @@ describe('given a component to configure IMDS secured setting', () => {
     })
 
     describe('when no action is performed on the checkbox', () => {
-      it('should be set to false', () => {
+      it('should not change the value', () => {
         expect(mockSetState).not.toHaveBeenCalled()
       })
     })

--- a/frontend/src/old-pages/Configure/__tests__/IMDSSecuredSettings.test.tsx
+++ b/frontend/src/old-pages/Configure/__tests__/IMDSSecuredSettings.test.tsx
@@ -89,11 +89,7 @@ describe('given a component to configure IMDS secured setting', () => {
 
     describe('when no action is performed on the checkbox', () => {
       it('should be set to false', () => {
-        expect(mockSetState).toHaveBeenCalledTimes(1)
-        expect(mockSetState).toHaveBeenCalledWith(
-          ['app', 'wizard', 'config', 'HeadNode', 'Imds', 'Secured'],
-          false,
-        )
+        expect(mockSetState).not.toHaveBeenCalled()
       })
     })
 
@@ -103,12 +99,41 @@ describe('given a component to configure IMDS secured setting', () => {
           screen.getByLabelText('wizard.headNode.imdsSecured.set'),
         )
 
-        expect(mockSetState).toHaveBeenCalledTimes(2)
+        expect(mockSetState).toHaveBeenCalledTimes(1)
         expect(mockSetState).toHaveBeenCalledWith(
           ['app', 'wizard', 'config', 'HeadNode', 'Imds', 'Secured'],
           true,
         )
       })
+    })
+  })
+
+  describe('when editing a cluster', () => {
+    beforeEach(() => {
+      ;(mockSetState as jest.Mock).mockClear()
+      mockStore.getState.mockReturnValue({
+        app: {
+          wizard: {
+            editing: true,
+          },
+        },
+      })
+
+      screen = render(
+        <MockProviders>
+          <IMDSSecuredSettings />
+        </MockProviders>,
+      )
+    })
+
+    it('should not change the checkbox state', () => {
+      expect(mockSetState).not.toHaveBeenCalled()
+    })
+
+    it('should be disabled', () => {
+      fireEvent.click(screen.getByLabelText('wizard.headNode.imdsSecured.set'))
+
+      expect(mockSetState).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description
When in editing mode, the IMDS secured must not be changed since it will break cluster update.
This PR solves that bug introduced by #101 
<!-- Summary of what this PR introduces and possibly why -->

<!-- List of relevant changes introduced -->

## How Has This Been Tested?
- manual
- unit tests
<!-- The tests you ran to verify your changes -->

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
