### PR TITLE
Storage wizard page minor fixes

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -692,9 +692,10 @@
       "title": "Storage",
       "description": "Configure shared storage for your cluster.",
       "container": {
+        "title": "Storage settings",
         "noStorageSelected": "No shared storage options selected.",
         "storageType": "Storage type",
-        "storageTypePlaceholder": "Select a file system type",
+        "storageTypePlaceholder": "Select one or more storage types",
         "volumePlaceholder": "Select a volume",
         "addStorage": "Add storage",
         "removeStorage": "Remove storage",
@@ -742,7 +743,8 @@
           "fsxOnTap": "FSx NetApp ONTAP volume"
         },
         "capacity": {
-          "label": "Storage capacity (GB)"
+          "label": "Storage capacity (GB)",
+          "placeholder": "1200"
         },
         "lustreType": {
           "label": "FSx for Lustre",
@@ -787,6 +789,7 @@
         },
         "provisioned": {
           "label": "Provisioned throughput (1-1024 in MiB/s)",
+          "placeholder": "128",
           "help": "Configure the provisioned throughput (from 1-1024 in MiB/s) for the Amazon EFS file system. If not configured, the file system is created in bursting mode.",
           "throughputLink": {
             "title": "ThroughputMode section",
@@ -801,7 +804,8 @@
           "placeholder": "Default ({{defaultVolumeType}})"
         },
         "volumeSize": {
-          "label": "Volume Size (35-2048 in GB)"
+          "label": "Volume Size (35-2048 in GB)",
+          "placeholder": "35"
         },
         "encrypted": {
           "label": "Encrypted",
@@ -814,6 +818,7 @@
         },
         "snapshotId": {
           "label": "Snapshot ID",
+          "placeholder": "snap-id",
           "help": "Enter the Amazon EBS snapshot ID if you're using a snapshot as the source for the volume.",
           "snapshotLink": {
             "title": "SnapshotID",
@@ -824,10 +829,12 @@
       "instance": {
         "mountPoint": {
           "label": "Mount path",
+          "placeholder": "/shared",
           "help": "Configure the mount path for the shared storage on both the head node and compute nodes."
         },
         "sourceName": {
           "label": "Shared source name",
+          "placeholder": "StorageName",
           "maxLengthError": "Name can be at most {{maxChars}} characters",
           "forbiddenCharsError": "The name contains one or more forbidden characters",
           "forbiddenKeywordError": "The name contains a forbidden keyword",

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -323,6 +323,7 @@ export function FsxLustreSettings({index}: any) {
       <FormField label={t('wizard.storage.Fsx.capacity.label')}>
         <Input
           value={storageCapacity}
+          placeholder={t('wizard.storage.Fsx.capacity.placeholder')}
           step={1200}
           onChange={({detail}) => {
             setState(storageCapacityPath, detail.value)
@@ -565,6 +566,7 @@ export function EfsSettings({index}: any) {
           {throughputMode === 'provisioned' && (
             <Input
               type="number"
+              placeholder={t('wizard.storage.Efs.provisioned.placeholder')}
               value={clamp(parseInt(provisionedThroughput), 1, 1024).toString()}
               onChange={({detail}) => {
                 setState(
@@ -699,6 +701,7 @@ export function EbsSettings({index}: any) {
         >
           <Input
             inputMode={'decimal'}
+            placeholder={t('wizard.storage.Ebs.volumeSize.placeholder')}
             type={'number' as InputProps.Type}
             value={volumeSize}
             onChange={({detail}) => {
@@ -751,6 +754,7 @@ export function EbsSettings({index}: any) {
           {snapshotId !== null && (
             <Input
               value={snapshotId}
+              placeholder={t('wizard.storage.Ebs.snapshotId.placeholder')}
               onChange={({detail}) => {
                 setState(snapshotIdPath, detail.value)
               }}
@@ -890,7 +894,11 @@ function StorageInstance({index}: any) {
             label={t('wizard.storage.instance.sourceName.label')}
             errorText={storageNameErrors}
           >
-            <Input value={storageName} onChange={updateStorageName} />
+            <Input
+              value={storageName}
+              onChange={updateStorageName}
+              placeholder={t('wizard.storage.instance.sourceName.placeholder')}
+            />
           </FormField>
           <FormField
             label={t('wizard.storage.instance.mountPoint.label')}
@@ -907,6 +915,7 @@ function StorageInstance({index}: any) {
           >
             <Input
               value={mountPoint}
+              placeholder={t('wizard.storage.instance.mountPoint.placeholder')}
               onChange={({detail}) => {
                 setState([...storagePath, index, 'MountDir'], detail.value)
               }}

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -1145,7 +1145,9 @@ function Storage() {
 
   return (
     <SpaceBetween direction="vertical" size="l">
-      <Container>
+      <Container
+        header={<Header>{t('wizard.storage.container.title')}</Header>}
+      >
         <SpaceBetween direction="vertical" size="m">
           {!hasAddedStorage && (
             <Alert statusIconAriaLabel="Info">


### PR DESCRIPTION
## Description
This PR introduces minor fixes for `Storage` wizard page:

* Added 'Storage settings' title container
* Addded and fix missing placeholders in input fields

## How Has This Been Tested?
* Manually inspected affected pages on local environment

## References
* https://cloudscape.design/components/input/?tabId=playground

## Screenshots

<img width="1724" alt="Screenshot 2023-03-22 at 01 09 21" src="https://user-images.githubusercontent.com/25930133/226847041-4afc5e7d-e512-4c74-a6a2-f52beda9226c.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
