### PR TITLE
Queues wizard page minor fixes

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -951,7 +951,7 @@
         "instanceType": {
           "label": "Instance type",
           "placeholder": {
-            "multiple": "Select one or more instance type"
+            "multiple": "Select one or more instance types"
           }
         },
         "disableHT": {
@@ -982,7 +982,7 @@
       },
       "name": {
         "label": "Queue name",
-        "placeholder": "queue-name"
+        "placeholder": "Enter the queue name"
       },
       "subnet": {
         "label": {

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -948,7 +948,12 @@
         "addComputeResource": "Add compute resource",
         "staticNodes": "Static nodes",
         "dynamicNodes": "Dynamic nodes",
-        "instanceType": "Instance type",
+        "instanceType": {
+          "label": "Instance type",
+          "placeholder": {
+            "multiple": "Select one or more instance type"
+          }
+        },
         "disableHT": {
           "label": "Turn off multithreading",
           "description": "Prevent multiple threads from running on an EC2 instance core."
@@ -976,13 +981,15 @@
         "label": "Use placement group"
       },
       "name": {
-        "label": "Queue name"
+        "label": "Queue name",
+        "placeholder": "queue-name"
       },
       "subnet": {
         "label": {
           "single": "Subnet ID",
           "multiple": "Subnet IDs"
-        }
+        },
+        "placeholder": "Select a subnet"
       },
       "purchaseType": {
         "label": "Purchase type"

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -873,6 +873,9 @@
     "queues": {
       "title": "Queues",
       "description": "Configure up to {{limit}} cluster queues.",
+      "container": {
+        "title": "Queue {{index}} - {{queueName}}"
+      },
       "help": {
         "main": "<p>Configure your cluster queues for job scheduling.</p><p>Add and remove queues and queue compute resources.</p><p>Choose <strong>Refresh</strong> to view recently changed or added AWS resources.</p>",
         "schedulerLink": {
@@ -938,6 +941,7 @@
           "title": "Compute resources",
           "description": "Configure up to {{limit}} compute resources."
         },
+        "name": "Resource {{index}} - {{crName}}",
         "removeComputeResourceButton": {
           "label": "Remove resource"
         },

--- a/frontend/src/old-pages/Configure/Cluster.tsx
+++ b/frontend/src/old-pages/Configure/Cluster.tsx
@@ -247,7 +247,7 @@ function initWizardState(
     [...configPath, 'Scheduling', 'SlurmQueues'],
     [
       {
-        Name: 'queue-0',
+        Name: 'queue-1',
         AllocationStrategy: isMultipleInstanceTypesActive
           ? 'lowest-price'
           : undefined,

--- a/frontend/src/old-pages/Configure/Cluster.tsx
+++ b/frontend/src/old-pages/Configure/Cluster.tsx
@@ -238,6 +238,7 @@ function initWizardState(
   isMultipleInstanceTypesActive: boolean,
 ) {
   const customAMIEnabled = getIn(config, ['Image', 'CustomAmi']) ? true : false
+  const queueName = 'queue-1'
   setState(['app', 'wizard', 'customAMI', 'enabled'], customAMIEnabled)
   setState([...configPath, 'HeadNode', 'InstanceType'], 't2.micro')
   setState([...configPath, 'Scheduling', 'Scheduler'], 'slurm')
@@ -247,14 +248,14 @@ function initWizardState(
     [...configPath, 'Scheduling', 'SlurmQueues'],
     [
       {
-        Name: 'queue-1',
+        Name: queueName,
         AllocationStrategy: isMultipleInstanceTypesActive
           ? 'lowest-price'
           : undefined,
         ComputeResources: [
           isMultipleInstanceTypesActive
-            ? multiCreate(0, 0)
-            : singleCreate(0, 0),
+            ? multiCreate(queueName, 0)
+            : singleCreate(queueName, 0),
         ],
       },
     ],

--- a/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
@@ -242,7 +242,7 @@ export function ComputeResource({
             </FormField>
           </div>
           <FormField
-            label={t('wizard.queues.computeResource.instanceType')}
+            label={t('wizard.queues.computeResource.instanceType.label')}
             errorText={typeError}
           >
             <Multiselect
@@ -250,6 +250,9 @@ export function ComputeResource({
                 value: instance.InstanceType,
                 label: instance.InstanceType,
               }))}
+              placeholder={t(
+                'wizard.queues.computeResource.instanceType.placeholder.multiple',
+              )}
               tokenLimit={3}
               onChange={setInstances}
               options={instanceOptions}

--- a/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
@@ -275,7 +275,7 @@ export function ComputeResource({
             />
           )}
         </ColumnLayout>
-        <div style={{display: 'flex', flexDirection: 'row', gap: '20px'}}>
+        <SpaceBetween direction="vertical" size="s">
           <Checkbox
             checked={multithreadingDisabled}
             disabled={hpcInstanceSelected}
@@ -299,7 +299,7 @@ export function ComputeResource({
           >
             <Trans i18nKey="wizard.queues.computeResource.enableEfa" />
           </Checkbox>
-        </div>
+        </SpaceBetween>
       </div>
     </div>
   )

--- a/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
@@ -7,6 +7,7 @@ import {
   Multiselect,
   MultiselectProps,
   Checkbox,
+  SpaceBetween,
 } from '@cloudscape-design/components'
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
 import {useCallback, useEffect, useMemo} from 'react'
@@ -203,7 +204,12 @@ export function ComputeResource({
     <div className="compute-resource">
       <div style={{display: 'flex', flexDirection: 'column', gap: '10px'}}>
         <ColumnLayout columns={2}>
-          <h4>{computeResource.Name}</h4>
+          <h3>
+            {t('wizard.queues.computeResource.name', {
+              index: index + 1,
+              crName: computeResource.Name,
+            })}
+          </h3>
           <Box margin={{top: 'xs'}} textAlign="right">
             {index > 0 && (
               <Button onClick={remove}>
@@ -304,7 +310,7 @@ export function createComputeResource(
   crIndex: number,
 ): MultiInstanceComputeResource {
   return {
-    Name: `queue-${queueIndex}-cr-${crIndex}`,
+    Name: `queue-${queueIndex + 1}-cr-${crIndex + 1}`,
     Instances: [
       {
         InstanceType: defaultInstanceType,

--- a/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
@@ -309,11 +309,11 @@ export function ComputeResource({
 }
 
 export function createComputeResource(
-  queueIndex: number,
+  queueName: string,
   crIndex: number,
 ): MultiInstanceComputeResource {
   return {
-    Name: `queue-${queueIndex + 1}-cr-${crIndex + 1}`,
+    Name: `${queueName}-cr-${crIndex + 1}`,
     Instances: [
       {
         InstanceType: defaultInstanceType,

--- a/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
@@ -75,7 +75,7 @@ describe('Given a list of queues', () => {
 
   describe("when they're 10 or more", () => {
     const queues = new Array(11).fill(null).map((_, index) => ({
-      Name: `queue-${index}`,
+      Name: `queue-${index + 1}`,
       ComputeResources: [],
       ComputeSettings: {
         LocalStorage: {
@@ -99,13 +99,13 @@ describe('Given a list of queues', () => {
       })
     })
     it('should not allow to add more queues', () => {
-      const {getByText} = render(
+      const {getAllByText} = render(
         <MockProviders store={mockStore}>
           <Queues />
         </MockProviders>,
       )
 
-      const button = getByText('Add queue')
+      const button = getAllByText('Add queue')[0]
       fireEvent.click(button)
       expect(setState).not.toHaveBeenCalled()
     })
@@ -113,7 +113,7 @@ describe('Given a list of queues', () => {
 
   describe("when they're less than 10", () => {
     const queues = new Array(5).fill(null).map((_, index) => ({
-      Name: `queue-${index}`,
+      Name: `queue-${index + 1}`,
       ComputeResources: [],
       ComputeSettings: {
         LocalStorage: {
@@ -137,13 +137,13 @@ describe('Given a list of queues', () => {
       })
     })
     it('should allow to add more queues', () => {
-      const {getByText} = render(
+      const {getAllByText} = render(
         <MockProviders store={mockStore}>
           <Queues />
         </MockProviders>,
       )
 
-      const button = getByText('Add queue')
+      const button = getAllByText('Add queue')[0]
       fireEvent.click(button)
       expect(setState).toHaveBeenCalled()
     })
@@ -158,7 +158,7 @@ describe('Given a list of queues', () => {
               Scheduling: {
                 SlurmQueues: [
                   {
-                    Name: 'queue-0',
+                    Name: 'queue-1',
                     ComputeResources: new Array(5).fill(null).map(index => ({
                       Name: `cr-${index}`,
                     })),
@@ -195,7 +195,7 @@ describe('Given a list of queues', () => {
               Scheduling: {
                 SlurmQueues: [
                   {
-                    Name: 'queue-0',
+                    Name: 'queue-1',
                     ComputeResources: new Array(2).fill(null).map(index => ({
                       Name: `cr-${index}`,
                     })),
@@ -265,7 +265,7 @@ describe('Given a queue', () => {
               Scheduling: {
                 SlurmQueues: [
                   {
-                    Name: `queue-0`,
+                    Name: `queue-1`,
                     ComputeResources: [
                       {
                         Instances: [{InstanceType: 'hpc6a.48xlarge'}],
@@ -320,7 +320,7 @@ describe('Given a queue', () => {
               Scheduling: {
                 SlurmQueues: [
                   {
-                    Name: `queue-0`,
+                    Name: `queue-1`,
                     ComputeResources: [
                       {
                         Instances: [{InstanceType: 'c5n.large'}],

--- a/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
@@ -69,7 +69,7 @@ const MockProviders = (props: any) => (
 describe('Given a list of queues', () => {
   describe('when creating a new compute resource', () => {
     it('should create it with a default instance type', () => {
-      expect(createComputeResource(0, 0).Instances).toHaveLength(1)
+      expect(createComputeResource('queueName', 0).Instances).toHaveLength(1)
     })
   })
 

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -460,14 +460,13 @@ function Queue({index}: any) {
               variant="h2"
               actions={
                 <SpaceBetween direction="horizontal" size="xs">
-                  {index === 0 ? (
-                    <Button
-                      disabled={queues.length >= MAX_QUEUES}
-                      onClick={addQueue}
-                    >
-                      {t('wizard.queues.addQueueButton.label')}
-                    </Button>
-                  ) : (
+                  <Button
+                    disabled={queues.length >= MAX_QUEUES}
+                    onClick={addQueue}
+                  >
+                    {t('wizard.queues.addQueueButton.label')}
+                  </Button>
+                  {queues.length > 1 && (
                     <Button onClick={remove}>
                       {t('wizard.queues.removeQueueButton.label')}
                     </Button>

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -574,7 +574,7 @@ function Queue({index}: any) {
               />
             </ColumnLayout>
             <ExpandableSection headerText="Advanced options">
-              <SpaceBetween direction="vertical" size="s">
+              <SpaceBetween direction="vertical" size="xs">
                 <FormField label={t('wizard.queues.securityGroups.label')}>
                   <SecurityGroups basePath={[...queuesPath, index]} />
                 </FormField>

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -441,7 +441,7 @@ function Queue({index}: any) {
       [
         ...(queues || []),
         {
-          Name: `queue-${queues.length}`,
+          Name: `queue-${queues.length + 1}`,
           ...defaultAllocationStrategy,
           ComputeResources: [
             computeResourceAdapter.createComputeResource(queues.length, 0),
@@ -475,134 +475,139 @@ function Queue({index}: any) {
                 </SpaceBetween>
               }
             >
-              {queue.Name}
+              {t('wizard.queues.container.title', {
+                index: index + 1,
+                queueName: queue.Name,
+              })}
             </Header>
           }
         >
-          <ColumnLayout borders="horizontal">
-            <SpaceBetween direction="vertical" size="xs">
-              <Box margin={{bottom: 'xs'}}>
-                <SpaceBetween direction="horizontal" size="xs">
+          <SpaceBetween direction="vertical" size="s">
+            <ColumnLayout borders="horizontal">
+              <SpaceBetween direction="vertical" size="xs">
+                <Box margin={{bottom: 'xs'}}>
+                  <SpaceBetween direction="horizontal" size="xs">
+                    <FormField
+                      label={t('wizard.queues.name.label')}
+                      errorText={nameError}
+                    >
+                      <Input
+                        value={queue.Name}
+                        onKeyDown={e => {
+                          if (
+                            e.detail.key === 'Enter' ||
+                            e.detail.key === 'Escape'
+                          ) {
+                            e.stopPropagation()
+                            queueValidate(index)
+                          }
+                        }}
+                        onChange={({detail}) => renameQueue(detail.value)}
+                      />
+                    </FormField>
+                  </SpaceBetween>
+                </Box>
+                <ColumnLayout columns={2}>
                   <FormField
-                    label={t('wizard.queues.name.label')}
-                    errorText={nameError}
+                    label={
+                      isMultiAZActive
+                        ? t('wizard.queues.subnet.label.multiple')
+                        : t('wizard.queues.subnet.label.single')
+                    }
+                    errorText={subnetError}
                   >
-                    <Input
-                      value={queue.Name}
-                      onKeyDown={e => {
-                        if (
-                          e.detail.key === 'Enter' ||
-                          e.detail.key === 'Escape'
-                        ) {
-                          e.stopPropagation()
-                          queueValidate(index)
-                        }
-                      }}
-                      onChange={({detail}) => renameQueue(detail.value)}
-                    />
-                  </FormField>
-                </SpaceBetween>
-              </Box>
-              <ColumnLayout columns={2}>
-                <FormField
-                  label={
-                    isMultiAZActive
-                      ? t('wizard.queues.subnet.label.multiple')
-                      : t('wizard.queues.subnet.label.single')
-                  }
-                  errorText={subnetError}
-                >
-                  {isMultiAZActive ? (
-                    <SubnetMultiSelect
-                      value={subnetsList}
-                      onChange={onSubnetMultiSelectChange}
-                    />
-                  ) : (
-                    <SubnetSelect
-                      value={subnetsList[0]}
-                      onChange={onSubnetSelectChange}
-                    />
-                  )}
-                </FormField>
-                <FormField label={t('wizard.queues.purchaseType.label')}>
-                  <Select
-                    selectedOption={itemToOption(
-                      findFirst(capacityTypes, x => x[0] === capacityType) || [
-                        '',
-                        '',
-                      ],
+                    {isMultiAZActive ? (
+                      <SubnetMultiSelect
+                        value={subnetsList}
+                        onChange={onSubnetMultiSelectChange}
+                      />
+                    ) : (
+                      <SubnetSelect
+                        value={subnetsList[0]}
+                        onChange={onSubnetSelectChange}
+                      />
                     )}
-                    onChange={({detail}) => {
-                      setState(capacityTypePath, detail.selectedOption.value)
-                    }}
-                    options={capacityTypes.map(itemToOption)}
-                  />
-                </FormField>
-                {isMultiInstanceTypesActive ? (
-                  <FormField
-                    label={t('wizard.queues.allocationStrategy.title')}
-                  >
+                  </FormField>
+                  <FormField label={t('wizard.queues.purchaseType.label')}>
                     <Select
-                      options={allocationStrategyOptions}
-                      selectedOption={
-                        allocationStrategyOptions.find(
-                          as => as.value === allocationStrategy,
-                        )!
-                      }
-                      onChange={setAllocationStrategy}
+                      selectedOption={itemToOption(
+                        findFirst(
+                          capacityTypes,
+                          x => x[0] === capacityType,
+                        ) || ['', ''],
+                      )}
+                      onChange={({detail}) => {
+                        setState(capacityTypePath, detail.selectedOption.value)
+                      }}
+                      options={capacityTypes.map(itemToOption)}
                     />
                   </FormField>
-                ) : null}
-              </ColumnLayout>
-              <Box variant="div" margin={{vertical: 'xs'}}>
-                <Checkbox
-                  checked={enablePlacementGroup}
-                  disabled={!canUsePlacementGroup}
-                  onChange={_e => {
-                    setEnablePG(!enablePlacementGroup)
-                  }}
-                >
-                  <Trans i18nKey="wizard.queues.placementGroup.label" />
-                </Checkbox>
-              </Box>
-            </SpaceBetween>
-            <ComputeResources
-              queue={queue}
-              index={index}
-              canUseEFA={canUseEFA}
-            />
-          </ColumnLayout>
-          <ExpandableSection headerText="Advanced options">
-            <SpaceBetween direction="vertical" size="s">
-              <FormField label={t('wizard.queues.securityGroups.label')}>
-                <SecurityGroups basePath={[...queuesPath, index]} />
-              </FormField>
-              <CustomAMISettings
-                basePath={[...queuesPath, index]}
-                appPath={['app', 'wizard', 'queues', index]}
-                errorsPath={errorsPath}
-                validate={queuesValidate}
+                  {isMultiInstanceTypesActive ? (
+                    <FormField
+                      label={t('wizard.queues.allocationStrategy.title')}
+                    >
+                      <Select
+                        options={allocationStrategyOptions}
+                        selectedOption={
+                          allocationStrategyOptions.find(
+                            as => as.value === allocationStrategy,
+                          )!
+                        }
+                        onChange={setAllocationStrategy}
+                      />
+                    </FormField>
+                  ) : null}
+                </ColumnLayout>
+                <Box variant="div" margin={{vertical: 'xs'}}>
+                  <Checkbox
+                    checked={enablePlacementGroup}
+                    disabled={!canUsePlacementGroup}
+                    onChange={_e => {
+                      setEnablePG(!enablePlacementGroup)
+                    }}
+                  >
+                    <Trans i18nKey="wizard.queues.placementGroup.label" />
+                  </Checkbox>
+                </Box>
+              </SpaceBetween>
+              <ComputeResources
+                queue={queue}
+                index={index}
+                canUseEFA={canUseEFA}
               />
-              <Header variant="h3">
-                {t('wizard.queues.advancedOptions.scripts.title')}
-              </Header>
-              <ActionsEditor
-                basePath={[...queuesPath, index]}
-                errorsPath={errorsPath}
-              />
-              <Header variant="h3">
-                {t('wizard.queues.advancedOptions.rootVolume.title')}
-              </Header>
-              <RootVolume
-                basePath={[...queuesPath, index, 'ComputeSettings']}
-                errorsPath={errorsPath}
-              />
-              <Header variant="h3">
-                {t('wizard.queues.advancedOptions.iamPolicies.label')}
-              </Header>
-              <IamPoliciesEditor basePath={[...queuesPath, index]} />
-            </SpaceBetween>
-          </ExpandableSection>
+            </ColumnLayout>
+            <ExpandableSection headerText="Advanced options">
+              <SpaceBetween direction="vertical" size="s">
+                <FormField label={t('wizard.queues.securityGroups.label')}>
+                  <SecurityGroups basePath={[...queuesPath, index]} />
+                </FormField>
+                <CustomAMISettings
+                  basePath={[...queuesPath, index]}
+                  appPath={['app', 'wizard', 'queues', index]}
+                  errorsPath={errorsPath}
+                  validate={queuesValidate}
+                />
+                <Header variant="h3">
+                  {t('wizard.queues.advancedOptions.scripts.title')}
+                </Header>
+                <ActionsEditor
+                  basePath={[...queuesPath, index]}
+                  errorsPath={errorsPath}
+                />
+                <Header variant="h3">
+                  {t('wizard.queues.advancedOptions.rootVolume.title')}
+                </Header>
+                <RootVolume
+                  basePath={[...queuesPath, index, 'ComputeSettings']}
+                  errorsPath={errorsPath}
+                />
+                <Header variant="h3">
+                  {t('wizard.queues.advancedOptions.iamPolicies.label')}
+                </Header>
+                <IamPoliciesEditor basePath={[...queuesPath, index]} />
+              </SpaceBetween>
+            </ExpandableSection>
+          </SpaceBetween>
         </Container>
       </div>
     </div>

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -556,8 +556,6 @@ function Queue({index}: any) {
                       />
                     </FormField>
                   ) : null}
-                </ColumnLayout>
-                <Box variant="div" margin={{vertical: 'xs'}}>
                   <Checkbox
                     checked={enablePlacementGroup}
                     disabled={!canUsePlacementGroup}
@@ -567,7 +565,7 @@ function Queue({index}: any) {
                   >
                     <Trans i18nKey="wizard.queues.placementGroup.label" />
                   </Checkbox>
-                </Box>
+                </ColumnLayout>
               </SpaceBetween>
               <ComputeResources
                 queue={queue}

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -276,7 +276,10 @@ function ComputeResources({queue, index, canUseEFA}: any) {
       ...queue,
       ComputeResources: [
         ...existingCRs,
-        computeResourceAdapter.createComputeResource(index, existingCRs.length),
+        computeResourceAdapter.createComputeResource(
+          queue.Name,
+          existingCRs.length,
+        ),
       ],
     })
   }
@@ -436,15 +439,16 @@ function Queue({index}: any) {
   const defaultAllocationStrategy = useDefaultAllocationStrategy()
 
   const addQueue = () => {
+    const queueName = `queue-${queues.length + 1}`
     setState(
       [...queuesPath],
       [
         ...(queues || []),
         {
-          Name: `queue-${queues.length + 1}`,
+          Name: queueName,
           ...defaultAllocationStrategy,
           ComputeResources: [
-            computeResourceAdapter.createComputeResource(queues.length, 0),
+            computeResourceAdapter.createComputeResource(queueName, 0),
           ],
         },
       ],

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -492,6 +492,7 @@ function Queue({index}: any) {
                     >
                       <Input
                         value={queue.Name}
+                        placeholder={t('wizard.queues.name.placeholder')}
                         onKeyDown={e => {
                           if (
                             e.detail.key === 'Enter' ||

--- a/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
@@ -244,9 +244,9 @@ export function ComputeResource({index, queueIndex, computeResource}: any) {
   )
 }
 
-export function createComputeResource(queueIndex: number, crIndex: number) {
+export function createComputeResource(queueName: string, crIndex: number) {
   return {
-    Name: `queue-${queueIndex + 1}-${defaultInstanceType.replace('.', '')}`,
+    Name: `${queueName}-${defaultInstanceType.replace('.', '')}`,
     InstanceType: defaultInstanceType,
     MinCount: 0,
     MaxCount: 4,

--- a/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
@@ -213,7 +213,7 @@ export function ComputeResource({index, queueIndex, computeResource}: any) {
             />
           )}
         </ColumnLayout>
-        <div style={{display: 'flex', flexDirection: 'row', gap: '20px'}}>
+        <SpaceBetween direction="vertical" size="s">
           <Checkbox
             disabled={
               tInstances.has(instanceType) ||
@@ -238,7 +238,7 @@ export function ComputeResource({index, queueIndex, computeResource}: any) {
           >
             <Trans i18nKey="wizard.queues.computeResource.enableEfa" />
           </Checkbox>
-        </div>
+        </SpaceBetween>
       </div>
     </div>
   )

--- a/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
@@ -5,6 +5,7 @@ import {
   FormField,
   Input,
   Checkbox,
+  SpaceBetween,
 } from '@cloudscape-design/components'
 import {useEffect} from 'react'
 import {Trans, useTranslation} from 'react-i18next'
@@ -147,7 +148,12 @@ export function ComputeResource({index, queueIndex, computeResource}: any) {
     <div className="compute-resource">
       <div style={{display: 'flex', flexDirection: 'column', gap: '10px'}}>
         <ColumnLayout columns={2}>
-          <h4>{computeResource.Name}</h4>
+          <h3>
+            {t('wizard.queues.computeResource.name', {
+              index: index + 1,
+              crName: computeResource.Name,
+            })}
+          </h3>
           <Box margin={{top: 'xs'}} textAlign="right">
             {index > 0 && (
               <Button onClick={remove}>
@@ -240,7 +246,7 @@ export function ComputeResource({index, queueIndex, computeResource}: any) {
 
 export function createComputeResource(queueIndex: number, crIndex: number) {
   return {
-    Name: `queue${queueIndex}-${defaultInstanceType.replace('.', '')}`,
+    Name: `queue-${queueIndex + 1}-${defaultInstanceType.replace('.', '')}`,
     InstanceType: defaultInstanceType,
     MinCount: 0,
     MaxCount: 4,

--- a/frontend/src/old-pages/Configure/Queues/SubnetMultiSelect.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SubnetMultiSelect.tsx
@@ -2,6 +2,7 @@ import {Multiselect, MultiselectProps} from '@cloudscape-design/components'
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
 import React from 'react'
 import {useMemo} from 'react'
+import {useTranslation} from 'react-i18next'
 import {useState} from '../../../store'
 import {subnetName} from '../util'
 import {Subnet} from './queues.types'
@@ -12,6 +13,7 @@ type SubnetMultiSelectProps = {
 }
 
 function SubnetMultiSelect({value, onChange}: SubnetMultiSelectProps) {
+  const {t} = useTranslation()
   const vpc = useState(['app', 'wizard', 'vpc'])
   const subnets = useState(['aws', 'subnets'])
   const filteredSubnets: Subnet[] = useMemo(
@@ -42,6 +44,7 @@ function SubnetMultiSelect({value, onChange}: SubnetMultiSelectProps) {
         return value.includes(option.value)
       })}
       onChange={onChange}
+      placeholder={t('wizard.queues.subnet.placeholder')}
       options={subnetOptions}
     />
   )


### PR DESCRIPTION
## Description
This PR introduces minor fixes for queues wizard page:

* Changed name structure for queues and compute resources
* Make add/remove button to be repeated in every queue
* Stack EFA/Multithreading checkboxes vertically
* Add missing placeholders for input fields


<!-- List of relevant changes introduced -->

## How Has This Been Tested?
* Unit tests
* Manually inspected affected pages in local environment, targeting version of PC API 3.2.0 and 3.5.0

## Screenshots

<img width="1726" alt="Screenshot 2023-03-22 at 10 23 53" src="https://user-images.githubusercontent.com/25930133/226858141-ffa22e70-0795-45c7-9feb-774e6adbebde.png">



## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
