### PR TITLE
Add Messages table to the Cluster Logs page

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -367,6 +367,30 @@
       "actions": {
         "refresh": "Refresh"
       }
+    },
+    "logEvents": {
+      "title": "Messages",
+      "columns": {
+        "message": "Message",
+        "timestamp": "Event time"
+      },
+      "loadingText": "Loading messages...",
+      "filtering": {
+        "countText": "Results: {{filteredItemsCount}}",
+        "filteringPlaceholder": "Find messages",
+        "empty": {
+          "title": "No messages",
+          "subtitle": "No messages to display."
+        },
+        "noMatch": {
+          "title": "No matches",
+          "subtitle": "No message matches the filters.",
+          "resetFilter": "Clear filter"
+        }
+      },
+      "actions": {
+        "refresh": "Refresh"
+      }
     }
   },
   "wizard": {

--- a/frontend/src/__tests__/ListClusterLogEvents.test.ts
+++ b/frontend/src/__tests__/ListClusterLogEvents.test.ts
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ListClusterLogEvents} from '../model'
+import {LogEvent, LogEventsResponse} from '../types/logs'
+
+const mockGet = jest.fn()
+
+jest.mock('axios', () => ({
+  create: () => ({
+    get: (...args: unknown[]) => mockGet(...args),
+  }),
+}))
+
+describe('given a ListClusterLogEvents command and a cluster name', () => {
+  const clusterName = 'any-name'
+  const logStreamName = 'any-name'
+
+  describe('when the log events can be retrieved successfully', () => {
+    beforeEach(() => {
+      const mockResponse: LogEventsResponse = {
+        events: [
+          {
+            message: 'some-message',
+            timestamp: 'some-timestamp',
+          },
+        ],
+      }
+
+      mockGet.mockResolvedValueOnce({data: mockResponse})
+    })
+
+    it('should return the log events list', async () => {
+      const data = await ListClusterLogEvents(clusterName, logStreamName)
+
+      expect(data).toEqual<LogEvent[]>([
+        {
+          message: 'some-message',
+          timestamp: 'some-timestamp',
+        },
+      ])
+    })
+  })
+
+  describe('when the call fails', () => {
+    let mockError: any
+
+    beforeEach(() => {
+      mockError = {
+        response: {
+          data: {
+            message: 'some-error-messasge',
+          },
+        },
+      }
+
+      mockGet.mockRejectedValueOnce(mockError)
+    })
+
+    it('should re-throw the error', async () => {
+      try {
+        await ListClusterLogEvents(clusterName, logStreamName)
+      } catch (e) {
+        expect(e).toEqual({
+          response: {
+            data: {
+              message: 'some-error-messasge',
+            },
+          },
+        })
+      }
+    })
+  })
+})

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -16,7 +16,13 @@ import {generateRandomId} from './util'
 import {AppConfig} from './app-config/types'
 import {getAppConfig} from './app-config'
 import {axiosInstance, executeRequest, HTTPMethod} from './http/executeRequest'
-import {LogStream, LogStreamsResponse, LogStreamView} from './types/logs'
+import {
+  LogEvent,
+  LogEventsResponse,
+  LogStream,
+  LogStreamsResponse,
+  LogStreamView,
+} from './types/logs'
 import {AxiosError} from 'axios'
 
 // Types
@@ -314,6 +320,22 @@ function DeprecatedListClusterLogStreams(clusterName: any) {
         )
       console.log(error)
     })
+}
+
+async function ListClusterLogEvents(
+  clusterName: string,
+  logStreamName: string,
+): Promise<LogEvent[]> {
+  var url = `api?path=/v3/clusters/${clusterName}/logstreams/${logStreamName}`
+  try {
+    const {data}: {data: LogEventsResponse} = await request('get', url)
+    return data?.events || []
+  } catch (error) {
+    if ((error as AxiosError).response) {
+      notify(`Error: ${(error as any).response.data.message}`, 'error')
+    }
+    throw error
+  }
 }
 
 function DeprecatedGetClusterLogEvents(
@@ -934,6 +956,7 @@ export {
   DeprecatedListClusterLogStreams,
   ListClusterLogStreams,
   DeprecatedGetClusterLogEvents,
+  ListClusterLogEvents,
   ListCustomImages,
   DescribeCustomImage,
   GetCustomImageConfiguration,

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -316,7 +316,7 @@ function DeprecatedListClusterLogStreams(clusterName: any) {
     })
 }
 
-function GetClusterLogEvents(
+function DeprecatedGetClusterLogEvents(
   clusterName: any,
   logStreamName: any,
   successCallback?: Callback,
@@ -933,7 +933,7 @@ export {
   GetClusterStackEvents,
   DeprecatedListClusterLogStreams,
   ListClusterLogStreams,
-  GetClusterLogEvents,
+  DeprecatedGetClusterLogEvents,
   ListCustomImages,
   DescribeCustomImage,
   GetCustomImageConfiguration,

--- a/frontend/src/old-pages/Clusters/Logs.tsx
+++ b/frontend/src/old-pages/Clusters/Logs.tsx
@@ -13,7 +13,10 @@ import React from 'react'
 import {useSearchParams} from 'react-router-dom'
 
 // Model
-import {GetClusterLogEvents, DeprecatedListClusterLogStreams} from '../../model'
+import {
+  DeprecatedGetClusterLogEvents,
+  DeprecatedListClusterLogStreams,
+} from '../../model'
 import {clearState, getState, setState, useState} from '../../store'
 import {useCollection} from '@cloudscape-design/collection-hooks'
 
@@ -61,7 +64,7 @@ function LogEventsTable() {
     const clusterName = getState(['app', 'clusters', 'selected'])
     const logStreamName = getState(['app', 'clusters', 'selectedLogStreamName'])
     if (clusterName && logStreamName) {
-      GetClusterLogEvents(
+      DeprecatedGetClusterLogEvents(
         clusterName,
         logStreamName,
         () => clearState(['app', 'clusters', 'logs', 'pending']),
@@ -238,7 +241,7 @@ function StreamList({instanceId}: {instanceId: string}) {
         'filename',
       )}`
       setState(['app', 'clusters', 'selectedLogStreamName'], logStreamName)
-      GetClusterLogEvents(selected, logStreamName)
+      DeprecatedGetClusterLogEvents(selected, logStreamName)
     }
   }, [searchParams, instanceId, ip, selectedLogStreamName])
 

--- a/frontend/src/old-pages/Logs/LogMessagesTable.tsx
+++ b/frontend/src/old-pages/Logs/LogMessagesTable.tsx
@@ -1,0 +1,137 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useCollection} from '@cloudscape-design/collection-hooks'
+import {
+  Button,
+  Header,
+  Pagination,
+  Table,
+  TableProps,
+  TextFilter,
+} from '@cloudscape-design/components'
+import {useCallback, useMemo} from 'react'
+import {useTranslation} from 'react-i18next'
+import {useQuery} from 'react-query'
+import DateView from '../../components/date/DateView'
+import EmptyState from '../../components/EmptyState'
+import {ListClusterLogEvents} from '../../model'
+import {extendCollectionsOptions} from '../../shared/extendCollectionsOptions'
+import {LogEvent} from '../../types/logs'
+
+interface Props {
+  clusterName: string
+  logStreamName?: string
+}
+
+export function LogMessagesTable({clusterName, logStreamName}: Props) {
+  const {t} = useTranslation()
+  const canFetchMessages = !!logStreamName
+  const {
+    data = [],
+    isLoading,
+    isFetching,
+    refetch,
+  } = useQuery(
+    ['CLUSTER_LOG_EVENTS', clusterName, logStreamName],
+    () => ListClusterLogEvents(clusterName, logStreamName!),
+    {enabled: canFetchMessages},
+  )
+
+  const columnDefinitions: TableProps.ColumnDefinition<LogEvent>[] = useMemo(
+    () => [
+      {
+        id: 'timestamp',
+        header: t('clusterLogs.logEvents.columns.timestamp'),
+        cell: item => <DateView date={item.timestamp} />,
+        sortingField: 'timestamp',
+      },
+      {
+        id: 'message',
+        header: t('clusterLogs.logEvents.columns.message'),
+        cell: item => item.message,
+        sortingField: 'message',
+      },
+    ],
+    [t],
+  )
+
+  const {
+    items,
+    filteredItemsCount,
+    collectionProps,
+    filterProps,
+    paginationProps,
+  } = useCollection(
+    data,
+    extendCollectionsOptions({
+      filtering: {
+        empty: (
+          <EmptyState
+            title={t('clusterLogs.logEvents.filtering.empty.title')}
+            subtitle={t('clusterLogs.logEvents.filtering.empty.subtitle')}
+          />
+        ),
+        noMatch: (
+          <EmptyState
+            title={t('clusterLogs.logEvents.filtering.noMatch.title')}
+            subtitle={t('clusterLogs.logEvents.filtering.noMatch.subtitle')}
+          />
+        ),
+      },
+      sorting: {},
+      selection: {},
+    }),
+  )
+
+  const onRefreshClick = useCallback(() => {
+    refetch()
+  }, [refetch])
+
+  return (
+    <Table
+      {...collectionProps}
+      loading={isLoading}
+      loadingText={t('clusterLogs.logEvents.loadingText')}
+      columnDefinitions={columnDefinitions}
+      items={items}
+      trackBy="message"
+      header={
+        <Header
+          counter={`(${items.length})`}
+          actions={
+            <Button
+              disabled={!canFetchMessages}
+              onClick={onRefreshClick}
+              loading={isFetching}
+            >
+              {t('clusterLogs.logEvents.actions.refresh')}
+            </Button>
+          }
+        >
+          {t('clusterLogs.logEvents.title')}
+        </Header>
+      }
+      pagination={<Pagination {...paginationProps} />}
+      filter={
+        <TextFilter
+          {...filterProps}
+          countText={t('clusterLogs.logEvents.filtering.countText', {
+            filteredItemsCount,
+          })}
+          filteringPlaceholder={t(
+            'clusterLogs.logEvents.filtering.filteringPlaceholder',
+          )}
+        />
+      }
+    />
+  )
+}

--- a/frontend/src/old-pages/Logs/LogStreamsTable.tsx
+++ b/frontend/src/old-pages/Logs/LogStreamsTable.tsx
@@ -11,6 +11,7 @@
 
 import {useCollection} from '@cloudscape-design/collection-hooks'
 import {
+  Button,
   Header,
   Pagination,
   PropertyFilter,
@@ -187,6 +188,10 @@ export function LogStreamsTable({clusterName, onLogStreamSelect}: Props) {
     [onLogStreamSelect],
   )
 
+  const onRefreshClick = useCallback(() => {
+    logStreamsQuery.refetch()
+  }, [logStreamsQuery])
+
   return (
     <Table
       {...collectionProps}
@@ -199,7 +204,17 @@ export function LogStreamsTable({clusterName, onLogStreamSelect}: Props) {
       selectedItems={selectedItems}
       onSelectionChange={onSelectionChange}
       header={
-        <Header counter={`(${items.length})`}>
+        <Header
+          counter={`(${items.length})`}
+          actions={
+            <Button
+              onClick={onRefreshClick}
+              loading={logStreamsQuery.isFetching}
+            >
+              {t('clusterLogs.logEvents.actions.refresh')}
+            </Button>
+          }
+        >
           {t('clusterLogs.logStreams.title')}
         </Header>
       }

--- a/frontend/src/old-pages/Logs/LogStreamsTable.tsx
+++ b/frontend/src/old-pages/Logs/LogStreamsTable.tsx
@@ -211,7 +211,7 @@ export function LogStreamsTable({clusterName, onLogStreamSelect}: Props) {
               onClick={onRefreshClick}
               loading={logStreamsQuery.isFetching}
             >
-              {t('clusterLogs.logEvents.actions.refresh')}
+              {t('clusterLogs.logStreams.actions.refresh')}
             </Button>
           }
         >

--- a/frontend/src/old-pages/Logs/LogStreamsTable.tsx
+++ b/frontend/src/old-pages/Logs/LogStreamsTable.tsx
@@ -48,12 +48,12 @@ export function LogStreamsTable({clusterName, onLogStreamSelect}: Props) {
 
   const [describeClusterQuery, logStreamsQuery] = useQueries([
     {
-      queryKey: 'DECRIBE_CLUSTER',
+      queryKey: ['DESCRIBE_CLUSTER', clusterName],
       queryFn: () => DescribeCluster(clusterName),
       enabled: !headNode,
     },
     {
-      queryKey: 'CLUSTER_LOGS',
+      queryKey: ['CLUSTER_LOGS', clusterName],
       queryFn: () => ListClusterLogStreams(clusterName),
     },
   ])
@@ -153,12 +153,6 @@ export function LogStreamsTable({clusterName, onLogStreamSelect}: Props) {
             title={t('clusterLogs.logStreams.filtering.empty.title')}
             subtitle={t('clusterLogs.logStreams.filtering.empty.subtitle')}
           />
-          /**
-           * This value is arbitrary and it has been chosen
-           * with goal of allowing the table below to be
-           * seen without too much scrolling.
-           *
-           */
         ),
         noMatch: (
           <EmptyState
@@ -168,6 +162,12 @@ export function LogStreamsTable({clusterName, onLogStreamSelect}: Props) {
         ),
       },
       pagination: {
+        /**
+         * This value is arbitrary and it has been chosen
+         * with goal of allowing the table below to be
+         * seen without too much scrolling.
+         *
+         */
         pageSize: 5,
       },
       sorting: {},
@@ -194,7 +194,7 @@ export function LogStreamsTable({clusterName, onLogStreamSelect}: Props) {
       loadingText={t('clusterLogs.logStreams.loadingText')}
       columnDefinitions={columnDefinitions}
       items={items}
-      trackBy="lastEventTimestamp"
+      trackBy="logStreamName"
       selectionType="single"
       selectedItems={selectedItems}
       onSelectionChange={onSelectionChange}

--- a/frontend/src/old-pages/Logs/__tests__/LogMessagesTable.test.tsx
+++ b/frontend/src/old-pages/Logs/__tests__/LogMessagesTable.test.tsx
@@ -1,0 +1,128 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {render, RenderResult} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {I18nextProvider, initReactI18next} from 'react-i18next'
+import {QueryClient, QueryClientProvider} from 'react-query'
+import {BrowserRouter} from 'react-router-dom'
+import i18n from '../../../i18n'
+import {LogEvent} from '../../../types/logs'
+import {LogMessagesTable} from '../LogMessagesTable'
+
+const queryClient = new QueryClient()
+const mockLogEvents: LogEvent[] = [
+  {
+    message: 'some-message',
+    timestamp: '2023-03-10T08:45:17.133Z',
+  },
+]
+
+i18n.use(initReactI18next).init({
+  resources: {},
+  lng: 'en',
+})
+
+const MockProviders = (props: any) => (
+  <QueryClientProvider client={queryClient}>
+    <I18nextProvider i18n={i18n}>
+      <BrowserRouter>{props.children}</BrowserRouter>
+    </I18nextProvider>
+  </QueryClientProvider>
+)
+
+const mockListClusterLogEvents = jest.fn()
+
+jest.mock('../../../model', () => ({
+  ListClusterLogEvents: () => mockListClusterLogEvents(),
+}))
+
+describe('given a component to show the log events list, a cluster name and a log stream name', () => {
+  let screen: RenderResult
+
+  const clusterName = 'someClusterName'
+  const logStreamName = 'someLogStreamName'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('when the log stream name is not available', () => {
+    beforeEach(() => {
+      screen = render(
+        <MockProviders>
+          <LogMessagesTable
+            clusterName={clusterName}
+            logStreamName={undefined}
+          />
+        </MockProviders>,
+      )
+    })
+
+    it('should not fetch the log events list', () => {
+      expect(mockListClusterLogEvents).toHaveBeenCalledTimes(0)
+    })
+
+    it('should disable the refresh button', async () => {
+      await userEvent.click(
+        screen.getByRole('button', {
+          name: 'clusterLogs.logEvents.actions.refresh',
+        }),
+      )
+      expect(mockListClusterLogEvents).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('when the log stream name is available', () => {
+    describe('when the log events list is not available', () => {
+      beforeEach(() => {
+        screen = render(
+          <MockProviders>
+            <LogMessagesTable
+              clusterName={clusterName}
+              logStreamName={logStreamName}
+            />
+          </MockProviders>,
+        )
+      })
+
+      it('should request the cluster log events', () => {
+        expect(mockListClusterLogEvents).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('when the log events list is available', () => {
+      beforeEach(() => {
+        mockListClusterLogEvents.mockResolvedValue(mockLogEvents)
+
+        screen = render(
+          <MockProviders>
+            <LogMessagesTable
+              clusterName={clusterName}
+              logStreamName={logStreamName}
+            />
+          </MockProviders>,
+        )
+      })
+
+      describe('when the user refreshes the list', () => {
+        it('should refetch the log events', async () => {
+          await userEvent.click(
+            screen.getByRole('button', {
+              name: 'clusterLogs.logEvents.actions.refresh',
+            }),
+          )
+          expect(mockListClusterLogEvents).toHaveBeenCalledTimes(2)
+        })
+      })
+    })
+  })
+})

--- a/frontend/src/old-pages/Logs/__tests__/LogStreamsTable.test.tsx
+++ b/frontend/src/old-pages/Logs/__tests__/LogStreamsTable.test.tsx
@@ -64,11 +64,6 @@ jest.mock('../../../model', () => ({
   DescribeCluster: () => mockDescribeCluster(),
 }))
 
-jest.mock('../../../store', () => ({
-  ...(jest.requireActual('../../../store') as any),
-  setState: jest.fn(),
-}))
-
 describe('given a component to show the log streams list and a cluster name', () => {
   let mockOnLogStreamSelect: jest.Mock
   let screen: RenderResult
@@ -159,7 +154,7 @@ describe('given a component to show the log streams list and a cluster name', ()
       it('should refetch the log streams', async () => {
         await userEvent.click(
           screen.getByRole('button', {
-            name: 'clusterLogs.logEvents.actions.refresh',
+            name: 'clusterLogs.logStreams.actions.refresh',
           }),
         )
         expect(mockListClusterLogStreams).toHaveBeenCalledTimes(2)

--- a/frontend/src/old-pages/Logs/__tests__/LogStreamsTable.test.tsx
+++ b/frontend/src/old-pages/Logs/__tests__/LogStreamsTable.test.tsx
@@ -10,10 +10,10 @@
 // limitations under the License.
 
 import {Store} from '@reduxjs/toolkit'
-import {render, RenderResult, waitFor} from '@testing-library/react'
+import {render, RenderResult} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import {mock, MockProxy} from 'jest-mock-extended'
-import {I18nextProvider} from 'react-i18next'
+import {mock} from 'jest-mock-extended'
+import {I18nextProvider, initReactI18next} from 'react-i18next'
 import {QueryClient, QueryClientProvider} from 'react-query'
 import {Provider} from 'react-redux'
 import {BrowserRouter} from 'react-router-dom'
@@ -37,6 +37,11 @@ const mockClusterInfo = mock<ClusterDescription>({
   headNode: {
     instanceId: 'instanceId',
   },
+})
+
+i18n.use(initReactI18next).init({
+  resources: {},
+  lng: 'en',
 })
 
 const mockStore = mock<Store>()
@@ -147,6 +152,17 @@ describe('given a component to show the log streams list and a cluster name', ()
         expect(mockOnLogStreamSelect).toHaveBeenCalledWith(
           'hostname.instanceId.logIdentifier',
         )
+      })
+    })
+
+    describe('when the user refreshes the list', () => {
+      it('should refetch the log streams', async () => {
+        await userEvent.click(
+          screen.getByRole('button', {
+            name: 'clusterLogs.logEvents.actions.refresh',
+          }),
+        )
+        expect(mockListClusterLogStreams).toHaveBeenCalledTimes(2)
       })
     })
   })

--- a/frontend/src/old-pages/Logs/index.tsx
+++ b/frontend/src/old-pages/Logs/index.tsx
@@ -16,6 +16,7 @@ import {
   Header,
   SpaceBetween,
 } from '@cloudscape-design/components'
+import React, {useCallback} from 'react'
 import {useMemo} from 'react'
 import {Trans, useTranslation} from 'react-i18next'
 import {useParams} from 'react-router-dom'
@@ -23,6 +24,7 @@ import {useHelpPanel} from '../../components/help-panel/HelpPanel'
 import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
 import InfoLink from '../../components/InfoLink'
 import Layout from '../Layout'
+import {LogMessagesTable} from './LogMessagesTable'
 import {LogStreamsTable} from './LogStreamsTable'
 
 function LogsHelpPanel() {
@@ -39,6 +41,9 @@ function LogsHelpPanel() {
 export function Logs() {
   const {t} = useTranslation()
   const {clusterName} = useParams()
+  const [selectedLogStream, setSelectedLogStream] = React.useState<
+    string | undefined
+  >()
 
   useHelpPanel(<LogsHelpPanel />)
 
@@ -50,6 +55,10 @@ export function Logs() {
     ],
     [clusterName, t],
   )
+
+  const onLogStreamSelect = useCallback((selectedLogStream: string) => {
+    setSelectedLogStream(selectedLogStream)
+  }, [])
 
   return (
     <Layout breadcrumbs={<BreadcrumbGroup items={breadcrumbItems} />}>
@@ -63,10 +72,14 @@ export function Logs() {
           </Header>
         }
       >
-        <SpaceBetween size="m">
+        <SpaceBetween size="xl">
           <LogStreamsTable
             clusterName={clusterName!}
-            onLogStreamSelect={() => null}
+            onLogStreamSelect={onLogStreamSelect}
+          />
+          <LogMessagesTable
+            clusterName={clusterName!}
+            logStreamName={selectedLogStream}
           />
         </SpaceBetween>
       </ContentLayout>

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -27,7 +27,13 @@ import {enableHttpLogs} from '../http/httpLogs'
 import {axiosInstance} from '../http/executeRequest'
 import {HelpPanelProvider} from '../components/help-panel/HelpPanel'
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+})
 declare global {
   interface Window {
     ace: any

--- a/frontend/src/types/logs.tsx
+++ b/frontend/src/types/logs.tsx
@@ -15,6 +15,10 @@ export interface LogStreamsResponse {
   logStreams: LogStream[]
 }
 
+export interface LogEventsResponse {
+  events: LogEvent[]
+}
+
 export type LogStreamName = string
 
 export type LogEvent = {


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR introduces the Messages table to the Cluster Logs page. 

It builds upon #123 

Following PRs will:
- activate the Logs page
- remove the Logs tab from the Cluster page

## Changes 

- add Log Messages Table to the Logs page
- add Refresh action to both the Log Messages and the Log Streams tables
- disable default behaviour of `react-query` which would re-fetch on window focus
   - this also affects the Images page

## Screenshot

![Screenshot 2023-03-20 at 10 33 58](https://user-images.githubusercontent.com/11457067/226300488-62d76f12-6438-45af-86a1-55fc35044146.png)

## How Has This Been Tested?

- manually
   - by simulating a navigation to the cluster logs page
   - by refreshing the cluster logs page directly
   - by selecting logstream and fetching the messages
- unit tests

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
