### PR TITLE
Fix e2e not selecting region when creating a cluster

### DIFF
--- a/e2e/specs/wizard.spec.ts
+++ b/e2e/specs/wizard.spec.ts
@@ -19,6 +19,6 @@ test.describe('Given an endpoint where AWS ParallelCluster UI is deployed', () =
     await page.getByRole('button', { name: 'Create cluster' }).first().click();
     await page.getByRole('menuitem', { name: 'Use interface' }).click();
     
-    await fillWizard(page, {vpc: /vpc-.*/})
+    await fillWizard(page, {vpc: /vpc-.*/, region: 'eu-west-1'})
   });
 })

--- a/e2e/test-utils/wizard.ts
+++ b/e2e/test-utils/wizard.ts
@@ -12,12 +12,13 @@
 import { expect, Page } from "@playwright/test";
 
 const DEFAULT_CONFIG: Config = {
-  clusterName: 'c' + Math.random().toString(20).substring(8)
+  clusterName: 'c' + Math.random().toString(20).substring(8),
 }
 
 interface Config {
   clusterName: string;
-  vpc?: RegExp | string
+  region?: string;
+  vpc?: RegExp | string;
 }
 
 export async function fillWizard(page: Page, config: Partial<Config> = {}) {
@@ -37,6 +38,11 @@ export async function fillClusterSection(page: Page, config: Config) {
   await expect(page.getByRole('heading', { name: 'Cluster', exact: true })).toBeVisible()
   
   await page.getByPlaceholder('Enter your cluster name').fill(config.clusterName);
+
+  if (config.region) {
+    await page.getByLabel("Region").click();
+    await page.getByText(config.region).first().click();
+  }
 
   if (config.vpc) {
     await page.getByRole('button', { name: 'Select a VPC' }).click();


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR fixes our e2e suites getting blocked when the region is not pre-populated.

## Changes

- select the region manually, without relying on the pre-fill of the region which depends on the speed with which the user interacts with the UI
- a better solution would be integrate a loading mechanism in the UI, but for the time being it is valuable that we unlock the e2e suite

## How Has This Been Tested?

- running e2e locally pointing to the demo environment

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
