### PR TITLE
Add + symbol to log messages count

### DIFF
--- a/frontend/src/old-pages/Logs/LogMessagesTable.tsx
+++ b/frontend/src/old-pages/Logs/LogMessagesTable.tsx
@@ -92,6 +92,9 @@ export function LogMessagesTable({clusterName, logStreamName}: Props) {
     }),
   )
 
+  const messagesCountText =
+    data.length > 0 ? `(${data.length}+)` : `(${data.length})`
+
   const onRefreshClick = useCallback(() => {
     refetch()
   }, [refetch])
@@ -106,7 +109,7 @@ export function LogMessagesTable({clusterName, logStreamName}: Props) {
       trackBy="message"
       header={
         <Header
-          counter={`(${data.length})`}
+          counter={messagesCountText}
           actions={
             <Button
               disabled={!canFetchMessages}


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR shows a `+` symbol next to the Log Messages count, with the following logic:
- when the count is 0, show `(0)`
- otherwise, show `(N+)`

This is done to be explicit about the fact that we don't know the total number of messages (as expressed in [CloudScape guidelines](https://cloudscape.design/components/table/?tabId=usage))

## How Has This Been Tested?

- manually, by checking both 0 and non-zero case

## References

- [Counter guidelines](https://cloudscape.design/components/table/?tabId=usage)

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
