### PR TITLE
Add View logs button to reach Cluster Logs page

### DIFF
--- a/e2e/specs/logs.spec.ts
+++ b/e2e/specs/logs.spec.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { test } from '@playwright/test';
+import { ClusterAction, selectCluster, selectClusterAction } from '../test-utils/clusters';
+import { visitAndLogin } from '../test-utils/login';
+import { visitClusterLogsPage } from '../test-utils/logs';
+
+test.describe('environment: @demo', () => {
+  test.describe('Given an endpoint where AWS ParallelCluster UI is deployed', () => {
+    test.describe('when the user selects a cluster', () => {
+      test('the user can navigate to the cluster logs page', async ({ page }) => {
+        await visitAndLogin(page)
+
+        await selectCluster(page)
+
+        await selectClusterAction(page, ClusterAction.VIEW_LOGS)
+
+        await visitClusterLogsPage(page)
+      });
+    })
+  })
+})

--- a/e2e/test-utils/clusters.ts
+++ b/e2e/test-utils/clusters.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Page } from "@playwright/test";
+
+const DEFAULT_CLUSTER_TO_SELECT = 'DO-NOT-DELETE'
+
+export async function selectCluster(page: Page, clusterName: string = DEFAULT_CLUSTER_TO_SELECT) {
+  await page.getByRole('row', { name: clusterName })
+    .getByRole('radio')
+    .click();
+}
+
+export enum ClusterAction {
+  VIEW_LOGS = 'View logs'
+}
+
+export async function selectClusterAction(page: Page, action: ClusterAction) {
+  await page.getByRole('button', { name: 'Actions', exact: true }).click();
+  await page.getByRole('menuitem', { name: action, exact: true }).click();
+}

--- a/e2e/test-utils/logs.ts
+++ b/e2e/test-utils/logs.ts
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect, Page } from "@playwright/test";
+
+const NON_ZERO_MESSAGES_COUNT = /Messages.*\([1-9][0-9]*\)/
+
+export async function visitClusterLogsPage(page: Page) {
+  await expect(page.getByRole('heading', { name: /cluster logs/i })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Log streams' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Messages' })).toBeVisible()
+
+  const logStreamsFilter = page.getByPlaceholder('Filter log streams')
+  await logStreamsFilter.click();
+  await logStreamsFilter.fill('clusterstatusmgtd');
+  await logStreamsFilter.press('Enter');
+
+  await page.getByRole('row', { name: 'clusterstatusmgtd' })
+    .getByRole('radio')
+    .click();
+
+  await expect(page.getByRole('heading', { name: NON_ZERO_MESSAGES_COUNT })).toBeVisible()
+}

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -141,8 +141,7 @@
       "actionsLabel": "Actions",
       "actions": {
         "stop": "Stop",
-        "start": "Start",
-        "logs": "Logs"
+        "start": "Start"
       },
       "loadingText": "Loading instances...",
       "filtering": {

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -269,7 +269,8 @@
         "delete": "Delete cluster",
         "shell": "Shell",
         "filesystem": "File system",
-        "dcv": "DCV"
+        "dcv": "DCV",
+        "logs": "View logs"
       },
       "actionsLabel": "Actions",
       "filtering": {

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -107,8 +107,7 @@
       "storage": "Storage",
       "scheduling": "Job scheduling",
       "accounting": "Accounting",
-      "stackEvents": "Stack events",
-      "logs": "Logs"
+      "stackEvents": "Stack events"
     },
     "properties": {
       "sshcommand": {

--- a/frontend/src/old-pages/Clusters/Actions.tsx
+++ b/frontend/src/old-pages/Clusters/Actions.tsx
@@ -178,12 +178,15 @@ export default function Actions() {
           case 'edit':
             editConfiguration()
             break
+          case 'logs':
+            navigate(`/clusters/${clusterName}/logs`)
+            break
           case 'delete':
             showDialog('deleteCluster')
             break
         }
       },
-      [openFileSystem, editConfiguration],
+      [openFileSystem, editConfiguration, navigate, clusterName],
     )
 
   const clusterActionsGroupButtonItems = React.useMemo(() => {
@@ -197,6 +200,10 @@ export default function Actions() {
         id: 'edit',
         text: t('cluster.list.actions.edit'),
         disabled: isEditDisabled,
+      },
+      {
+        id: 'logs',
+        text: t('cluster.list.actions.logs'),
       },
       {
         id: 'delete',

--- a/frontend/src/old-pages/Clusters/Details.tsx
+++ b/frontend/src/old-pages/Clusters/Details.tsx
@@ -23,7 +23,6 @@ import Instances from './Instances'
 import Filesystems from './Filesystems'
 import Scheduling from './Scheduling'
 import Properties from './Properties'
-import Logs from './Logs'
 import Loading from '../../components/Loading'
 import {useTranslation} from 'react-i18next'
 import {Alert} from '@cloudscape-design/components'
@@ -92,7 +91,6 @@ export default function ClusterTabs() {
             id: 'stack-events',
             content: <StackEvents />,
           },
-          {label: t('cluster.tabs.logs'), id: 'logs', content: <Logs />},
         ]}
         onChange={({detail}) => {
           navigate(`/clusters/${selectedClusterName}/${detail.activeTabId}`)

--- a/frontend/src/old-pages/Clusters/Instances.tsx
+++ b/frontend/src/old-pages/Clusters/Instances.tsx
@@ -12,7 +12,6 @@ import {Region} from '../../types/base'
 import {ClusterName, ComputeFleetStatus} from '../../types/clusters'
 import {InstanceState, Instance, NodeType} from '../../types/instances'
 import React from 'react'
-import {useNavigate} from 'react-router-dom'
 import {useTranslation} from 'react-i18next'
 
 import {GetClusterInstances, Ec2Action} from '../../model'
@@ -36,7 +35,6 @@ import {extendCollectionsOptions} from '../../shared/extendCollectionsOptions'
 
 function InstanceActions({instance}: {instance?: Instance}) {
   const {t} = useTranslation()
-  const navigate = useNavigate()
 
   const clusterName = useState(['app', 'clusters', 'selected'])
   const fleetStatus: ComputeFleetStatus = useState([
@@ -68,17 +66,6 @@ function InstanceActions({instance}: {instance?: Instance}) {
     Ec2Action(instance!.instanceId, 'start_instances', refresh)
   }, [instance, refresh])
 
-  const navigateToLogTab = React.useCallback(
-    (event: CustomEvent) => {
-      const logHref = `/clusters/${clusterName}/logs?instance=${
-        instance!.instanceId
-      }`
-      navigate(logHref)
-      event.preventDefault()
-    },
-    [clusterName, instance, navigate],
-  )
-
   const isComputeFleetStopped = fleetStatus === ComputeFleetStatus.Stopped
   const isHeadNodeRunning =
     instance?.nodeType === NodeType.HeadNode &&
@@ -102,9 +89,6 @@ function InstanceActions({instance}: {instance?: Instance}) {
         onClick={startInstance}
       >
         {t('cluster.instances.actions.start')}
-      </Button>
-      <Button disabled={!instance} onClick={navigateToLogTab}>
-        {t('cluster.instances.actions.logs')}
       </Button>
     </SpaceBetween>
   )

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -24,6 +24,7 @@ import Users from '../old-pages/Users/Users'
 import Loading from '../components/Loading'
 import {NoMatch} from '../components/NoMatch'
 import {Images} from '../old-pages/Images'
+import {Logs} from '../old-pages/Logs'
 
 export default function App() {
   const identity = useState(['identity'])
@@ -47,6 +48,7 @@ export default function App() {
                 <Route path=":tab" element={<div></div>} />
               </Route>
             </Route>
+            <Route path="clusters/:clusterName/logs" element={<Logs />} />
             <Route path="configure" element={<Configure />} />
             <Route path="images" element={<Images />} />
             <Route path="users" element={<Users />} />


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR allows users to reach the Cluster Logs page via a cluster action

It builds on #123 and #126 

## Changes

- remove Logs tab
- remove Logs button from the Instances tab
- add "View logs" button to actions dropdown in Clusters page

## Screenshot

![Screenshot 2023-03-21 at 10 53 17](https://user-images.githubusercontent.com/11457067/226635584-ab4b1faa-66d4-46b5-92a1-f9281c594020.png)

## How Has This Been Tested?

- manually, by selecting a cluster and clicking on the View logs button
- manually, by making sure the page correctly shows the cluster logs
- e2e test

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
