### PR TITLE
Add validation in select region field in cluster wizard page

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -344,6 +344,7 @@
       },
       "validation": {
         "VpcSelect": "You must select a VPC.",
+        "regionSelect": "You must select a region.",
         "customAmiSelect": "You must select an AMI ID if you add a custom AMI."
       },
       "clusterName": {
@@ -357,7 +358,8 @@
       "region": {
         "label": "Region",
         "description": "The AWS Region for the cluster.",
-        "selectedAriaLabel": "Selected"
+        "selectedAriaLabel": "Selected",
+        "placeholder": "Select a region"
       },
       "os": {
         "label": "Operating system",

--- a/frontend/src/old-pages/Configure/Cluster.tsx
+++ b/frontend/src/old-pages/Configure/Cluster.tsx
@@ -68,6 +68,7 @@ const selectAwsSubnets = (state: any) => getState(state, ['aws', 'subnets'])
 
 function clusterValidate() {
   const vpc = getState(['app', 'wizard', 'vpc'])
+  const region = getState(['app', 'wizard', 'config', 'Region'])
   const editing = getState(['app', 'wizard', 'editing'])
   const customAmiEnabled = getState(['app', 'wizard', 'customAMI', 'enabled'])
   const customAmi = getState(['app', 'wizard', 'config', 'Image', 'CustomAmi'])
@@ -84,6 +85,16 @@ function clusterValidate() {
     valid = false
   } else {
     clearState([...errorsPath, 'vpc'])
+  }
+
+  if (!region) {
+    setState(
+      [...errorsPath, 'region'],
+      i18next.t('wizard.cluster.validation.regionSelect'),
+    )
+    valid = false
+  } else {
+    clearState([...errorsPath, 'region'])
   }
 
   if (customAmiEnabled && !customAmi) {
@@ -142,11 +153,13 @@ function RegionSelect() {
   const isMultipleInstanceTypesActive = useFeatureFlag(
     'queues_multiple_instance_types',
   )
+  const error = useState([...errorsPath, 'region'])
 
   const handleChange = useCallback(
     ({detail}: NonCancelableCustomEvent<SelectProps.ChangeDetail>) => {
-      const chosenRegion = detail.selectedOption.value
+      clearState([...errorsPath, 'region'])
 
+      const chosenRegion = detail.selectedOption.value
       if (!chosenRegion) return
 
       /**
@@ -198,6 +211,7 @@ function RegionSelect() {
       <FormField
         label={t('wizard.cluster.region.label')}
         description={t('wizard.cluster.region.description')}
+        errorText={error}
       >
         <Select
           disabled={editing}
@@ -210,6 +224,7 @@ function RegionSelect() {
           onChange={handleChange}
           // @ts-expect-error TS(2322) FIXME: Type '({ label: Element; value: string; } | undefi... Remove this comment to see the full error message
           options={supportedRegions.map(itemToOption)}
+          placeholder={t('wizard.cluster.region.placeholder')}
           selectedAriaLabel={t('wizard.cluster.region.selectedAriaLabel')}
         />
       </FormField>


### PR DESCRIPTION
## Description
Even though the Region field is not strictly required (see [docs](https://docs.aws.amazon.com/parallelcluster/latest/ug/cluster-configuration-file-v3.html#cluster-configuration-file-v3.properties)), the wizard requires users to explicitly select the region to create the cluster in.

In order to match the user's expectations, the field should be validated as required.

## Changes

* Added field validation for region selection in Cluster wizard page

## How Has This Been Tested?

* Manually tested on local environment
   * Verified that if region is not selected you can't move forward in wizard
   * Verified that error message disappears upon region selection 

## Screenshots

<img width="1720" alt="Screenshot 2023-03-17 at 11 20 24" src="https://user-images.githubusercontent.com/25930133/225880324-79223a31-1677-47f1-a3ab-4206794b62dc.png">


<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
