### PR TITLE
`[AP]` Use lambda layer for deployment, cfn for replacement

### DIFF
--- a/Dockerfile.lambdalayer
+++ b/Dockerfile.lambdalayer
@@ -1,0 +1,21 @@
+FROM public.ecr.aws/lambda/python:3.9
+
+ARG data_dir=/opt
+
+COPY --from=frontend /app/build ${data_dir}/frontend/public
+
+COPY resources/attributions/docker-attributions.txt license.txt
+COPY requirements.txt  .
+RUN  pip3 install -r requirements.txt --target "${data_dir}/python"
+
+COPY app.py ${data_dir}/python/pcui/app.py
+COPY api ${data_dir}/python/api
+COPY awslambda ${data_dir}/python/awslambda
+RUN touch ${data_dir}/python/pcui/__init__.py
+RUN rm -fr ${data_dir}/python/boto* ${data_dir}/python/pip*
+RUN mkdir -p /data
+WORKDIR /opt
+RUN python -c "import shutil; shutil.make_archive('/data/layer', format='zip')"
+
+ENTRYPOINT ["bash"]
+CMD ["-c", "cp /data/layer.zip /output" ]

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -18,34 +18,34 @@ import boto3
 import botocore
 import requests
 import yaml
-from flask import abort, redirect, request, Blueprint
+from flask import Blueprint, abort, redirect, request
 from jose import jwt
 
 from api.exception.exceptions import RefreshTokenError
-from api.pcm_globals import set_auth_cookies_in_context, logger, auth_cookies
+from api.pcm_globals import auth_cookies, logger, set_auth_cookies_in_context
 from api.security.csrf.constants import CSRF_COOKIE_NAME
 from api.security.csrf.csrf import csrf_needed
 from api.utils import disable_auth
 from api.validation import validated
 from api.validation.schemas import PCProxyArgs, PCProxyBody
 
-USER_POOL_ID = os.getenv("USER_POOL_ID")
-AUTH_PATH = os.getenv("AUTH_PATH")
 API_BASE_URL = os.getenv("API_BASE_URL")
-API_VERSION = os.getenv("API_VERSION", "3.1.0")
 API_USER_ROLE = os.getenv("API_USER_ROLE")
-OIDC_PROVIDER = os.getenv("OIDC_PROVIDER")
+API_VERSION = os.getenv("API_VERSION", "3.1.0")
+AUDIENCE = os.getenv("AUDIENCE")
+AUTH_PATH = os.getenv("AUTH_PATH")
+AUTH_URL = os.getenv("AUTH_URL", f"{AUTH_PATH}/login")
 CLIENT_ID = os.getenv("CLIENT_ID")
 CLIENT_SECRET = os.getenv("CLIENT_SECRET")
+JWKS_URL = os.getenv("JWKS_URL")
+OIDC_PROVIDER = os.getenv("OIDC_PROVIDER")
+REGION = os.getenv("AWS_DEFAULT_REGION")
+REVOKE_REFRESH_TOKEN_URL = f"{AUTH_PATH}/oauth2/revoke"
+SCOPES_LIST = os.getenv("SCOPES_LIST")
 SECRET_ID = os.getenv("SECRET_ID")
 SITE_URL = os.getenv("SITE_URL", API_BASE_URL)
-SCOPES_LIST = os.getenv("SCOPES_LIST")
-REGION = os.getenv("AWS_DEFAULT_REGION")
 TOKEN_URL = os.getenv("TOKEN_URL", f"{AUTH_PATH}/oauth2/token")
-REVOKE_REFRESH_TOKEN_URL = f"{AUTH_PATH}/oauth2/revoke"
-AUTH_URL = os.getenv("AUTH_URL", f"{AUTH_PATH}/login")
-JWKS_URL = os.getenv("JWKS_URL")
-AUDIENCE = os.getenv("AUDIENCE")
+USER_POOL_ID = os.getenv("USER_POOL_ID")
 USER_ROLES_CLAIM = os.getenv("USER_ROLES_CLAIM", "cognito:groups")
 
 try:

--- a/api/utils.py
+++ b/api/utils.py
@@ -12,12 +12,12 @@ import datetime
 import os
 
 import dateutil
-from flask import Flask, Response, request, send_from_directory
 import requests
+from flask import Flask, Response, request, send_from_directory
 
-from api.pcm_globals import PCMGlobals, logger
 from api.exception import ExceptionHandler
 from api.logging import RequestResponseLogging
+from api.pcm_globals import PCMGlobals, logger
 from api.security import SecurityHeaders
 
 # needed to only allow tests to disable auth

--- a/api/utils.py
+++ b/api/utils.py
@@ -92,7 +92,7 @@ def build_flask_app(name):
 
     additional_args = {}
     if not is_running_local:
-        additional_args = dict(static_url_path="", static_folder="frontend/public")
+        additional_args = dict(static_url_path="", static_folder=os.getenv("STATIC_PATH", "frontend/public"))
 
     app = Flask(name, **additional_args)
     # Pcm globals setter functions before any other before_func

--- a/api/validation/schemas.py
+++ b/api/validation/schemas.py
@@ -1,7 +1,7 @@
 from marshmallow import Schema, fields, validate, INCLUDE, validates_schema
 
-from api.validation.validators import aws_region_validator, is_alphanumeric_with_hyphen, \
-    valid_api_log_levels_predicate, size_not_exceeding
+from api.validation.validators import  aws_region_validator, is_alphanumeric_with_hyphen, \
+    is_alphanumeric_with_hyphen_and_dot, valid_api_log_levels_predicate, size_not_exceeding
 
 
 class EC2ActionSchema(Schema):
@@ -84,6 +84,12 @@ class CancelJobSchema(Schema):
     region = fields.String(required=True, validate=aws_region_validator)
 
 CancelJob = CancelJobSchema(unknown=INCLUDE)
+
+
+class SetPCUIVersionSchema(Schema):
+    version = fields.String(validate=is_alphanumeric_with_hyphen_and_dot)
+
+SetPCUIVersion = SetPCUIVersionSchema(unknown=INCLUDE)
 
 
 class SacctSchema(Schema):

--- a/api/validation/validators.py
+++ b/api/validation/validators.py
@@ -21,6 +21,11 @@ def is_alphanumeric_with_hyphen(arg: str):
     return bool(re.fullmatch(pattern, arg))
 
 
+def is_alphanumeric_with_hyphen_and_dot(arg: str):
+    pattern = re.compile(r"^[a-zA-Z][a-zA-Z0-9-.]+$")
+    return bool(re.fullmatch(pattern, arg))
+
+
 aws_region_validator = validate.OneOf(choices=PC_REGIONS)
 
 

--- a/app.py
+++ b/app.py
@@ -15,7 +15,11 @@ from flask.json import JSONEncoder
 from werkzeug.routing import BaseConverter
 
 import api.utils as utils
+from api.logging import parse_log_entry, push_log_entry
 from api.PclusterApiHandler import (
+    CLIENT_ID,
+    CLIENT_SECRET,
+    USER_POOL_ID,
     authenticated,
     cancel_job,
     create_user,
@@ -27,25 +31,38 @@ from api.PclusterApiHandler import (
     get_custom_image_config,
     get_dcv_session,
     get_identity,
-    get_version,
     get_instance_types,
+    get_version,
     list_users,
     login,
     logout,
+    pc,
     price_estimate,
     queue_status,
     sacct,
     scontrol_job,
-    CLIENT_ID, CLIENT_SECRET, USER_POOL_ID, pc
 )
-from api.logging import parse_log_entry, push_log_entry
 from api.pcm_globals import logger
 from api.security.csrf import CSRF
 from api.security.csrf.csrf import csrf_needed
 from api.security.fingerprint import CognitoFingerprintGenerator
-from api.validation import validated, EC2Action
-from api.validation.schemas import CreateUser, DeleteUser, GetClusterConfig, GetCustomImageConfig, GetAwsConfig, GetInstanceTypes,\
-     Login, PushLog, PriceEstimate, GetDcvSession, QueueStatus, ScontrolJob, CancelJob, Sacct
+from api.validation import EC2Action, validated
+from api.validation.schemas import (
+    CancelJob,
+    CreateUser,
+    DeleteUser,
+    GetAwsConfig,
+    GetClusterConfig,
+    GetCustomImageConfig,
+    GetDcvSession,
+    GetInstanceTypes,
+    Login,
+    PriceEstimate,
+    PushLog,
+    QueueStatus,
+    Sacct,
+    ScontrolJob,
+)
 
 ADMINS_GROUP = { "admin" }
 

--- a/app.py
+++ b/app.py
@@ -32,6 +32,8 @@ from api.PclusterApiHandler import (
     get_dcv_session,
     get_identity,
     get_instance_types,
+    get_pcui_versions,
+    get_stack_info,
     get_version,
     list_users,
     login,
@@ -41,6 +43,7 @@ from api.PclusterApiHandler import (
     queue_status,
     sacct,
     scontrol_job,
+    set_pcui_version,
 )
 from api.pcm_globals import logger
 from api.security.csrf import CSRF
@@ -62,6 +65,7 @@ from api.validation.schemas import (
     QueueStatus,
     Sacct,
     ScontrolJob,
+    SetPCUIVersion,
 )
 
 ADMINS_GROUP = { "admin" }
@@ -149,6 +153,20 @@ def run():
     @app.route("/manager/get_version")
     def get_version_():
         return get_version()
+
+    @app.route("/manager/get_stack_info")
+    def get_stack_info_():
+        return get_stack_info()
+
+    @app.route("/manager/get_pcui_versions")
+    def get_pcui_versions_():
+        return get_pcui_versions()
+
+    @app.route("/manager/set_pcui_version", methods=["POST"])
+    @authenticated(ADMINS_GROUP)
+    @validated(params=SetPCUIVersion)
+    def set_pcui_version_():
+        return set_pcui_version()
 
     @app.route("/manager/get_app_config")
     def get_app_config_():

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -11,6 +11,7 @@
     },
     "topBar": {
       "signOut": "Sign out",
+      "reloadOnDeploy": "A new version of PCUI has has been deployed, click ok to reload.",
       "logoAltText": "$t(global.projectDisplayName} logo",
       "regionSelector": {
         "defaultRegionText": "Region",

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -11,7 +11,7 @@
 import React, {useMemo} from 'react'
 
 import {useState, setState, clearAllState} from '../store'
-import {LoadInitialState} from '../model'
+import {LoadInitialState, GetPCUIVersions, SetPCUIVersion, GetStackInfo } from '../model'
 
 // UI Elements
 import TopNavigation from '@cloudscape-design/components/top-navigation'
@@ -65,6 +65,27 @@ export function regions(selected: string) {
   return supportedRegions
 }
 
+const versionsToDropdownItems= (
+    versions: string[], currentVersion: string
+) => {
+
+    return versions.map(version => {
+        let className = 'version'
+        if (currentVersion === version) className += ' version-selected'
+
+        return {
+            type: 'button',
+            id: version,
+            text: (
+                <span className={className}>
+                    <span className="version">{version}</span>
+                </span>
+            )
+        }
+
+    })
+}
+
 const regionsToDropdownItems = (
   regionGroups: string[][][],
   selected: string,
@@ -112,7 +133,19 @@ export default function Topbar() {
   const defaultRegionText = t('global.topBar.regionSelector.defaultRegionText')
   const defaultRegion = useState(['aws', 'region']) || defaultRegionText
   const selectedRegion = useState(['app', 'selectedRegion']) || defaultRegion
+  const stackStatus = useState(['app', 'stack_info', 'StackStatus']) || "unknown"
+  const currentVersion = useState(['app', 'pcui_versions', 'current_version'])
+  const versions = useState(['app', 'pcui_versions', 'versions']) || [...(currentVersion ? [currentVersion] : [])]
   const displayedRegions = regions(selectedRegion)
+  let finishedStates = new Set(["UPDATE_COMPLETE_CLEANUP_IN_PROGRESS", "UPDATE_COMPLETE", "UPDATE_ROLLBACK_COMPLETE"])
+
+  const selectVersion = (version: any) => {
+      let newVersion = version.detail.id
+      if(newVersion != currentVersion) {
+          SetPCUIVersion(newVersion)
+          setState(['app', 'stack_info', 'StackStatus'], "UPDATE_IN_PROGRESS")
+      }
+  }
 
   const selectRegion = (region: any) => {
     let newRegion = region.detail.id
@@ -134,11 +167,50 @@ export default function Topbar() {
     [t],
   )
 
+  const statusIcon = (status: string) => {
+      let status_map: Record<string, string> = {
+          "COMPLETE": 'status-positive',
+          "PROGRESS": 'status-in-progress',
+          "FAILED": 'status-negative'}
+      let status_suffix = status.split("_").slice(-1)[0]
+      return status_map[status_suffix] ?? 'status-pending'
+  }
+
+
+  React.useEffect(() =>{
+      let old_stack_status: string = ''
+      const stackInfoTick = () => {
+          GetStackInfo(stack_info => {
+              let finished = finishedStates.has(stack_info.StackStatus)
+              if(old_stack_status != '' && stack_info.StackStatus != old_stack_status && finished)
+                  {
+                      if(confirm(t('global.topBar.reloadOnDeploy')))
+                      {
+                          location.href = "/"
+                          location.reload()
+                      }
+                  }
+                  old_stack_status = stack_info.StackStatus
+          })
+
+      }
+      const stackInfoTimerId = setInterval(stackInfoTick, 10000)
+      return () => {
+          clearInterval(stackInfoTimerId)
+      }
+  }, [])
+
+
+  React.useEffect(() => {
+    const versionsTimerId = setInterval(GetPCUIVersions, 60000)
+    return () => { clearInterval(versionsTimerId)}
+  }, [])
+
   return (
     <div id="top-bar">
       <TopNavigation
         identity={{
-          title: t('global.projectDisplayName'),
+          title: t('global.projectDisplayName') + (currentVersion ? ` (${currentVersion})` : ""),
           href: '/',
           logo: {
             src: '/img/pcluster.svg',
@@ -146,6 +218,35 @@ export default function Topbar() {
           },
         }}
         utilities={[
+          ...[
+            versions && {
+                type: 'button',
+                disabled: true,
+                iconName: statusIcon(stackStatus),
+                title: "Stack status"
+            }
+          ],
+          ...[
+            versions && currentVersion && (
+                stackStatus.split("_").slice(-1)[0] == "COMPLETE" || finishedStates.has(stackStatus)
+            )
+                ? {
+                    type: 'menu-dropdown',
+                    text: (
+                        <span style={{fontWeight: 'normal'}}>{currentVersion}</span>
+                    ),
+                    onItemClick: selectVersion,
+                    items: versionsToDropdownItems(versions, currentVersion),
+                  }
+                : {
+                    type: 'button',
+                    disabled: true,
+                    text: (
+                        <span style={{fontWeight: 'normal', cursor: 'not-allowed'}}>upgrading...</span>
+                    ),
+                }
+          ]
+          ,
           ...[
             username
               ? {

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -692,6 +692,63 @@ function GetVersion() {
     })
 }
 
+function GetPCUIVersions(callback?: Callback) {
+  var url = `manager/get_pcui_versions`
+  request('get', url)
+    .then((response: any) => {
+      if (response.status === 200) {
+        console.log('pcui_versions', response.data)
+        callback && callback(response.data)
+        setState(['app', 'pcui_versions'], response.data)
+      }
+    })
+    .catch((error: any) => {
+      if (error.response) {
+        console.log(error.response)
+        notify(`Error: ${error.response.data.message}`, 'error')
+      }
+      console.log(error)
+    })
+}
+
+function GetStackInfo(callback?: Callback) {
+  var url = `manager/get_stack_info`
+  request('get', url)
+    .then((response: any) => {
+      if (response.status === 200) {
+        console.log('stack_info', response.data)
+        callback && callback(response.data.stack_info)
+        setState(['app', 'stack_info'], response.data.stack_info)
+      }
+    })
+    .catch((error: any) => {
+      if (error.response) {
+        console.log(error.response)
+        notify(`Error: ${error.response.data.message}`, 'error')
+      }
+      console.log(error)
+    })
+}
+
+function SetPCUIVersion(version: string, callback?: Callback) {
+  var url = `manager/set_pcui_version?version=${version}`
+  console.log(url)
+  request('post', url)
+    .then((response: any) => {
+      if (response.status === 200) {
+        console.log('set_pcui_version', response.data)
+      }
+      callback && callback(response.data)
+    })
+    .catch((error: any) => {
+      if (error.response) {
+        console.log(error.response)
+        notify(`Error: ${error.response.data.message}`, 'error')
+      }
+      console.log(error)
+    })
+}
+
 function Ec2Action(instanceId: any, action: any, callback?: Callback) {
   let url = `manager/ec2_action?instance_id=${instanceId}&action=${action}`
 
@@ -891,6 +948,8 @@ async function LoadInitialState() {
     ListCustomImages()
     ListOfficialImages()
     LoadAwsConfig(region)
+    GetPCUIVersions()
+    GetStackInfo()
   })
 }
 
@@ -916,6 +975,9 @@ export {
   ListOfficialImages,
   LoadInitialState,
   Ec2Action,
+  GetPCUIVersions,
+  SetPCUIVersion,
+  GetStackInfo,
   LoadAwsConfig,
   GetDcvSession,
   QueueStatus,

--- a/infrastructure/parallelcluster-ui-cognito.yaml
+++ b/infrastructure/parallelcluster-ui-cognito.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
-Description: ParallelCluster UI Cognito User Pool
+Description: AWS ParallelCluster UI Cognito User Pool
 
 Parameters:
   AdminUserEmail:

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -1,12 +1,10 @@
+Description: 'AWS ParallelCluster UI'
+
 Parameters:
   AdminUserEmail:
     Description: Email address of administrative user to setup by default (only with new Cognito instances).
     Type: String
     Default: ''
-  PublicEcrImageUri:
-    Description: When specified, the URI of the Docker image for the Lambda of the ParallelCluster UI container
-    Type: String
-    Default: public.ecr.aws/pcm/parallelcluster-ui:2023.02
   UserPoolId:
     Description: UserPoolId of a previously deployed PCUI Cognito User Pool. Leave blank to create a new one.
     Type: String
@@ -23,14 +21,10 @@ Parameters:
     Description: Version of AWS ParallelCluster to deploy
     Type: String
     Default: 3.5.0
-  ImageBuilderVpcId:
-    Description: (Optional) Select the VPC to use for building the container images. If not selected, default VPC will be used.
+  PCUIVersion:
+    Description: Version of AWS ParallelCluster to deploy
     Type: String
-    Default: ''
-  ImageBuilderSubnetId:
-    Description: (Optional) Select the subnet to use for building the container images (public subnets only). If not selected, Subnet in the default VPC will be used.
-    Type: String
-    Default: ''
+    Default: latest
   InfrastructureBucket:
     Description: (Optional) S3 bucket where CloudFormation files are stored. Change this parameter only when testing changes made to the infrastructure itself.
     Type: String
@@ -44,10 +38,6 @@ Metadata:
         Parameters: 
           - AdminUserEmail
       - Label:
-          default: ParallelCluster UI
-        Parameters:
-          - PublicEcrImageUri
-      - Label:
           default: (Optional) External PCUI Cognito
         Parameters:
           - UserPoolId
@@ -57,11 +47,6 @@ Metadata:
           default: ParallelCluster API
         Parameters:
           - Version
-      - Label:
-          default: (Optional) ImageBuilder Custom VPC
-        Parameters:
-          - ImageBuilderVpcId
-          - ImageBuilderSubnetId
       - Label:
           default: (Debugging only) Infrastructure S3 Bucket
         Parameters:
@@ -78,10 +63,6 @@ Metadata:
         default: SNSRole ARN from a previously deployed PCUI
 
 Conditions:
-  NonDefaultVpc:
-    Fn::And:
-      - !Not [!Equals [!Ref ImageBuilderVpcId, ""]]
-      - !Not [!Equals [!Ref ImageBuilderSubnetId, ""]]
   HasDefaultInfrastructure: !Equals [!Ref InfrastructureBucket, '']
   UseExistingCognito:
     !And
@@ -89,12 +70,16 @@ Conditions:
       - !Not [!Equals [!Ref UserPoolAuthDomain, ""]]
       - !Not [!Equals [!Ref SNSRole, ""]]
   UseNewCognito:
-    !Not [ Condition: UseExistingCognito]
+    !Not [ Condition: UseExistingCognito ]
+  HasDefaultPCInfrastructure: !Equals [!FindInMap [ParallelCluster, Constants, Bucket ], '']
 
 Mappings:
   ParallelClusterUI:
     Constants:
       Version: 2023.02.0 # format YYYY.MM.REVISION
+  ParallelCluster:
+    Constants:
+      Bucket: ''  # default ParallelCluster bucket
 
 Resources:
 
@@ -106,11 +91,12 @@ Resources:
       Parameters:
         AdminUserEmail: !Ref AdminUserEmail
       TemplateURL: !Sub 
-        - '${Bucket}/parallelcluster-ui-cognito.yaml'
-        - Bucket: !If 
+        - 'https://s3.${AWS::URLSuffix}/${Bucket}/parallelcluster-ui/${PCUIVersion}/templates/parallelcluster-ui-cognito.yaml'
+        - Bucket: !If
           - HasDefaultInfrastructure
           - PLACEHOLDER
-          - !Sub ${InfrastructureBucket}
+          - !Ref InfrastructureBucket
+          PCUIVersion: !Ref PCUIVersion
 
       TimeoutInMinutes: 10
 
@@ -118,39 +104,39 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       Parameters:
-        ApiDefinitionS3Uri: !Sub s3://${AWS::Region}-aws-parallelcluster/parallelcluster/${Version}/api/ParallelCluster.openapi.yaml
+        ApiDefinitionS3Uri: !Sub
+          - s3://${Bucket}/parallelcluster/${Version}/api/ParallelCluster.openapi.yaml
+          - { Bucket: !If [ HasDefaultPCInfrastructure, !Sub "${AWS::Region}-aws-parallelcluster", !FindInMap [ParallelCluster, Constants, Bucket]]}
         CreateApiUserRole: False
         EnableIamAdminAccess: True
-        PublicEcrImageUri: !Sub public.ecr.aws/parallelcluster/pcluster-api:${Version}
-        ImageBuilderSubnetId:
-          Fn::If:
-            - NonDefaultVpc
-            - !Ref ImageBuilderSubnetId
-            - !Ref AWS::NoValue
-        ImageBuilderVpcId:
-          Fn::If:
-            - NonDefaultVpc
-            - !Ref ImageBuilderVpcId
-            - !Ref AWS::NoValue
-      TemplateURL: !Sub https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.amazonaws.com/parallelcluster/${Version}/api/parallelcluster-api.yaml
+        CustomBucket: !If
+          - HasDefaultPCInfrastructure
+          - !Sub ${AWS::Region}-aws-parallelcluster
+          - !FindInMap [ParallelCluster, Constants, Bucket ]
+        PoliciesTemplateUri: !Sub 
+          - https://${Bucket}.s3.${AWS::Region}.${AWS::URLSuffix}/parallelcluster/${Version}/templates/policies/policies.yaml
+          - { Bucket: !If [ HasDefaultPCInfrastructure, !Sub "${AWS::Region}-aws-parallelcluster", !FindInMap [ParallelCluster, Constants, Bucket]]}
+      TemplateURL: !Sub https://pcluster-cfn-${AWS::Region}.s3.${AWS::Region}.${AWS::URLSuffix}/parallelcluster/${Version}/api/parallelcluster-api.yaml
       TimeoutInMinutes: 30
 
-  SSMDefaultUser:
-    Type: AWS::CloudFormation::Stack
+  PclusterUILayer:
+    Type: AWS::Lambda::LayerVersion
     Properties:
-      TemplateURL: !Sub 
-        - '${Bucket}/SSMSessionProfile-cfn.yaml'
-        - Bucket: !If 
-          - HasDefaultInfrastructure
-          - PLACEHOLDER
-          - !Sub ${InfrastructureBucket}
-      TimeoutInMinutes: 30
+      LayerName: !Sub PCUILayer-${AWS::StackName}
+      Description: Library which contains aws-parallelcluster-ui python package and dependencies
+      Content:
+        S3Bucket: !If [ HasDefaultInfrastructure, !Sub "pcluster-cfn-${AWS::Region}",!Ref InfrastructureBucket ]
+        S3Key: !Sub
+          - parallelcluster-ui/${Version}/layers/aws-parallelcluster-ui/layer.zip
+          - { Version: !Ref PCUIVersion }
+      CompatibleRuntimes:
+        - python3.9
+
 
   ParallelClusterUIFunction:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt ParallelClusterUIUserRole.Arn
-      PackageType: Image
       MemorySize: 512
       Timeout: 30
       Tags:
@@ -160,6 +146,8 @@ Resources:
         Mode: Active
       Environment:
         Variables:
+          PYTHONUNBUFFERED: 1
+          STATIC_PATH: /opt/frontend/public/
           API_BASE_URL: !GetAtt [ ParallelClusterApi, Outputs.ParallelClusterApiInvokeUrl ]
           API_VERSION: !Ref Version
           SITE_URL: !Sub
@@ -172,13 +160,49 @@ Resources:
       FunctionName: !Sub
         - ParallelClusterUIFunction-${StackIdSuffix}
         - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
+      Handler: index.handler
+      Layers:
+        - !Ref PclusterUILayer
+      Runtime: python3.9
       Code:
-        ImageUri: !Sub
-          - ${AWS::AccountId}.dkr.ecr.${AWS::Region}.${AWS::URLSuffix}/${Repository}:${Version}
-          - Repository: !Ref PrivateEcrRepository
-            Version: !Join
-              - '-'
-              - [!Select [2, !Split ['/', !Ref EcrImage]], !Select [3, !Split ['/', !Ref EcrImage]]]
+        ZipFile: |
+          import logging
+          import os
+          from os import environ
+          from typing import Any, Dict
+
+
+          logger = logging.getLogger()
+          logger.setLevel(logging.INFO)
+
+          from awslambda.serverless_wsgi import handle_request
+          import pcui.app
+
+          # Initialize as a global to re-use across Lambda invocations
+          pcluster_ui_api = None  # pylint: disable=invalid-name
+
+          profile = environ.get("PROFILE", "prod")
+          is_dev_profile = profile == "dev"
+
+          if is_dev_profile:
+              logger.info("Running with dev profile")
+              environ["FLASK_ENV"] = "development"
+              environ["FLASK_DEBUG"] = "1"
+
+          def _init_flask_app():
+              return pcui.app.run()
+
+          def handler(event: Dict[str, Any], context) -> Dict[str, Any]:
+              try:
+                  global pcluster_ui_api  # pylint: disable=global-statement,invalid-name
+                  if not pcluster_ui_api:
+                      logger.info("Initializing Flask Application")
+                      pcluster_ui_api = _init_flask_app()
+                  os.environ["AWS_DEFAULT_REGION"] = os.environ["AWS_REGION"]
+                  return handle_request(pcluster_ui_api, event, context)
+              except Exception as e:
+                  logger.critical("Unexpected exception: %s", e, exc_info=True)
+                  raise Exception("Unexpected fatal exception. Please look at API logs for details on the encountered failure.")
 
   ApiGateway:
     Type: AWS::ApiGatewayV2::Api
@@ -378,238 +402,6 @@ Resources:
                   - secretsmanager:DeleteSecret
                 Resource:
                   - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${AWS::StackName}*
-
-  PrivateEcrRepository:
-    DependsOn: ParallelClusterApi
-    Type: AWS::ECR::Repository
-    Properties:
-      RepositoryName: !Sub
-        - 'parallelcluster-ui-${StackIdSuffix}'
-        - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
-
-  ImageBuilderInstanceRole:
-    Type: AWS::IAM::Role
-    Properties:
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action:
-              - sts:AssumeRole
-            Effect: Allow
-            Principal:
-              Service:
-                - !Sub ec2.${AWS::URLSuffix}
-        Version: '2012-10-17'
-      Path: /executionServiceEC2Role/
-
-  ImageBuilderInstanceProfile:
-    Type: AWS::IAM::InstanceProfile
-    Properties:
-      Path: /executionServiceEC2Role/
-      Roles:
-        - !Ref ImageBuilderInstanceRole
-
-  InfrastructureConfigurationSecurityGroup:
-    Condition: NonDefaultVpc
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      VpcId: !Ref ImageBuilderVpcId
-      GroupDescription: Parallel cluster image builder security group
-
-  InfrastructureConfiguration:
-    Type: AWS::ImageBuilder::InfrastructureConfiguration
-    Properties:
-      Name: !Sub
-        - ParallelClusterUIImageBuilderInfrastructureConfiguration-${Version}-${StackIdSuffix}
-        - { Version: !Join ['_', !Split ['.', !FindInMap [ParallelClusterUI, Constants, Version]]], StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
-      InstanceProfileName: !Ref ImageBuilderInstanceProfile
-      TerminateInstanceOnFailure: true
-      SubnetId:
-        Fn::If:
-          - NonDefaultVpc
-          - !Ref ImageBuilderSubnetId
-          - !Ref AWS::NoValue
-      SecurityGroupIds:
-        Fn::If:
-          - NonDefaultVpc
-          - [!Ref InfrastructureConfigurationSecurityGroup]
-          - !Ref AWS::NoValue
-      InstanceMetadataOptions:
-        HttpTokens: required
-
-  EcrImageRecipe:
-    Type: AWS::ImageBuilder::ContainerRecipe
-    Properties:
-      Components:
-        - ComponentArn: !Sub arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:component/update-linux/x.x.x
-      ContainerType: DOCKER
-      Name: !Sub
-        - 'parallelcluster-ui-${Version}-${StackIdSuffix}'
-        - { Version: !Join ['_', !Split ['.', !FindInMap [ParallelClusterUI, Constants, Version]]], StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
-      Version: !FindInMap [ParallelClusterUI, Constants, Version]
-      ParentImage: !Ref PublicEcrImageUri
-      PlatformOverride: Linux
-      TargetRepository:
-        Service: ECR
-        RepositoryName: !Ref PrivateEcrRepository
-      DockerfileTemplateData: 'FROM {{{ imagebuilder:parentImage }}}'
-      WorkingDirectory: '/tmp'
-
-  EcrImage:
-    Type: AWS::ImageBuilder::Image
-    Properties:
-      ContainerRecipeArn: !Ref EcrImageRecipe
-      EnhancedImageMetadataEnabled: true
-      InfrastructureConfigurationArn: !Ref InfrastructureConfiguration
-      ImageTestsConfiguration:
-        ImageTestsEnabled: false
-
-  EcrImagePipeline:
-    Type: AWS::ImageBuilder::ImagePipeline
-    Properties:
-      Name: !Sub
-        - 'EcrImagePipeline-${Version}-${StackIdSuffix}'
-        - { Version: !Join ['_', !Split ['.', !FindInMap [ParallelClusterUI, Constants, Version]]], StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
-      Status: ENABLED
-      ContainerRecipeArn: !Ref EcrImageRecipe
-      InfrastructureConfigurationArn: !Ref InfrastructureConfiguration
-      ImageTestsConfiguration:
-        ImageTestsEnabled: false
-
-  EcrImageDeletionLambda:
-    Type: AWS::Lambda::Function
-    Properties:
-      MemorySize: 128
-      Code:
-        ZipFile: |
-          import cfnresponse
-          import boto3
-          import random
-          import string
-
-          ecr = boto3.client('ecr')
-          imagebuilder = boto3.client('imagebuilder')
-
-          def get_image_ids(repository_name, version):
-              image_digests = set()
-              paginator = ecr.get_paginator('list_images')
-              response_iterator = paginator.paginate(repositoryName=repository_name, filter={'tagStatus': 'TAGGED'})
-              for response in response_iterator:
-                  image_digests.update([image_id['imageDigest'] for image_id in response['imageIds']])
-              return list({'imageDigest': image_digest} for image_digest in image_digests)
-
-          def get_imagebuilder_images(ecr_image_pipeline_arn):
-              response = imagebuilder.list_image_pipeline_images(imagePipelineArn=ecr_image_pipeline_arn)
-              images = [image['arn'] for image in response['imageSummaryList']]
-              while 'nextToken' in response:
-                  response = imagebuilder.list_image_pipeline_images(imagePipelineArn=ecr_image_pipeline_arn, nextToken=response['nextToken'])
-                  images.extend([image['arn'] for image in response['imageSummaryList']])
-              return images
-
-          def create_physical_resource_id():
-              alnum = string.ascii_uppercase + string.ascii_lowercase + string.digits
-              return ''.join(random.choice(alnum) for _ in range(16))
-
-          def handler(event, context):
-              print(event)
-              print('boto version {}'.format(boto3.__version__))
-
-              response_data = {}
-              reason = None
-              response_status = cfnresponse.SUCCESS
-
-              if event['RequestType'] == 'Create':
-                  response_data['Message'] = 'Resource creation successful!'
-                  physical_resource_id = create_physical_resource_id()
-              else:
-                  physical_resource_id = event['PhysicalResourceId']
-
-              if event['RequestType'] == 'Update' or event['RequestType'] == 'Delete':
-                  try:
-                      resource_key = 'OldResourceProperties' if 'OldResourceProperties' in event else 'ResourceProperties'
-                      ecr_repository_name = event[resource_key]['EcrRepositoryName']
-                      ecr_image_pipeline_arn = event[resource_key]['EcrImagePipelineArn']
-                      version = event[resource_key]['Version']
-
-                      image_ids = get_image_ids(ecr_repository_name, version)
-                      if image_ids:
-                          ecr.batch_delete_image(repositoryName=ecr_repository_name, imageIds=image_ids)
-                          reason = 'Image deletion successful!'
-                      else:
-                          reason = 'No image found, considering image deletion successful'
-
-                      for imagebuilder_image in get_imagebuilder_images(ecr_image_pipeline_arn):
-                          imagebuilder.delete_image(imageBuildVersionArn=imagebuilder_image)
-
-                  except ecr.exceptions.RepositoryNotFoundException:
-                      reason = 'Repository was not found, considering image deletion successfull'
-                  except Exception as exception:
-                      response_status = cfnresponse.FAILED
-                      reason = 'Failed image deletion with error: {}'.format(exception)
-
-              cfnresponse.send(event, context, response_status, response_data, physical_resource_id, reason)
-
-      Handler: index.handler
-      Runtime: python3.7
-      Role: !GetAtt EcrImageDeletionLambdaRole.Arn
-
-  EcrImageDeletionLambdaLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub /aws/lambda/${EcrImageDeletionLambda}
-
-  EcrImageDeletionLambdaRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
-            Action:
-              - 'sts:AssumeRole'
-      Policies:
-        - PolicyName: LoggingPolicy
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
-                Resource: !Sub arn:${AWS::Partition}:logs:*:*:*
-        - PolicyName: BatchDeletePolicy
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              - Effect: Allow
-                Action:
-                  - ecr:BatchDeleteImage
-                  - ecr:ListImages
-                Resource: !GetAtt PrivateEcrRepository.Arn
-              - Effect: Allow
-                Action:
-                  - imagebuilder:ListImagePipelineImages
-                Resource: !Sub
-                  - arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image-pipeline/ecrimagepipeline-*${StackIdSuffix}*
-                  - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
-              - Effect: Allow
-                Action:
-                  - imagebuilder:DeleteImage
-                Resource: !Sub
-                  - arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/*${StackIdSuffix}*
-                  - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
-
-  EcrImagesRemover:
-    Type: Custom::EcrImagesRemover
-    Properties:
-      ServiceToken: !GetAtt EcrImageDeletionLambda.Arn
-      EcrRepositoryName: !Ref PrivateEcrRepository
-      Version: !FindInMap [ParallelClusterUI, Constants, Version]
-      EcrImagePipelineArn: !GetAtt EcrImagePipeline.Arn
 
   ParallelClusterUILambdaLogGroup:
     Type: AWS::Logs::LogGroup

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -423,16 +423,12 @@ Resources:
         # Required for Lambda logging and XRay
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSXRayDaemonWriteAccess
         - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-        # Access to the ParllelCluster API
-        - !Ref ParallelClusterApiGatewayInvoke
         # Required to run ParallelClusterUI functionalities
         - !Ref CognitoPolicy
-        - !Ref EC2Policy
-        - !Ref DescribeFsxPolicy
-        - !Ref DescribeEfsPolicy
+        - !Ref StoragePolicy
         - !Ref PricingPolicy
-        - !Ref SsmSendPolicy
-        - !Ref SsmGetCommandInvocationPolicy
+        - !Ref SsmPolicy
+        - !Ref InfrastructurePolicy
 
 
   ParallelClusterUIApiGatewayInvoke:
@@ -445,18 +441,6 @@ Resources:
         - arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${ApiGateway}/*
         - { ApiGateway: !Ref ApiGateway }
 
-  ParallelClusterApiGatewayInvoke:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Action:
-              - execute-api:Invoke
-            Effect: Allow
-            Resource: !Sub
-              - arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PCApiGateway}/*/*
-              - { PCApiGateway: !Select [2, !Split ['/', !Select [0, !Split ['.', !GetAtt [ ParallelClusterApi, Outputs.ParallelClusterApiInvokeUrl ]]]]] }
 
   CognitoPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -483,7 +467,7 @@ Resources:
             Effect: Allow
             Sid: SecretsRole
 
-  EC2Policy:
+  StoragePolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
@@ -509,13 +493,6 @@ Resources:
                 ec2:ResourceTag/parallelcluster:version: "*"
             Effect: Allow
             Sid: EC2ManagePolicy
-
-  DescribeFsxPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
           - Action:
               - fsx:DescribeFileSystems
               - fsx:DescribeVolumes
@@ -524,19 +501,26 @@ Resources:
               - !Sub arn:${AWS::Partition}:fsx:*:${AWS::AccountId}:file-system/*
             Effect: Allow
             Sid: FsxPolicy
-
-  DescribeEfsPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
           - Action:
               - elasticfilesystem:DescribeFileSystems
             Resource:
               - !Sub arn:${AWS::Partition}:elasticfilesystem:*:${AWS::AccountId}:file-system/*
             Effect: Allow
             Sid: EfsPolicy
+
+  InfrastructurePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - execute-api:Invoke
+            Effect: Allow
+            Resource: !Sub
+              - arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PCApiGateway}/*/*
+              - { PCApiGateway: !Select [2, !Split ['/', !Select [0, !Split ['.', !GetAtt [ ParallelClusterApi, Outputs.ParallelClusterApiInvokeUrl ]]]]] }
+            Sid: InfrastructureAPIProxyPolicy
 
   PricingPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -551,7 +535,7 @@ Resources:
             Effect: Allow
             Sid: PricingPolicy
 
-  SsmSendPolicy:
+  SsmPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
@@ -572,13 +556,6 @@ Resources:
               - !Sub arn:${AWS::Partition}:ssm:*::document/AWS-RunShellScript
             Effect: Allow
             Sid: SsmSendPolicyCommand
-
-  SsmGetCommandInvocationPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
           - Action:
             - ssm:GetCommandInvocation
             Resource:

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -148,6 +148,9 @@ Resources:
         Variables:
           PYTHONUNBUFFERED: 1
           STATIC_PATH: /opt/frontend/public/
+          BUCKET: !Ref InfrastructureBucket
+          PCUI_STACK_ID: !Ref AWS::StackId
+          PCUI_VERSION: !Ref PCUIVersion
           API_BASE_URL: !GetAtt [ ParallelClusterApi, Outputs.ParallelClusterApiInvokeUrl ]
           API_VERSION: !Ref Version
           SITE_URL: !Sub
@@ -515,12 +518,73 @@ Resources:
         Version: '2012-10-17'
         Statement:
           - Action:
+              - cloudformation:DescribeStacks
+              - cloudformation:UpdateStack
+              - cloudformation:CreateChangeSet
+            Resource:
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/Include
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/Serverless-2016-10-31
+            Effect: Allow
+            Sid: InfrastructureCloudFormationPolicy
+          - Action:
+              - lambda:PublishLayerVersion
+              - lambda:GetLayerVersion
+              - lambda:DeleteLayerVersion
+            Resource:
+              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:PCUILayer-${AWS::StackName}*
+            Effect: Allow
+            Sid: InfrastructureLambdaLayerPolicy
+          - Action:
+              - lambda:UpdateFunctionConfiguration
+              - lambda:UpdateFunctionCode
+              - lambda:ListTags
+            Resource:
+              - !Sub
+                - arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:ParallelClusterUIFunction-${StackIdSuffix}*
+                - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
+            Effect: Allow
+            Sid: InfrastructureLambdaPolicy
+          - Action:
+              - s3:ListBucket
+              - s3:GetBucketLocation
+            Resource:
+              - !Sub arn:${AWS::Partition}:s3:::${InfrastructureBucket}
+            Condition: {"StringLike":{"s3:prefix":["parallelcluster-ui/*"]}}
+            Effect: Allow
+            Sid: InfrastructureS3Policy
+          - Action:
+              - s3:GetObject
+            Resource:
+              - !Sub arn:${AWS::Partition}:s3:::${InfrastructureBucket}/parallelcluster-ui/*
+              - !Sub arn:${AWS::Partition}:s3:::${InfrastructureBucket}/parallelcluster/*
+              - !Sub arn:${AWS::Partition}:s3:::${AWS::Region}-aws-parallelcluster/parallelcluster/*
+            Effect: Allow
+            Sid: InfrastructureS3LayerPolicy
+          - Action:
               - execute-api:Invoke
             Effect: Allow
             Resource: !Sub
               - arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${PCApiGateway}/*/*
               - { PCApiGateway: !Select [2, !Split ['/', !Select [0, !Split ['.', !GetAtt [ ParallelClusterApi, Outputs.ParallelClusterApiInvokeUrl ]]]]] }
             Sid: InfrastructureAPIProxyPolicy
+          - Action:
+              - iam:GetRole
+              - iam:GetRolePolicy
+              - iam:GetPolicy
+              - iam:SimulatePrincipalPolicy
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/*
+              - !Sub arn:${AWS::Partition}:iam::aws:policy/*
+            Effect: Allow
+            Sid: InfrastructureIamRead
+          - Action:
+              - iam:PassRole
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${AWS::StackName}-ParallelClusterUIUserRole-*
+            Effect: Allow
+            Sid: InfrastructureIamPassRole
 
   PricingPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/scripts/bucket_policy.json.templ
+++ b/scripts/bucket_policy.json.templ
@@ -1,0 +1,20 @@
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowPublicRead",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": [
+                "s3:GetObject",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${bucket}/parallelcluster-ui/*",
+                "arn:aws:s3:::${bucket}"
+            ]
+        }
+    ]
+}

--- a/scripts/build_layer.sh
+++ b/scripts/build_layer.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -e
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Determine container runtime, preferring finch
+container_runtime=docker
+if command -v finch &> /dev/null
+then
+    container_runtime="finch"
+fi
+echo "Using ${container_runtime} as container runtime."
+
+# build front-end
+pushd frontend
+if [ ! -d node_modules ]; then
+  npm install
+fi
+${container_runtime} build --build-arg PUBLIC_URL=/ -t frontend .
+popd
+
+# build the lambda build environment runtime
+echo "Building Lambda layer runtime..."
+lambdalayer=lambda_build
+${container_runtime} build -f Dockerfile.lambdalayer -t ${lambdalayer} .
+
+echo "Creating Lambda archive..."
+# For some reason the container runtime doesn't like this type of temporary directory...
+# output=$(mktemp -d 2>/dev/null || mktemp -d -t 'output')
+output=${dir}/output
+mkdir -p ${output}
+${container_runtime} run -t -v ${output}:/output/ --rm ${lambdalayer}
+cp ${output}/layer.zip ${dir}/layer.zip
+rm -fr ${output}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+usage="$(basename "$0") [-h] [--version version] [--overwrite true|false] [--regions \"space_separated_regions\"] [--bucket bucket] [--pcbucket bucket]"
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+version=latest
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -h)
+    echo "$usage" >&2
+    exit 1
+    ;;
+    --version)
+    export version=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --overwrite)
+    export overwrite=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --pcbucket)
+    export pcbucket=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --bucket)
+    export bucket=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --regions)
+    export regions=$2
+    shift # past argument
+    shift # past value
+    ;;
+    *)    # unknown option
+    echo "$usage" >&2
+    exit 1
+    ;;
+esac
+done
+
+create_bucket() {
+    bucket=$1
+    region=$2
+    echo "Creating bucket: ${bucket} in region ${region}"
+    if [ ! "${region}" == "us-east-1" ]; then
+        aws s3api create-bucket --bucket ${bucket} --region ${region} --create-bucket-configuration LocationConstraint=${region}
+    else
+        aws s3api create-bucket --bucket ${bucket} --region ${region}
+    fi
+
+    policy_file=$(mktemp /tmp/bucket_policy.XXXXXX).json
+    (export bucket=$bucket; cat ${dir}/bucket_policy.json.templ | envsubst > ${policy_file})
+    aws s3api put-bucket-policy  --bucket ${bucket} --policy file://${policy_file} --region ${region}
+    rm ${policy_file}
+}
+
+if [ ! -e ${dir}/layer.zip ] || [ "${overwrite}" == "true" ]; then
+    ${dir}/build_layer.sh
+fi
+
+if [ -z "${regions}" ]; then
+    regions=( $(aws ec2 describe-regions --query "Regions[*].RegionName" --output text) )
+else
+    regions=( ${regions} )
+fi
+
+for region in "${regions[@]}"
+do
+    regional_bucket=$(export region=${region}; echo $bucket | envsubst)
+    bucket_arg="--bucket $regional_bucket"
+
+    if [ ! -z "${pcbucket}" ]; then
+        pcbucket_arg=$(export region=${region}; echo --pcbucket $pcbucket | envsubst)
+    fi
+
+    if ! aws s3api head-bucket --bucket "$regional_bucket" 2>/dev/null; then
+        create_bucket ${regional_bucket} ${region}
+    else
+        echo "arn:aws:s3:::${regional_bucket}"
+    fi
+    ${dir}/upload.sh --region ${region} ${bucket_arg} ${pcbucket_arg} --public true --version ${version} --overwrite true
+done

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+usage="$(basename "$0") [-h] --version version --stack-name stack-name [--email email] [--region region] [--prefix prefix] [--suffix suffix] [--cognito-stack-id stack-id]"
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+version=latest
+stack_name=${PCUI_STACK_ID}
+pc_version=3.6.0
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -h)
+    echo "$usage" >&2
+    exit 1
+    ;;
+    --version)
+    export version=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --email)
+    export email=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --stack-name)
+    export stack_name=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --cognito-stack-id)
+    export cognito_stack_id=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --bucket)
+    export bucket=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --region)
+    export AWS_DEFAULT_REGION=$2
+    shift # past argument
+    shift # past value
+    ;;
+    *)    # unknown option
+    echo "$usage" >&2
+    exit 1
+    ;;
+esac
+done
+
+
+random-string() {
+    if [[ $OSTYPE == 'darwin'* ]]; then
+        echo $RANDOM | md5 | head -c 5; echo;
+    else
+        echo $RANDOM | md5sum | head -c 5; echo;
+    fi
+}
+
+update_stack(){
+    if [ ! -z "${bucket}" ]; then
+        regional_bucket=$(export region=${AWS_DEFAULT_REGION}; echo $bucket | envsubst)
+    fi
+    regional_bucket=$(export region=${AWS_DEFAULT_REGION}; echo $bucket | envsubst)
+
+    if [ ! -z "${cognito_stack_id}" ]; then
+        cognito_params="
+                  ParameterKey=SNSRole,UsePreviousValue=true \
+                  ParameterKey=UserPoolAuthDomain,UsePreviousValue=true \
+                  ParameterKey=UserPoolId,UsePreviousValue=true"
+    fi
+    aws cloudformation update-stack --stack-name ${stack_name} \
+                  --template-url="https://${regional_bucket}.s3.us-east-2.amazonaws.com/parallelcluster-ui/${version}/templates/parallelcluster-ui.yaml" \
+                  --parameters ParameterKey=InfrastructureBucket,UsePreviousValue=true \
+                  ParameterKey=AdminUserEmail,UsePreviousValue=true \
+                  ParameterKey=Version,UsePreviousValue=true \
+                  ParameterKey=PCUIVersion,ParameterValue=${version} \
+                  ${cognito_params} \
+                  --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND
+}
+
+create_stack(){
+    if [ -z "${email}" ]; then
+        echo "You must specify an email address to create a new PCUI stack."
+        echo "$usage" >&2
+        exit 1
+    fi
+
+    stack_name=$(echo "pcui"-`random-string`)
+
+    if [ ! -z "${bucket}" ]; then
+        regional_bucket=$(export region=${AWS_DEFAULT_REGION}; echo $bucket | envsubst)
+        bucket_arg="ParameterKey=InfrastructureBucket,ParameterValue=${regional_bucket}"
+    fi
+    url="https://${regional_bucket}.s3.us-east-2.amazonaws.com/parallelcluster-ui/${version}/templates/parallelcluster-ui.yaml"
+
+    if [ ! -z "${cognito_stack_id}" ]; then
+        cognito_params=$(aws cloudformation describe-stacks \
+            --stack-name ${cognito_stack_id} \
+            --query "Stacks|[0].Outputs[*].[OutputKey,'=',OutputValue]" \
+            --output text | sed -e"s/\([a-zA-Z]*\)[^=]*=[^a-z]*\(.*\)/ParameterKey=\1,ParameterValue=\2 /g" | xargs echo)
+    fi
+
+    aws cloudformation create-stack \
+        --stack-name ${stack_name} \
+        --parameters ${bucket_arg} \
+                     ParameterKey=AdminUserEmail,ParameterValue=${email} \
+                     ParameterKey=Version,ParameterValue=${pc_version} \
+                     ParameterKey=PCUIVersion,ParameterValue=${version} \
+                     ${cognito_params} \
+        --template-url ${url} \
+        --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND
+}
+
+if [ -z ${stack_name} ]; then
+    create_stack
+else
+    update_stack
+fi

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -1,0 +1,120 @@
+#!/bin/bash -e
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+usage="$(basename "$0") [-h] --bucket bucket [--region region] [--version version] [--public true|false] [--overwrite true|false])"
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+version=latest
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -h)
+    echo "$usage" >&2
+    exit 1
+    ;;
+    --region)
+    export region=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --bucket)
+    bucket=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --pcbucket)
+    pcbucket=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --public)
+    export public=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --overwrite)
+    export overwrite=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --version)
+    export version=$2
+    shift # past argument
+    shift # past value
+    ;;
+    *)    # unknown option
+    echo "$usage" >&2
+    exit 1
+    ;;
+esac
+done
+
+if [ -z "${bucket}" ] ; then
+    echo "$usage" >&2
+    exit 1
+fi
+
+if [ "${public}" == "true" ]; then
+    echo "Uploading for public read access."
+    acl="--acl public-read"
+else
+    acl=""
+fi
+
+
+key="parallelcluster-ui/${version}/layers/aws-parallelcluster-ui/layer.zip"
+if ! aws s3api head-object --bucket ${bucket} --key ${key} 2>1 > /dev/null || [ "${overwrite}" == "true" ]; then
+    if [ "${region}" == "us-east-1" ]; then
+        aws s3 cp ${acl} ${dir}/layer.zip s3://${bucket}/${key}
+    else
+        aws s3 cp ${acl} ${dir}/layer.zip s3://${bucket}/${key} --region $region
+    fi
+fi
+
+s3_upload() {
+    src=$1
+    bucket=$2
+    key=$3
+
+    if ! aws s3api head-object --bucket ${bucket} --key ${key} > /dev/null 2>1 || [ "${overwrite}" == "true" ] ; then
+        if [ "${region}" == "us-east-1" ]; then
+            aws s3 cp ${acl} ${src} s3://${bucket}/${key}
+        else
+            aws s3 cp ${acl} ${src} s3://${bucket}/${key} --region $region
+        fi
+    fi
+}
+
+# loop over each of the known stacks and upload them
+stacks=( "${dir}/../infrastructure/parallelcluster-ui.yaml"
+         "${dir}/../infrastructure/parallelcluster-ui-cognito.yaml" )
+for stack in "${stacks[@]}"
+do
+    stack_file=$(basename ${stack})
+    if [ "${stack_file}" == "parallelcluster-ui.yaml" ]; then
+        key="parallelcluster-ui/${version}/templates/parallelcluster-ui.yaml"
+        if [ ! -z "${pcbucket}" ]; then
+            temp_stack_file=$(mktemp /tmp/parallelcluster-ui.XXXXXX).yaml
+            cat ${stack} | \
+                sed "s/Bucket: ''.*\( #.*ParallelCluster bucket.*\)/Bucket: \"${pcbucket}\"\1/" \
+                > ${temp_stack_file}
+            s3_upload ${temp_stack_file} ${bucket} ${key}
+            rm ${temp_stack_file}
+            continue
+        fi
+    elif [ "${stack_file}" == "parallelcluster-ui-cognito.yaml" ]; then
+        key="parallelcluster-ui/${version}/templates/parallelcluster-ui-cognito.yaml"
+    else
+        echo "Unknown stack file: ${stack_file}"
+        exit -1
+    fi
+    s3_upload ${stack} ${bucket} ${key}
+done


### PR DESCRIPTION

## Description

- Switch from using image-builder and a docker container into using a lambda layer to provide the API infrastructure
- Add support for retrieving the version list and upgrading inline

## Changes

- Use `isort` on imports for files changed
- Add the lambda layer infrastructure and scripts for deployment
- Consolidate policies in infrastructure stack as there is a limit of 10
- Add backend/frontend changes to set the current version

## How Has This Been Tested?

- deploying 2 versions (as well as PC infrastructure files) to a custom bucket
- creating a PCUI stack using one of those versions
- use PCUI to select the second version

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
