### PR TITLE
Remove head node check from SSM-based actions

### DIFF
--- a/frontend/src/old-pages/Clusters/Actions.tsx
+++ b/frontend/src/old-pages/Clusters/Actions.tsx
@@ -95,10 +95,6 @@ export default function Actions() {
     clusterStatus === ClusterStatus.DeleteInProgress ||
     !dcvEnabled
 
-  const configure = React.useCallback(() => {
-    wizardShow(navigate)
-  }, [navigate])
-
   const startFleet = React.useCallback(() => {
     UpdateComputeFleet(clusterName, 'START_REQUESTED')
   }, [clusterName])

--- a/frontend/src/old-pages/Clusters/Actions.tsx
+++ b/frontend/src/old-pages/Clusters/Actions.tsx
@@ -89,9 +89,7 @@ export default function Actions() {
   const isDeleteDisabled =
     !clusterName || clusterStatus === ClusterStatus.DeleteInProgress
   const isSsmDisabled =
-    !isHeadNode ||
-    clusterStatus === ClusterStatus.DeleteInProgress ||
-    !ssmEnabled
+    clusterStatus === ClusterStatus.DeleteInProgress || !ssmEnabled
   const isDcvDisabled =
     !isHeadNode ||
     clusterStatus === ClusterStatus.DeleteInProgress ||


### PR DESCRIPTION
## Description

Disable SSM-based actions only when the SSM policy is not applied.
The check on the head node public IP address is kept only for the DCV button.

## How Has This Been Tested?
- created two clusters, one with and one without the SSM policy
- I cannot click on the Shell and Filesystem button when SSM is disabled
- I can click on the Shell and Filesystem button when SSM is enabled

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
