### PR TITLE
Use Flashbar in place of ValidationErrors component

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -885,6 +885,9 @@
         "forceUpdate": "Force update: Edit the cluster while the compute fleet is still running.",
         "disableRollback": "Disable rollback: Retain the cluster resources in case of a cluster create failure."
       },
+      "flashBar": {
+        "success": "Success"
+      },
       "helpPanel": {
         "title": "Cluster configuration",
         "description": "<p>Review, edit and test cluster configuration.</p><p>Choose <strong>Dry run</strong> to validate your configuration without creating your cluster.</p><p>Choose <strong>Create</strong> to validate your configuration and create your cluster in one step.</p>",

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -881,6 +881,7 @@
       "description": "Review or edit your cluster configuration and create your cluster.",
       "configuration": {
         "title": "Cluster configuration",
+        "description": "Check/edit the yaml file that is used to create the cluster",
         "pending": "{{action}} request pending...",
         "forceUpdate": "Force update: Edit the cluster while the compute fleet is still running.",
         "disableRollback": "Disable rollback: Retain the cluster resources in case of a cluster create failure."

--- a/frontend/src/old-pages/Configure/Create.types.ts
+++ b/frontend/src/old-pages/Configure/Create.types.ts
@@ -1,0 +1,20 @@
+type ErrorLevel = 'INFO' | 'WARNING' | 'ERROR'
+
+export type ConfigError = {
+  id: string
+  type: string
+  level: ErrorLevel
+  message: string
+}
+
+export type UpdateError = {
+  message: string
+  level: ErrorLevel
+}
+
+export type CreateErrors = {
+  message: string
+  validationMessages?: ConfigError[]
+  configurationValidationErrors?: ConfigError[]
+  updateValidationErrors?: UpdateError[]
+}

--- a/frontend/src/old-pages/Configure/__tests__/errorsToFlashbarItems.test.ts
+++ b/frontend/src/old-pages/Configure/__tests__/errorsToFlashbarItems.test.ts
@@ -1,0 +1,221 @@
+import {FlashbarProps} from '@cloudscape-design/components'
+import {ClickDetail} from '@cloudscape-design/components/internal/events'
+import {describe} from '@jest/globals'
+import {errorsToFlashbarItems} from '../Create'
+import {ConfigError, CreateErrors, UpdateError} from '../Create.types'
+import i18n from '../../../i18n'
+import {initReactI18next} from 'react-i18next'
+
+i18n.use(initReactI18next).init({
+  resources: {},
+  lng: 'en',
+})
+
+describe('Given a function to map create/dry-run errors to FlashbarItems', () => {
+  let setFlashbarItems = jest.fn()
+  beforeEach(() => {
+    setFlashbarItems.mockReset()
+  })
+
+  describe('when errors contain "succeeded" in the error message', () => {
+    const errors: CreateErrors = {
+      message: 'Request would have succeeded, but DryRun flag is set.',
+    }
+
+    it('should return an item of type "success" with the error message as content', () => {
+      const expected: FlashbarProps.MessageDefinition[] = [
+        {
+          type: 'success',
+          dismissible: true,
+          header: 'wizard.create.flashBar.success',
+          content: errors.message,
+          id: 'success',
+        },
+      ]
+      expect(errorsToFlashbarItems(errors, setFlashbarItems)).toMatchObject(
+        expected,
+      )
+    })
+  })
+
+  describe('when errors contain "succeed" in the error message, and validation errors too', () => {
+    const validationMessages: ConfigError[] = [
+      {
+        id: 'Id1',
+        level: 'WARNING',
+        type: 'Validation',
+        message: 'WarningMessage',
+      },
+    ]
+    const errors: CreateErrors = {
+      message: 'Request would have succeeded, but DryRun flag is set.',
+      validationMessages: validationMessages,
+    }
+
+    it('should return both success and error items, with expected type and content', () => {
+      const expected: FlashbarProps.MessageDefinition[] = [
+        {
+          type: 'success',
+          dismissible: true,
+          header: 'wizard.create.flashBar.success',
+          content: errors.message,
+          id: 'success',
+        },
+        {
+          type: 'warning',
+          dismissible: true,
+          header: 'Warning',
+          content: `${validationMessages[0].type}: ${validationMessages[0].message}`,
+          id: 'config-err-0',
+        },
+      ]
+      expect(errorsToFlashbarItems(errors, setFlashbarItems)).toMatchObject(
+        expected,
+      )
+    })
+  })
+
+  describe('when errors contain configuration errors', () => {
+    const configErrors: ConfigError[] = [
+      {
+        id: 'Id1',
+        level: 'ERROR',
+        type: 'Type',
+        message: 'ErrorMessage',
+      },
+      {
+        id: 'Id2',
+        level: 'WARNING',
+        type: 'Type',
+        message: 'WarningMessage',
+      },
+    ]
+    const errors: CreateErrors = {
+      message: 'Invalid cluster configuration',
+      configurationValidationErrors: configErrors,
+    }
+
+    it('should return one item per error with the expected type, header and content', () => {
+      const expected: FlashbarProps.MessageDefinition[] = [
+        {
+          type: 'error',
+          dismissible: true,
+          header: 'Error',
+          content: `${configErrors[0].type}: ${configErrors[0].message}`,
+          id: 'config-err-0',
+        },
+        {
+          type: 'warning',
+          dismissible: true,
+          header: 'Warning',
+          content: `${configErrors[1].type}: ${configErrors[1].message}`,
+          id: 'config-err-1',
+        },
+      ]
+      expect(errorsToFlashbarItems(errors, setFlashbarItems)).toMatchObject(
+        expected,
+      )
+    })
+
+    describe('when one configuration error is dismissed', () => {
+      it('should remove the error from the list of visible items', () => {
+        const items = errorsToFlashbarItems(errors, setFlashbarItems)
+        const onDismiss = items[0].onDismiss!
+        onDismiss(new CustomEvent<ClickDetail>('click'))
+
+        const filterPredicate = setFlashbarItems.mock.calls[0][0]
+        expect(filterPredicate(items)).toEqual([
+          expect.objectContaining({
+            type: 'warning',
+            dismissible: true,
+            header: 'Warning',
+            content: `${configErrors[1].type}: ${configErrors[1].message}`,
+            id: 'config-err-1',
+          }),
+        ])
+      })
+    })
+  })
+
+  describe('when errors contain validation messages', () => {
+    const configErrors: ConfigError[] = [
+      {
+        id: 'Id1',
+        level: 'ERROR',
+        type: 'Type',
+        message: 'ErrorMessage',
+      },
+      {
+        id: 'Id2',
+        level: 'WARNING',
+        type: 'Type',
+        message: 'WarningMessage',
+      },
+    ]
+    const errors: CreateErrors = {
+      message: 'Invalid cluster configuration',
+      validationMessages: configErrors,
+    }
+
+    it('should return one item per error with the expected type, header and content', () => {
+      const expected: FlashbarProps.MessageDefinition[] = [
+        {
+          type: 'error',
+          dismissible: true,
+          header: 'Error',
+          content: `${configErrors[0].type}: ${configErrors[0].message}`,
+          id: 'config-err-0',
+        },
+        {
+          type: 'warning',
+          dismissible: true,
+          header: 'Warning',
+          content: `${configErrors[1].type}: ${configErrors[1].message}`,
+          id: 'config-err-1',
+        },
+      ]
+      expect(errorsToFlashbarItems(errors, setFlashbarItems)).toMatchObject(
+        expected,
+      )
+    })
+  })
+
+  describe('when errors contain update errors', () => {
+    const updateErrors: UpdateError[] = [
+      {
+        level: 'ERROR',
+        message: 'ErrorMessage',
+      },
+      {
+        level: 'WARNING',
+        message: 'WarningMessage',
+      },
+    ]
+    const errors: CreateErrors = {
+      message: 'Invalid cluster configuration',
+      updateValidationErrors: updateErrors,
+    }
+
+    it('should return one item per error with the expected type, header and content', () => {
+      const expected: FlashbarProps.MessageDefinition[] = [
+        {
+          type: 'error',
+          dismissible: true,
+          header: 'Error',
+          content: updateErrors[0].message,
+          id: 'update-err-0',
+        },
+        {
+          type: 'warning',
+          dismissible: true,
+          header: 'Warning',
+          content: updateErrors[1].message,
+          id: 'update-err-1',
+        },
+      ]
+      expect(errorsToFlashbarItems(errors, setFlashbarItems)).toMatchObject(
+        expected,
+      )
+    })
+  })
+})


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

Currently, upon a dry-run/creation of a cluster, we are showing errors through a custom `ValidationErrors` component, which displays errors in a styled `div`.

In order to be compliant with Cloudscape, we need to display errors leveraging `Flashbar` component, at the top YAML code editor.

This PR introduces Cloudscape `Flashbar` component in place of `ValidationErrors`.

## How Has This Been Tested?

* E2E tests
* Unit tests
* Manual tests
   * Verified that `Flashbar` is displayed with success message (with and without validation warnings)
   * Verified that `Flashbar` is displayed with error messages upon cluster creation
   * Verified that `Flashbar` is displayed with error messages upon cluster editing


## References

* https://cloudscape.design/components/flashbar


## Screenshots

<img width="1728" alt="Screenshot 2023-03-14 at 17 41 27" src="https://user-images.githubusercontent.com/25930133/225076599-ec904e5d-c377-4945-97b6-1b60471117af.png">




## PR Quality Checklist

- [x] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
