### PR TITLE
Add a loading state spinner at application loading time to prevent portal usage before necessary info are downloaded

### DIFF
--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,0 +1,1 @@
+**/jest.config.js

--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,1 +1,0 @@
-**/jest.config.js

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -2,5 +2,8 @@
   "extends": [
     "next/core-web-vitals",
     "prettier"
+  ],
+  "ignorePatterns": [
+    "**/jest.config.js"
   ]
 }

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,6 +1,6 @@
-const merge = require('lodash/merge');
+const merge = require('lodash/merge')
 const nextJest = require('next/jest')
-const awsuiPreset = require('@cloudscape-design/jest-preset/jest-preset');
+const awsuiPreset = require('@cloudscape-design/jest-preset/jest-preset')
 
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
@@ -22,5 +22,17 @@ async function mergePolarisPreset() {
 
   return mergedConfig
 }
+
+// necessary to circumvent Jest exception handlers to test exception throwing
+// this is due to the impossibility to run code before Jest starts, since Jest performs its
+// override/patching of the `process` variable
+// see https://johann.pardanaud.com/blog/how-to-assert-unhandled-rejection-and-uncaught-exception-with-jest/
+// this is not the right place for setup code or custom configuration code
+// do NOT add code here
+process._original = (function (_original) {
+  return function () {
+    return _original
+  }
+})(process)
 
 module.exports = mergePolarisPreset

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -28,6 +28,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, State> {
 
   private promiseRejectionHandler = (event: PromiseRejectionEvent) => {
     this.props.logger.error(event.reason)
+    this.setState({error: true})
   }
 
   private errorHandler = (event: ErrorEvent) => {

--- a/frontend/src/components/__tests__/useLoadingState.test.tsx
+++ b/frontend/src/components/__tests__/useLoadingState.test.tsx
@@ -1,0 +1,63 @@
+import {renderHook} from '@testing-library/react-hooks'
+
+jest.mock('../../model', () => {
+  return {
+    GetAppConfig: jest.fn(),
+    GetIdentity: jest.fn(),
+  }
+})
+
+import {GetIdentity, GetAppConfig} from '../../model'
+import {useLoadingState} from '../useLoadingState'
+import {Box} from '@cloudscape-design/components'
+import React from 'react'
+import {Mock} from 'jest-mock'
+
+describe('given a prerequisite to allow a component to be displayed', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('when the prerequisites are met', () => {
+    it('should render the component', async () => {
+      const box = <Box></Box>
+      const {result, waitForNextUpdate} = renderHook(() => useLoadingState(box))
+
+      await waitForNextUpdate()
+
+      expect(result.current.loading).toBe(false)
+      expect(result.current.content).toEqual(box)
+    })
+
+    it('should invoke the necessary functions', async () => {
+      const {waitForNextUpdate} = renderHook(() => useLoadingState(<Box></Box>))
+
+      await waitForNextUpdate()
+
+      expect(GetAppConfig).toHaveBeenCalledTimes(1)
+      expect(GetIdentity).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when the prerequisites are being checked', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+      ;(GetIdentity as Mock).mockImplementation(
+        () => new Promise(resolve => setTimeout(resolve, 10000)),
+      )
+      ;(GetAppConfig as Mock).mockImplementation(
+        () => new Promise(resolve => setTimeout(resolve, 10000)),
+      )
+    })
+
+    afterEach(() => jest.useRealTimers())
+
+    it('should render a loading component', () => {
+      const {result} = renderHook(() => useLoadingState(<Box></Box>))
+
+      jest.advanceTimersByTime(1000)
+
+      expect(result.current.loading).toBe(true)
+    })
+  })
+})

--- a/frontend/src/components/useLoadingState.tsx
+++ b/frontend/src/components/useLoadingState.tsx
@@ -16,7 +16,9 @@ interface UseLoadingStateResponse {
   loading: boolean
   content: React.ReactNode
 }
-function useLoadingState(wrappedComponents: any): UseLoadingStateResponse {
+function useLoadingState(
+  wrappedComponents: React.ReactNode,
+): UseLoadingStateResponse {
   const [loading, setLoading] = React.useState(false)
 
   React.useEffect(() => {

--- a/frontend/src/components/useLoadingState.tsx
+++ b/frontend/src/components/useLoadingState.tsx
@@ -1,11 +1,8 @@
 import {Box, SpaceBetween, Spinner} from '@cloudscape-design/components'
 import React from 'react'
 import {GetAppConfig, GetIdentity} from '../model'
-import {useTranslation} from 'react-i18next'
 
 export function LoadingSpinnerContent() {
-  const {t} = useTranslation()
-
   return (
     <SpaceBetween direction="vertical" size="l">
       <Box textAlign="center">

--- a/frontend/src/components/useLoadingState.tsx
+++ b/frontend/src/components/useLoadingState.tsx
@@ -27,7 +27,7 @@ function useLoadingState(
       await GetAppConfig()
 
       try {
-        await GetIdentity(undefined, true)
+        await GetIdentity()
       } catch (error: any) {
         const status = (error as AxiosError)?.response?.status
         if (status != 403 && status != 401) {

--- a/frontend/src/components/useLoadingState.tsx
+++ b/frontend/src/components/useLoadingState.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import {GetAppConfig, GetIdentity} from '../model'
 import {AxiosError} from 'axios'
 
-export function LoadingSpinnerContent() {
+function LoadingSpinnerContent() {
   return (
     <SpaceBetween direction="vertical" size="l">
       <Box textAlign="center">
@@ -16,9 +16,7 @@ interface UseLoadingStateResponse {
   loading: boolean
   content: React.ReactNode
 }
-export function useLoadingState(
-  wrappedComponents: any,
-): UseLoadingStateResponse {
+function useLoadingState(wrappedComponents: any): UseLoadingStateResponse {
   const [loading, setLoading] = React.useState(false)
 
   React.useEffect(() => {
@@ -45,3 +43,5 @@ export function useLoadingState(
     content: loading ? <LoadingSpinnerContent /> : wrappedComponents,
   }
 }
+
+export {useLoadingState, LoadingSpinnerContent}

--- a/frontend/src/components/useLoadingState.tsx
+++ b/frontend/src/components/useLoadingState.tsx
@@ -1,6 +1,7 @@
 import {Box, SpaceBetween, Spinner} from '@cloudscape-design/components'
 import React from 'react'
 import {GetAppConfig, GetIdentity} from '../model'
+import {AxiosError} from 'axios'
 
 export function LoadingSpinnerContent() {
   return (
@@ -28,7 +29,7 @@ export function useLoadingState(
       try {
         await GetIdentity(undefined, true)
       } catch (error: any) {
-        const status = error?.response?.status
+        const status = (error as AxiosError)?.response?.status
         if (status != 403 && status != 401) {
           throw error // rethrow in case error is not authn/z related
         }

--- a/frontend/src/components/useLoadingState.tsx
+++ b/frontend/src/components/useLoadingState.tsx
@@ -1,0 +1,49 @@
+import {Box, SpaceBetween, Spinner} from '@cloudscape-design/components'
+import React from 'react'
+import {GetAppConfig, GetIdentity} from '../model'
+import {useTranslation} from 'react-i18next'
+
+export function LoadingSpinnerContent() {
+  const {t} = useTranslation()
+
+  return (
+    <SpaceBetween direction="vertical" size="l">
+      <Box textAlign="center">
+        <Spinner size="large"></Spinner>
+      </Box>
+    </SpaceBetween>
+  )
+}
+interface UseLoadingStateResponse {
+  loading: boolean
+  content: React.ReactNode
+}
+export function useLoadingState(
+  wrappedComponents: any,
+): UseLoadingStateResponse {
+  const [loading, setLoading] = React.useState(false)
+
+  React.useEffect(() => {
+    const getPreliminaryInfo = async () => {
+      setLoading(true)
+      await GetAppConfig()
+
+      try {
+        await GetIdentity(undefined, true)
+      } catch (error: any) {
+        const status = error?.response?.status
+        if (status != 403 && status != 401) {
+          throw error // rethrow in case error is not authn/z related
+        }
+      }
+      setLoading(false)
+    }
+
+    getPreliminaryInfo()
+  }, [])
+
+  return {
+    loading,
+    content: loading ? <LoadingSpinnerContent /> : wrappedComponents,
+  }
+}

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -898,22 +898,26 @@ function SlurmAccounting(
     })
 }
 
-export function GetIdentity(successCallback?: Callback) {
+export function GetIdentity(successCallback?: Callback, throwing = false) {
   const url = 'manager/get_identity'
-  return request('get', url)
-    .then(response => {
-      if (response.status === 200) {
-        setState(['identity'], response.data)
-        successCallback && successCallback(response.data)
-      }
-    })
-    .catch(error => {
+  let responsePromise = request('get', url).then(response => {
+    if (response.status === 200) {
+      setState(['identity'], response.data)
+      successCallback && successCallback(response.data)
+    }
+  })
+
+  if (!throwing) {
+    responsePromise = responsePromise.catch(error => {
       if (error.response) {
         console.log(error.response)
         notify(`Error: ${error.response.data.message}`, 'error')
       }
       console.log(error)
     })
+  }
+
+  return responsePromise
 }
 
 export async function GetAppConfig() {

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -898,7 +898,7 @@ function SlurmAccounting(
     })
 }
 
-export function GetIdentity(successCallback?: Callback, throwing = false) {
+function GetIdentity(successCallback?: Callback, throwing = false) {
   const url = 'manager/get_identity'
   let responsePromise = request('get', url).then(response => {
     if (response.status === 200) {
@@ -920,7 +920,7 @@ export function GetIdentity(successCallback?: Callback, throwing = false) {
   return responsePromise
 }
 
-export async function GetAppConfig() {
+async function GetAppConfig() {
   try {
     const appConfig = await getAppConfig(axiosInstance)
     setState(['app', 'appConfig'], appConfig)
@@ -981,4 +981,6 @@ export {
   notify,
   CreateUser,
   DeleteUser,
+  GetIdentity,
+  GetAppConfig,
 }

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -900,7 +900,7 @@ function SlurmAccounting(
 
 export function GetIdentity(successCallback?: Callback) {
   const url = 'manager/get_identity'
-  request('get', url)
+  return request('get', url)
     .then(response => {
       if (response.status === 200) {
         setState(['identity'], response.data)

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -898,26 +898,19 @@ function SlurmAccounting(
     })
 }
 
-function GetIdentity(successCallback?: Callback, throwing = false) {
-  const url = 'manager/get_identity'
-  let responsePromise = request('get', url).then(response => {
+async function GetIdentity(successCallback?: Callback, throwing = false) {
+  try {
+    const response = await request('get', 'manager/get_identity')
     if (response.status === 200) {
       setState(['identity'], response.data)
       successCallback && successCallback(response.data)
     }
-  })
-
-  if (!throwing) {
-    responsePromise = responsePromise.catch(error => {
-      if (error.response) {
-        console.log(error.response)
-        notify(`Error: ${error.response.data.message}`, 'error')
-      }
-      console.log(error)
-    })
+  } catch (e) {
+    console.log(e)
+    if (throwing) {
+      throw e as AxiosError
+    }
   }
-
-  return responsePromise
 }
 
 async function GetAppConfig() {

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -937,14 +937,11 @@ async function LoadInitialState() {
   const region = getState(['app', 'selectedRegion'])
   clearState(['app', 'aws'])
   GetVersion()
-  await GetAppConfig()
-  GetIdentity(_ => {
-    ListUsers()
-    ListClusters()
-    ListCustomImages()
-    ListOfficialImages()
-    LoadAwsConfig(region)
-  })
+  ListUsers()
+  ListClusters()
+  ListCustomImages()
+  ListOfficialImages()
+  LoadAwsConfig(region)
 }
 
 export {

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -898,19 +898,13 @@ function SlurmAccounting(
     })
 }
 
-async function GetIdentity(successCallback?: Callback, throwing = false) {
-  try {
-    const response = await request('get', 'manager/get_identity')
-    if (response.status === 200) {
-      setState(['identity'], response.data)
-      successCallback && successCallback(response.data)
-    }
-  } catch (e) {
-    console.log(e)
-    if (throwing) {
-      throw e as AxiosError
-    }
+async function GetIdentity() {
+  const response = await request('get', 'manager/get_identity')
+  if (response.status === 200) {
+    setState(['identity'], response.data)
+    return response.data
   }
+  return undefined
 }
 
 async function GetAppConfig() {

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -898,7 +898,7 @@ function SlurmAccounting(
     })
 }
 
-function GetIdentity(successCallback?: Callback) {
+export function GetIdentity(successCallback?: Callback) {
   const url = 'manager/get_identity'
   request('get', url)
     .then(response => {
@@ -916,7 +916,7 @@ function GetIdentity(successCallback?: Callback) {
     })
 }
 
-async function GetAppConfig() {
+export async function GetAppConfig() {
   try {
     const appConfig = await getAppConfig(axiosInstance)
     setState(['app', 'appConfig'], appConfig)

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -25,6 +25,7 @@ import Loading from '../components/Loading'
 import {NoMatch} from '../components/NoMatch'
 import {Images} from '../old-pages/Images'
 import {Logs} from '../old-pages/Logs'
+import {useLoadingState} from '../components/useLoadingState'
 
 export default function App() {
   const identity = useState(['identity'])
@@ -33,31 +34,33 @@ export default function App() {
     LoadInitialState()
   }, [])
 
-  return (
-    <>
-      {identity ? (
-        <BrowserRouter>
-          <Routes>
-            <Route
-              path="index.html"
-              element={<Navigate replace to="/clusters" />}
-            />
-            <Route index element={<Navigate replace to="/clusters" />} />
-            <Route path="clusters" element={<Clusters />}>
-              <Route path=":clusterName" element={<div></div>}>
-                <Route path=":tab" element={<div></div>} />
-              </Route>
-            </Route>
-            <Route path="clusters/:clusterName/logs" element={<Logs />} />
-            <Route path="configure" element={<Configure />} />
-            <Route path="images" element={<Images />} />
-            <Route path="users" element={<Users />} />
-            <Route path="*" element={<NoMatch />} />
-          </Routes>
-        </BrowserRouter>
-      ) : (
-        <Loading />
-      )}
-    </>
+  const {loading, content} = useLoadingState (
+    <BrowserRouter>
+      <Routes>
+        <Route
+          path="index.html"
+          element={<Navigate replace to="/clusters" />}
+        />
+        <Route index element={<Navigate replace to="/clusters" />} />
+        <Route path="clusters" element={<Clusters />}>
+          <Route path=":clusterName" element={<div></div>}>
+            <Route path=":tab" element={<div></div>} />
+          </Route>
+        </Route>
+        <Route path="clusters/:clusterName/logs" element={<Logs />} />
+        <Route path="configure" element={<Configure />} />
+        <Route path="images" element={<Images />} />
+        <Route path="users" element={<Users />} />
+        <Route path="*" element={<NoMatch />} />
+      </Routes>
+    </BrowserRouter>
   )
+
+  React.useEffect(() => {
+    if (!loading) {
+      LoadInitialState()
+    }
+  }, [loading])
+
+  return content
 }

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -27,13 +27,7 @@ import {Logs} from '../old-pages/Logs'
 import {useLoadingState} from '../components/useLoadingState'
 
 export default function App() {
-  const identity = useState(['identity'])
-
-  React.useEffect(() => {
-    LoadInitialState()
-  }, [])
-
-  const {loading, content} = useLoadingState (
+  const {loading, content} = useLoadingState(
     <BrowserRouter>
       <Routes>
         <Route
@@ -52,7 +46,7 @@ export default function App() {
         <Route path="users" element={<Users />} />
         <Route path="*" element={<NoMatch />} />
       </Routes>
-    </BrowserRouter>
+    </BrowserRouter>,
   )
 
   React.useEffect(() => {

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -21,7 +21,6 @@ import Configure from '../old-pages/Configure/Configure'
 import Users from '../old-pages/Users/Users'
 
 // Components
-import Loading from '../components/Loading'
 import {NoMatch} from '../components/NoMatch'
 import {Images} from '../old-pages/Images'
 import {Logs} from '../old-pages/Logs'


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description
This PR introduces a preliminary "step" to the loading of the application, a loading state is shown when the application is first displayed and two set of info are downloaded, since they are necessary for the inner workings of the application.
- application config (with info like where to redirect an authenticating user, etc.)
- identity of the user (if the user is actually authenticated)

Important: this PR doesn't handle the same loading state with preliminary info download in case of a region change from the region selector!
<!-- Summary of what this PR introduces and possibly why -->

## Changes
- added new hook `useLoadingState`
- `GetIdentity` and `GetAppConfig` functions are now exported
- `GetIdentity` now always throws the error it gets since it is only used in one place (inside the `useLoadingState` hook)
- `GetIdentity` not returns the http response data
- small change in the `ErrorBoundary` component to set the error state to true for unhandled `Promise` errors also
- added setup code to `jest.config.js` as an extraordinary measure to test unhandled exceptions at Jest level
- ignored `jest.config.js` for es-linting since it's not necessary and would otherwise break the linter

The spinner displayed while loading:

https://user-images.githubusercontent.com/6314859/226667089-95ba1e5d-49bf-40b8-868a-8e866323cc0f.mov



## How Has This Been Tested?
- manually
- unit tests
<!-- The tests you ran to verify your changes -->

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
