### PR TITLE
Deselect custom image when hitting the refresh button

### DIFF
--- a/frontend/src/old-pages/Images/CustomImages/CustomImages.tsx
+++ b/frontend/src/old-pages/Images/CustomImages/CustomImages.tsx
@@ -64,6 +64,7 @@ function CustomImagesList() {
   }
 
   const refreshImages = () => {
+    setSelected([])
     clearState(['customImages', 'list'])
     clearState(['app', 'customImages', 'selected'])
     ListCustomImages(imageStatus || 'AVAILABLE')


### PR DESCRIPTION
## Description

Delesect the selected custom image when htting the refresh button, mimicking the EC2 console behavior.

## How Has This Been Tested?

- Selected a custom image
- Hit refresh button
- The split panel is emptied and the list has no images selected

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
