### PR TITLE
Remove refresh icon from refresh buttons

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -178,9 +178,14 @@
       }
     },
     "stackEvents": {
+      "title": "Events",
       "filter": {
         "filteringPlaceholder": "Find stack events",
         "filteringAriaLabel": "Find stack events"
+      },
+      "actions": {
+        "refresh": "Refresh",
+        "view": "View in CloudFormation"
       }
     },
     "accounting": {

--- a/frontend/src/old-pages/Clusters/StackEvents.tsx
+++ b/frontend/src/old-pages/Clusters/StackEvents.tsx
@@ -203,14 +203,16 @@ export default function ClusterStackEvents() {
           counter={filteredItemsCount && `(${filteredItemsCount})`}
           actions={
             <SpaceBetween direction="horizontal" size="s">
-              <Button onClick={refreshStackEvents} iconName="refresh" />
+              <Button onClick={refreshStackEvents}>
+                {t('cluster.stackEvents.actions.refresh')}
+              </Button>
               <Button iconName="external" href={cfnHref} target="_blank">
-                View in CloudFormation
+                {t('cluster.stackEvents.actions.view')}
               </Button>
             </SpaceBetween>
           }
         >
-          Events
+          {t('cluster.stackEvents.title')}
         </Header>
       }
       resizableColumns

--- a/frontend/src/old-pages/Configure/Configure.tsx
+++ b/frontend/src/old-pages/Configure/Configure.tsx
@@ -177,11 +177,7 @@ function Configure() {
     return (
       <SpaceBetween direction="horizontal" size="xs">
         {currentPage !== 'create' && (
-          <Button
-            loading={refreshing}
-            onClick={handleRefresh}
-            iconName={'refresh'}
-          >
+          <Button loading={refreshing} onClick={handleRefresh}>
             {t('wizard.actions.refreshConfig')}
           </Button>
         )}


### PR DESCRIPTION
## Description
* Remove refresh icon from refresh buttons
* Add missing i18n strings

## How Has This Been Tested?

* Manually inspected affected pages on local environment

## Screenshots

<img width="1728" alt="Screenshot 2023-03-20 at 12 03 12" src="https://user-images.githubusercontent.com/25930133/226321323-cdc8f370-da13-43de-94d7-9b03d3b8fcc0.png">

<img width="1725" alt="Screenshot 2023-03-20 at 12 03 23" src="https://user-images.githubusercontent.com/25930133/226321348-cbbab12f-c50c-420f-894d-48d28b35ec5f.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
