### PR TITLE
Apply UI minor fixes to HeadNode wizard page

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -581,8 +581,7 @@
         "header": "Networking",
         "subnetId": {
           "label": "Subnet ID",
-          "description": "Subnet ID for head node.",
-          "alert": "If you don't have a default VPC or subnet, Amazon ParallelCluster UI will use defaults for your cluster."
+          "description": "Subnet ID for head node."
         }
       },
       "security": {
@@ -612,7 +611,7 @@
           }
         },
         "iamPolicies": {
-          "label": "IAM Policies - optional"
+          "label": "IAM Policies"
         }
       },
       "slurmSettings": {
@@ -1036,7 +1035,10 @@
           "label": "Run script on node configured"
         },
         "addArgument": "Add argument",
-        "argument": "Argument"
+        "argument": {
+          "label": "Argument",
+          "placeholder": "argument"
+        }
       }
     }
   },

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -350,12 +350,13 @@ function ArgEditor({path, i}: any) {
       className={styles.spaceBetweenCentered}
       style={{'--spacing': spaceScaledXs}}
     >
-      <span>{t('wizard.components.actionsEditor.argument')}</span>
+      <span>{t('wizard.components.actionsEditor.argument.label')}</span>
       <Input
         value={arg}
         onChange={({detail}) => {
           setState([...path, i], detail.value)
         }}
+        placeholder={t('wizard.components.actionsEditor.argument.placeholder')}
       />
       <Button onClick={remove}>{t('wizard.actions.remove')}</Button>
     </div>
@@ -470,7 +471,7 @@ function HeadNodeActionsEditor({basePath, errorsPath}: ActionsEditorProps) {
   const onUpdatedErrors = useState([...errorsPath, 'onUpdated'])
 
   return (
-    <SpaceBetween direction="vertical" size="s">
+    <SpaceBetween direction="vertical" size="xs">
       <ActionEditor
         label={t('wizard.headNode.advancedOptions.scripts.onStart.label')}
         error={onStartErrors}

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -448,7 +448,7 @@ function HeadNode() {
           <ExpandableSection
             headerText={t('wizard.headNode.advancedOptions.label')}
           >
-            <SpaceBetween size="s">
+            <SpaceBetween size="xs">
               <FormField
                 label={t('wizard.headNode.securityGroups.label')}
                 info={
@@ -464,20 +464,22 @@ function HeadNode() {
               >
                 <SecurityGroups basePath={headNodePath} />
               </FormField>
-              <TextContent>
-                <h5>{t('wizard.headNode.advancedOptions.scripts.title')}</h5>
-              </TextContent>
-              {isOnNodeUpdatedActive ? (
-                <HeadNodeActionsEditor
-                  basePath={headNodePath}
-                  errorsPath={errorsPath}
-                />
-              ) : (
-                <ActionsEditor
-                  basePath={headNodePath}
-                  errorsPath={errorsPath}
-                />
-              )}
+              <SpaceBetween size="xxs">
+                <TextContent>
+                  <h3>{t('wizard.headNode.advancedOptions.scripts.title')}</h3>
+                </TextContent>
+                {isOnNodeUpdatedActive ? (
+                  <HeadNodeActionsEditor
+                    basePath={headNodePath}
+                    errorsPath={errorsPath}
+                  />
+                ) : (
+                  <ActionsEditor
+                    basePath={headNodePath}
+                    errorsPath={errorsPath}
+                  />
+                )}
+              </SpaceBetween>
             </SpaceBetween>
           </ExpandableSection>
         </SpaceBetween>
@@ -500,11 +502,6 @@ function HeadNode() {
               value={subnetValue}
               onChange={(subnetId: any) => setState(subnetPath, subnetId)}
             />
-          </Box>
-          <Box>
-            <Alert statusIconAriaLabel="Info">
-              {t('wizard.headNode.networking.subnetId.alert')}
-            </Alert>
           </Box>
         </SpaceBetween>
       </Container>


### PR DESCRIPTION

## Description
* Added missing input fields placeholders
* Reduced advanced options spacing between elements
* Removed 'optional' from "IAM Policies" title
* Changed "Scripts" header from h5 to h3

## How Has This Been Tested?
* Manually verified on affected pages in local environment

## Screenshots

<img width="1728" alt="Screenshot 2023-03-20 at 16 40 40" src="https://user-images.githubusercontent.com/25930133/226393762-122601b4-a278-41a4-bc82-db9f8945bda7.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
