### PR TITLE
Sort create cluster outcome messages based on severity

### DIFF
--- a/frontend/src/old-pages/Configure/Create.tsx
+++ b/frontend/src/old-pages/Configure/Create.tsx
@@ -45,6 +45,7 @@ import i18next from 'i18next'
 
 // Constants
 const configPath = ['app', 'wizard', 'clusterConfigYaml']
+const priority: FlashbarProps.Type[] = ['error', 'success', 'warning', 'info']
 
 function handleWarnings(resp: any) {
   if (!resp.validationMessages) return
@@ -210,6 +211,18 @@ function dismissableMessage(
   }
 }
 
+function compareFlashbarItems(
+  itemA: FlashbarProps.MessageDefinition,
+  itemB: FlashbarProps.MessageDefinition,
+): number {
+  const itemAPriority = priority.indexOf(itemA.type!)
+  const itemBPriority = priority.indexOf(itemB.type!)
+
+  if (itemAPriority > itemBPriority) return 1
+  if (itemAPriority < itemBPriority) return -1
+  else return 0
+}
+
 export function errorsToFlashbarItems(
   errors: CreateErrors,
   setFlashbarItems: React.Dispatch<
@@ -267,6 +280,7 @@ export function errorsToFlashbarItems(
     )
   })
 
+  items.sort(compareFlashbarItems)
   return items
 }
 

--- a/frontend/src/old-pages/Configure/__tests__/errorsToFlashbarItems.test.ts
+++ b/frontend/src/old-pages/Configure/__tests__/errorsToFlashbarItems.test.ts
@@ -218,4 +218,111 @@ describe('Given a function to map create/dry-run errors to FlashbarItems', () =>
       )
     })
   })
+
+  describe('when errors contain messages with different types', () => {
+    const updateErrors: UpdateError[] = [
+      {
+        level: 'INFO',
+        message: 'InfoMessage',
+      },
+      {
+        level: 'ERROR',
+        message: 'ErrorMessage',
+      },
+      {
+        level: 'WARNING',
+        message: 'WarningMessage',
+      },
+    ]
+    const errors: CreateErrors = {
+      message: 'Invalid cluster configuration',
+      updateValidationErrors: updateErrors,
+    }
+
+    it('should return error items, with expected type and content, ordered by the following priority: ["success", "error", "warning", "info"]', () => {
+      const expected: FlashbarProps.MessageDefinition[] = [
+        {
+          type: 'error',
+          dismissible: true,
+          header: 'Error',
+          content: updateErrors[1].message,
+          id: 'update-err-1',
+        },
+        {
+          type: 'warning',
+          dismissible: true,
+          header: 'Warning',
+          content: updateErrors[2].message,
+          id: 'update-err-2',
+        },
+        {
+          type: 'info',
+          dismissible: true,
+          header: 'Info',
+          content: updateErrors[0].message,
+          id: 'update-err-0',
+        },
+      ]
+      expect(errorsToFlashbarItems(errors, setFlashbarItems)).toMatchObject(
+        expected,
+      )
+    })
+  })
+
+  describe('when errors contain messages with different types, including a success message', () => {
+    const updateErrors: UpdateError[] = [
+      {
+        level: 'INFO',
+        message: 'InfoMessage1',
+      },
+      {
+        level: 'WARNING',
+        message: 'WarningMessage',
+      },
+      {
+        level: 'INFO',
+        message: 'InfoMessage2',
+      },
+    ]
+    const errors: CreateErrors = {
+      message: 'Request would have succeeded, but DryRun flag is set.',
+      updateValidationErrors: updateErrors,
+    }
+
+    it('should return error items, with expected type and content, ordered by the following priority: ["success", "error", "warning", "info"]', () => {
+      const expected: FlashbarProps.MessageDefinition[] = [
+        {
+          type: 'success',
+          dismissible: true,
+          header: 'wizard.create.flashBar.success',
+          content: errors.message,
+          id: 'success',
+        },
+        {
+          type: 'warning',
+          dismissible: true,
+          header: 'Warning',
+          content: updateErrors[1].message,
+          id: 'update-err-1',
+        },
+        {
+          type: 'info',
+          dismissible: true,
+          header: 'Info',
+          content: updateErrors[0].message,
+          id: 'update-err-0',
+        },
+        {
+          type: 'info',
+          dismissible: true,
+          header: 'Info',
+          content: updateErrors[2].message,
+          id: 'update-err-2',
+        },
+      ]
+      expect(errorsToFlashbarItems(errors, setFlashbarItems)).toMatchObject(
+        expected,
+      )
+    })
+  })
 })


### PR DESCRIPTION
## Description
Currently upon cluster creation, outcome messages are stacked following the same order of the returned JSON from PC API, and errors comes at the very end, causing the UI to display a blue message instead of a red one.

This PR introduces a mechanism to sort Flashbar items according the following priority:
1. `success`
2. `error`
3. `warning`
4. `info`

## How Has This Been Tested?
* Unit tests
* Manually triggered different dry-runs

## References
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort

## Screenshots

<img width="1728" alt="Screenshot 2023-03-22 at 17 32 01" src="https://user-images.githubusercontent.com/25930133/226973879-e8a98718-b42e-4e91-b6c2-6e54753b8636.png">
<img width="1728" alt="Screenshot 2023-03-22 at 17 32 23" src="https://user-images.githubusercontent.com/25930133/226973904-595ac172-c7f8-4c0c-84cf-93713df1c186.png">


## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
