### PR TITLE
Move slurm settings under expandable section and add placeholder fields

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -653,7 +653,7 @@
         "container": {
           "title": "Slurm settings",
           "description": "Connect with an external Slurm database to monitor and analyze cluster usage.",
-          "optional": "optional"
+          "optional": "- optional"
         },
         "database": {
           "label": "Database",
@@ -662,10 +662,12 @@
         },
         "username": {
           "label": "Username",
+          "placeholder": "Username",
           "description": "Enter the user ID for access to the database."
         },
         "password": {
           "label": "Password secret ARN",
+          "placeholder": "arn::aws::...",
           "description": "The ARN of the AWS secret containing the database password."
         },
         "scaledownIdleTime": {

--- a/frontend/src/old-pages/Configure/SlurmSettings/SlurmAccountingForm.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/SlurmAccountingForm.tsx
@@ -10,9 +10,40 @@
 // limitations under the License.
 
 import {ColumnLayout, FormField, Input} from '@cloudscape-design/components'
-import {useTranslation} from 'react-i18next'
+import React from 'react'
+import {Trans, useTranslation} from 'react-i18next'
+import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
+import InfoLink from '../../../components/InfoLink'
 import {useFeatureFlag} from '../../../feature-flags/useFeatureFlag'
 import {setState, useState} from '../../../store'
+
+const SlurmAccountingsHelpPanel = ({title}: {title: string}) => {
+  const {t} = useTranslation()
+  const footerLinks = React.useMemo(
+    () => [
+      {
+        title: t('wizard.headNode.help.accountingLink.title'),
+        href: t('wizard.headNode.help.accountingLink.href'),
+      },
+      {
+        title: t('wizard.headNode.help.databaseLink.title'),
+        href: t('wizard.headNode.help.databaseLink.href'),
+      },
+      {
+        title: t('wizard.headNode.help.queueLink.title'),
+        href: t('wizard.headNode.help.queueLink.href'),
+      },
+    ],
+    [t],
+  )
+  return (
+    <TitleDescriptionHelpPanel
+      title={title}
+      description={<Trans i18nKey="wizard.headNode.help.slurmSettings" />}
+      footerLinks={footerLinks}
+    />
+  )
+}
 
 interface DatabaseFieldProps {
   uriPath: string[]
@@ -28,6 +59,15 @@ function DatabaseField({uriPath, uriErrorPath}: DatabaseFieldProps) {
     <FormField
       label={t('wizard.headNode.slurmSettings.database.label')}
       description={t('wizard.headNode.slurmSettings.database.description')}
+      info={
+        <InfoLink
+          helpPanel={
+            <SlurmAccountingsHelpPanel
+              title={t('wizard.headNode.slurmSettings.database.label')}
+            />
+          }
+        />
+      }
       errorText={uriError}
     >
       <Input
@@ -55,12 +95,22 @@ function UsernameField({usernamePath, usernameErrorPath}: UsernameFieldProps) {
     <FormField
       label={t('wizard.headNode.slurmSettings.username.label')}
       description={t('wizard.headNode.slurmSettings.username.description')}
+      info={
+        <InfoLink
+          helpPanel={
+            <SlurmAccountingsHelpPanel
+              title={t('wizard.headNode.slurmSettings.username.label')}
+            />
+          }
+        />
+      }
       errorText={usernameError}
     >
       <Input
         onChange={({detail}) => {
           setState(usernamePath, detail.value)
         }}
+        placeholder={t('wizard.headNode.slurmSettings.username.placeholder')}
         value={username}
         type="text"
       />
@@ -82,12 +132,22 @@ function PasswordField({passwordPath, passwordErrorPath}: PasswordFieldProps) {
     <FormField
       label={t('wizard.headNode.slurmSettings.password.label')}
       description={t('wizard.headNode.slurmSettings.password.description')}
+      info={
+        <InfoLink
+          helpPanel={
+            <SlurmAccountingsHelpPanel
+              title={t('wizard.headNode.slurmSettings.password.label')}
+            />
+          }
+        />
+      }
       errorText={passwordError}
     >
       <Input
         onChange={({detail}) => {
           setState(passwordPath, detail.value)
         }}
+        placeholder={t('wizard.headNode.slurmSettings.password.placeholder')}
         value={password}
         type="text"
       />

--- a/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
+++ b/frontend/src/old-pages/Configure/SlurmSettings/SlurmSettings.tsx
@@ -12,7 +12,7 @@
 import * as React from 'react'
 import i18next from 'i18next'
 import {Trans, useTranslation} from 'react-i18next'
-import {Container, Header} from '@cloudscape-design/components'
+import {ExpandableSection, Header} from '@cloudscape-design/components'
 import {setState, getState, clearState} from '../../../store'
 import {SlurmAccountingForm} from './SlurmAccountingForm'
 import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
@@ -85,21 +85,13 @@ function SlurmSettings() {
   if (!isSlurmAccountingEnabled) return null
 
   return (
-    <Container
-      header={
-        <Header
-          variant="h2"
-          description={t('wizard.headNode.slurmSettings.container.description')}
-          info={<InfoLink helpPanel={<SlurmSettingsHelpPanel />} />}
-        >
-          {t('wizard.headNode.slurmSettings.container.title')}{' '}
-          <span
-            style={{fontWeight: '400', fontStyle: 'italic', fontSize: '14px'}}
-          >
-            ({t('wizard.headNode.slurmSettings.container.optional')})
-          </span>
-        </Header>
-      }
+    <ExpandableSection
+      variant="container"
+      headerText={t('wizard.headNode.slurmSettings.container.title')}
+      headerCounter={t('wizard.headNode.slurmSettings.container.optional')}
+      headerDescription={t(
+        'wizard.headNode.slurmSettings.container.description',
+      )}
     >
       <SlurmAccountingForm
         uriPath={uriPath}
@@ -109,35 +101,7 @@ function SlurmSettings() {
         passwordPath={passwordPath}
         passwordErrorPath={passwordErrorPath}
       />
-    </Container>
-  )
-}
-
-const SlurmSettingsHelpPanel = () => {
-  const {t} = useTranslation()
-  const footerLinks = React.useMemo(
-    () => [
-      {
-        title: t('wizard.headNode.help.accountingLink.title'),
-        href: t('wizard.headNode.help.accountingLink.href'),
-      },
-      {
-        title: t('wizard.headNode.help.databaseLink.title'),
-        href: t('wizard.headNode.help.databaseLink.href'),
-      },
-      {
-        title: t('wizard.headNode.help.queueLink.title'),
-        href: t('wizard.headNode.help.queueLink.href'),
-      },
-    ],
-    [t],
-  )
-  return (
-    <TitleDescriptionHelpPanel
-      title={t('wizard.headNode.slurmSettings.container.title')}
-      description={<Trans i18nKey="wizard.headNode.help.slurmSettings" />}
-      footerLinks={footerLinks}
-    />
+    </ExpandableSection>
   )
 }
 


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

* Moved Slurm settings under expandable section
* Added missing placeholders for Slurm settings fields
* Moved help panel info link into individual fields

## How Has This Been Tested?
* Manually inspected affected section in local environment

## References
* https://cloudscape.design/components/expandable-section/?tabId=playground&example=container

## Screenshots
<img width="1728" alt="Screenshot 2023-03-21 at 11 46 22" src="https://user-images.githubusercontent.com/25930133/226584498-4eee53be-ee53-4fb3-8606-977b2637ae42.png">



## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
