### PR TITLE
Show count of total entries in table headers

### DIFF
--- a/frontend/src/old-pages/Clusters/Clusters.tsx
+++ b/frontend/src/old-pages/Clusters/Clusters.tsx
@@ -92,6 +92,8 @@ function ClusterList({clusters}: {clusters: ClusterInfoSummary[]}) {
     wizardShow(navigate)
   }
 
+  const clustersCount = (clusters || []).length
+
   const {
     items,
     actions,
@@ -140,7 +142,7 @@ function ClusterList({clusters}: {clusters: ClusterInfoSummary[]}) {
         <Header
           variant="awsui-h1-sticky"
           description={t('cluster.list.header.description')}
-          counter={items && `(${items.length})`}
+          counter={`(${clustersCount})`}
           info={<InfoLink helpPanel={<ClustersHelpPanel />} />}
           actions={<Actions />}
         >

--- a/frontend/src/old-pages/Images/CustomImages/CustomImages.tsx
+++ b/frontend/src/old-pages/Images/CustomImages/CustomImages.tsx
@@ -70,6 +70,8 @@ function CustomImagesList() {
     ListCustomImages(imageStatus || 'AVAILABLE')
   }
 
+  const imagesCount = (images || []).length
+
   const {
     items,
     actions,
@@ -128,7 +130,7 @@ function CustomImagesList() {
               ></Link>
             </Trans>
           }
-          counter={images && `(${images.length})`}
+          counter={`(${imagesCount})`}
           actions={
             <SpaceBetween direction="horizontal" size="xs">
               <Button className="action" onClick={refreshImages}>

--- a/frontend/src/old-pages/Images/OfficialImages/OfficialImages.tsx
+++ b/frontend/src/old-pages/Images/OfficialImages/OfficialImages.tsx
@@ -61,6 +61,7 @@ function OfficialImagesHelpPanel() {
 
 function OfficialImagesList({images}: {images: Image[]}) {
   const {t} = useTranslation()
+  const imagesCount = (images || []).length
   const {
     items,
     actions,
@@ -104,7 +105,7 @@ function OfficialImagesList({images}: {images: Image[]}) {
       header={
         <Header
           variant="awsui-h1-sticky"
-          counter={items && `(${items.length})`}
+          counter={`(${imagesCount})`}
           description={t('officialImages.header.description')}
           info={<InfoLink helpPanel={<OfficialImagesHelpPanel />} />}
         >

--- a/frontend/src/old-pages/Logs/LogMessagesTable.tsx
+++ b/frontend/src/old-pages/Logs/LogMessagesTable.tsx
@@ -106,7 +106,7 @@ export function LogMessagesTable({clusterName, logStreamName}: Props) {
       trackBy="message"
       header={
         <Header
-          counter={`(${items.length})`}
+          counter={`(${data.length})`}
           actions={
             <Button
               disabled={!canFetchMessages}

--- a/frontend/src/old-pages/Logs/LogStreamsTable.tsx
+++ b/frontend/src/old-pages/Logs/LogStreamsTable.tsx
@@ -205,7 +205,7 @@ export function LogStreamsTable({clusterName, onLogStreamSelect}: Props) {
       onSelectionChange={onSelectionChange}
       header={
         <Header
-          counter={`(${items.length})`}
+          counter={`(${logStreamsToDisplay.length})`}
           actions={
             <Button
               onClick={onRefreshClick}


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR updates table headers so to display the total number of entries

## Changes

- update Cluster list counter
- update Official Images list counter
- update Custom Images list counter
- update LogStreams and LogMessages list counter

## Screenshot

![image](https://user-images.githubusercontent.com/11457067/226918496-c3ee1943-420d-4a1c-bd4d-bc27db1e1260.png)

## How Has This Been Tested?

- manually, by simulating everything works fine when
   - no data is returned at all (defaults to 0)
   - data is returned (shows total count)

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
