### PR TITLE
Adjust the layout of some wizard components

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -1096,8 +1096,8 @@
         },
         "addArgument": "Add argument",
         "argument": {
-          "label": "Argument",
-          "placeholder": "argument"
+          "label": "Arguments",
+          "placeholder": "Argument"
         }
       }
     }

--- a/frontend/src/old-pages/Configure/Components.module.css
+++ b/frontend/src/old-pages/Configure/Components.module.css
@@ -1,5 +1,0 @@
-.spaceBetweenCentered {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing);
-}

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -17,7 +17,7 @@ import React, {
   useMemo,
   useState as useStateReact,
 } from 'react'
-import {Trans, useTranslation} from 'react-i18next'
+import {useTranslation} from 'react-i18next'
 import {useSelector} from 'react-redux'
 import {findFirst} from '../../util'
 
@@ -40,13 +40,12 @@ import {
   Input,
   SpaceBetween,
   Checkbox,
-  TokenGroup,
   Select,
   InputProps,
-  TextContent,
   CheckboxProps,
   Multiselect,
   MultiselectProps,
+  ColumnLayout,
 } from '@cloudscape-design/components'
 
 // Components
@@ -346,11 +345,7 @@ function ArgEditor({path, i}: any) {
   }
 
   return (
-    <div
-      className={styles.spaceBetweenCentered}
-      style={{'--spacing': spaceScaledXs}}
-    >
-      <span>{t('wizard.components.actionsEditor.argument.label')}</span>
+    <ColumnLayout columns={2}>
       <Input
         value={arg}
         onChange={({detail}) => {
@@ -359,7 +354,7 @@ function ArgEditor({path, i}: any) {
         placeholder={t('wizard.components.actionsEditor.argument.placeholder')}
       />
       <Button onClick={remove}>{t('wizard.actions.remove')}</Button>
-    </div>
+    </ColumnLayout>
   )
 }
 
@@ -399,10 +394,7 @@ function ActionEditor({
       </Checkbox>
       {enabled ? (
         <>
-          <div
-            className={styles.spaceBetweenCentered}
-            style={{'--spacing': spaceScaledXs}}
-          >
+          <ColumnLayout columns={2}>
             <FormField errorText={error}>
               <Input
                 placeholder="/home/ec2-user/start.sh"
@@ -415,17 +407,23 @@ function ActionEditor({
             <Button onClick={() => addArg([...path, 'Args'])}>
               {t('wizard.components.actionsEditor.addArgument')}
             </Button>
-          </div>
-          <SpaceBetween direction="vertical" size="xs">
-            {args.map((a: any, i: any) => (
-              <ArgEditor
-                key={`osa${i}`}
-                arg={a}
-                i={i}
-                path={[...path, 'Args']}
+          </ColumnLayout>
+          {args.length > 0 ? (
+            <SpaceBetween direction="vertical" size="xs">
+              {/* The title is stiled as an empty FormField because the shortest heading is an h3, too big for this case */}
+              <FormField
+                label={t('wizard.components.actionsEditor.argument.label')}
               />
-            ))}
-          </SpaceBetween>
+              {args.map((a: any, i: any) => (
+                <ArgEditor
+                  key={`osa${i}`}
+                  arg={a}
+                  i={i}
+                  path={[...path, 'Args']}
+                />
+              ))}
+            </SpaceBetween>
+          ) : null}
         </>
       ) : null}
     </SpaceBetween>

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -60,9 +60,6 @@ import {
   InstanceTypeOption,
 } from './Components.types'
 
-import styles from './Components.module.css'
-import {spaceScaledXs} from '@cloudscape-design/design-tokens'
-
 // Helper Functions
 function strToOption(str: any) {
   return {value: str, label: str}

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -491,18 +491,17 @@ function HeadNode() {
         }
       >
         <SpaceBetween direction="vertical" size="s">
-          <Box>
-            <FormField
-              label={t('wizard.headNode.networking.subnetId.label')}
-              errorText={subnetErrors}
-              description={t('wizard.headNode.networking.subnetId.description')}
-            ></FormField>
+          <FormField
+            label={t('wizard.headNode.networking.subnetId.label')}
+            errorText={subnetErrors}
+            description={t('wizard.headNode.networking.subnetId.description')}
+          >
             <SubnetSelect
               disabled={editing}
               value={subnetValue}
               onChange={(subnetId: any) => setState(subnetPath, subnetId)}
             />
-          </Box>
+          </FormField>
         </SpaceBetween>
       </Container>
 

--- a/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
@@ -8,6 +8,7 @@ import {
   MultiselectProps,
   Checkbox,
   SpaceBetween,
+  Header,
 } from '@cloudscape-design/components'
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
 import {useCallback, useEffect, useMemo} from 'react'
@@ -201,110 +202,103 @@ export function ComputeResource({
     )
 
   return (
-    <div className="compute-resource">
-      <div style={{display: 'flex', flexDirection: 'column', gap: '10px'}}>
-        <ColumnLayout columns={2}>
-          <h3>
-            {t('wizard.queues.computeResource.name', {
-              index: index + 1,
-              crName: computeResource.Name,
-            })}
-          </h3>
-          <Box margin={{top: 'xs'}} textAlign="right">
-            {index > 0 && (
-              <Button onClick={remove}>
-                {t(
-                  'wizard.queues.computeResource.removeComputeResourceButton.label',
-                )}
-              </Button>
-            )}
-          </Box>
-        </ColumnLayout>
-        <ColumnLayout columns={2}>
-          <div style={{display: 'flex', flexDirection: 'row', gap: '20px'}}>
-            <FormField label={t('wizard.queues.computeResource.staticNodes')}>
-              <Input
-                value={computeResource.MinCount || 0}
-                type="number"
-                onChange={({detail}) => setMinCount(parseInt(detail.value))}
-              />
-            </FormField>
-            <FormField label={t('wizard.queues.computeResource.dynamicNodes')}>
-              <Input
-                value={Math.max(
-                  (computeResource.MaxCount || 0) -
-                    (computeResource.MinCount || 0),
-                  0,
-                ).toString()}
-                type="number"
-                onChange={({detail}) => setMaxCount(parseInt(detail.value))}
-              />
-            </FormField>
-          </div>
-          <FormField
-            label={t('wizard.queues.computeResource.instanceType.label')}
-            errorText={typeError}
-          >
-            <Multiselect
-              selectedOptions={instances.map(instance => ({
-                value: instance.InstanceType,
-                label: instance.InstanceType,
-              }))}
-              placeholder={t(
-                'wizard.queues.computeResource.instanceType.placeholder.multiple',
+    <SpaceBetween direction="vertical" size="s">
+      <Header
+        variant="h3"
+        actions={
+          index > 0 && (
+            <Button onClick={remove}>
+              {t(
+                'wizard.queues.computeResource.removeComputeResourceButton.label',
               )}
-              tokenLimit={3}
-              onChange={setInstances}
-              options={instanceOptions}
-              filteringType="auto"
+            </Button>
+          )
+        }
+      >
+        {t('wizard.queues.computeResource.name', {
+          index: index + 1,
+          crName: computeResource.Name,
+        })}
+      </Header>
+      <ColumnLayout columns={2}>
+        <SpaceBetween direction="horizontal" size="l">
+          <FormField label={t('wizard.queues.computeResource.staticNodes')}>
+            <Input
+              value={computeResource.MinCount || 0}
+              type="number"
+              onChange={({detail}) => setMinCount(parseInt(detail.value))}
             />
           </FormField>
-          {enableMemoryBasedScheduling && (
-            <HelpTextInput
-              name={t('wizard.queues.schedulableMemory.name')}
-              path={path}
-              errorsPath={errorsPath}
-              configKey={'SchedulableMemory'}
-              onChange={({detail}) =>
-                setSchedulableMemory(
-                  [...path, 'SchedulableMemory'],
-                  detail.value,
-                )
-              }
-              description={t('wizard.queues.schedulableMemory.description')}
-              placeholder={t('wizard.queues.schedulableMemory.placeholder')}
-              help={t('wizard.queues.schedulableMemory.help')}
+          <FormField label={t('wizard.queues.computeResource.dynamicNodes')}>
+            <Input
+              value={Math.max(
+                (computeResource.MaxCount || 0) -
+                  (computeResource.MinCount || 0),
+                0,
+              ).toString()}
               type="number"
+              onChange={({detail}) => setMaxCount(parseInt(detail.value))}
             />
-          )}
-        </ColumnLayout>
-        <SpaceBetween direction="vertical" size="s">
-          <Checkbox
-            checked={multithreadingDisabled}
-            disabled={hpcInstanceSelected}
-            onChange={_e => {
-              setDisableHT(!multithreadingDisabled)
-            }}
-            description={t(
-              'wizard.queues.computeResource.disableHT.description',
-            )}
-          >
-            <Trans i18nKey="wizard.queues.computeResource.disableHT.label" />
-          </Checkbox>
-          <Checkbox
-            disabled={
-              !allInstancesSupportEFA(instances, efaInstances) || !canUseEFA
-            }
-            checked={enableEFA}
-            onChange={_e => {
-              setEnableEFA(!enableEFA)
-            }}
-          >
-            <Trans i18nKey="wizard.queues.computeResource.enableEfa" />
-          </Checkbox>
+          </FormField>
         </SpaceBetween>
-      </div>
-    </div>
+        <FormField
+          label={t('wizard.queues.computeResource.instanceType.label')}
+          errorText={typeError}
+        >
+          <Multiselect
+            selectedOptions={instances.map(instance => ({
+              value: instance.InstanceType,
+              label: instance.InstanceType,
+            }))}
+            placeholder={t(
+              'wizard.queues.computeResource.instanceType.placeholder.multiple',
+            )}
+            tokenLimit={3}
+            onChange={setInstances}
+            options={instanceOptions}
+            filteringType="auto"
+          />
+        </FormField>
+        {enableMemoryBasedScheduling && (
+          <HelpTextInput
+            name={t('wizard.queues.schedulableMemory.name')}
+            path={path}
+            errorsPath={errorsPath}
+            configKey={'SchedulableMemory'}
+            onChange={({detail}) =>
+              setSchedulableMemory([...path, 'SchedulableMemory'], detail.value)
+            }
+            description={t('wizard.queues.schedulableMemory.description')}
+            placeholder={t('wizard.queues.schedulableMemory.placeholder')}
+            help={t('wizard.queues.schedulableMemory.help')}
+            type="number"
+          />
+        )}
+      </ColumnLayout>
+      <SpaceBetween direction="vertical" size="s">
+        <Checkbox
+          checked={multithreadingDisabled}
+          disabled={hpcInstanceSelected}
+          onChange={_e => {
+            setDisableHT(!multithreadingDisabled)
+          }}
+          description={t('wizard.queues.computeResource.disableHT.description')}
+        >
+          <Trans i18nKey="wizard.queues.computeResource.disableHT.label" />
+        </Checkbox>
+        <Checkbox
+          disabled={
+            !allInstancesSupportEFA(instances, efaInstances) || !canUseEFA
+          }
+          checked={enableEFA}
+          onChange={_e => {
+            setEnableEFA(!enableEFA)
+          }}
+        >
+          <Trans i18nKey="wizard.queues.computeResource.enableEfa" />
+        </Checkbox>
+      </SpaceBetween>
+    </SpaceBetween>
   )
 }
 

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -487,30 +487,28 @@ function Queue({index}: any) {
         >
           <SpaceBetween direction="vertical" size="s">
             <ColumnLayout borders="horizontal">
-              <SpaceBetween direction="vertical" size="xs">
-                <Box margin={{bottom: 'xs'}}>
-                  <SpaceBetween direction="horizontal" size="xs">
-                    <FormField
-                      label={t('wizard.queues.name.label')}
-                      errorText={nameError}
-                    >
-                      <Input
-                        value={queue.Name}
-                        placeholder={t('wizard.queues.name.placeholder')}
-                        onKeyDown={e => {
-                          if (
-                            e.detail.key === 'Enter' ||
-                            e.detail.key === 'Escape'
-                          ) {
-                            e.stopPropagation()
-                            queueValidate(index)
-                          }
-                        }}
-                        onChange={({detail}) => renameQueue(detail.value)}
-                      />
-                    </FormField>
-                  </SpaceBetween>
-                </Box>
+              <SpaceBetween direction="vertical" size="m">
+                <ColumnLayout columns={2}>
+                  <FormField
+                    label={t('wizard.queues.name.label')}
+                    errorText={nameError}
+                  >
+                    <Input
+                      value={queue.Name}
+                      placeholder={t('wizard.queues.name.placeholder')}
+                      onKeyDown={e => {
+                        if (
+                          e.detail.key === 'Enter' ||
+                          e.detail.key === 'Escape'
+                        ) {
+                          e.stopPropagation()
+                          queueValidate(index)
+                        }
+                      }}
+                      onChange={({detail}) => renameQueue(detail.value)}
+                    />
+                  </FormField>
+                </ColumnLayout>
                 <ColumnLayout columns={2}>
                   <FormField
                     label={


### PR DESCRIPTION
## Changes

See commits tab

## How Has This Been Tested?

<img width="655" alt="Screenshot 2023-03-27 at 10 33 30" src="https://user-images.githubusercontent.com/3091286/227904668-47a9b92e-dd1d-4318-b7a5-728bb791b6e6.png">
<img width="977" alt="Screenshot 2023-03-27 at 10 34 14" src="https://user-images.githubusercontent.com/3091286/227904675-e9d8957d-97ed-4109-912b-bc8580e4fca9.png">
Compute resource before

<img width="417" alt="Screenshot 2023-03-27 at 10 45 10" src="https://user-images.githubusercontent.com/3091286/227904680-3ccb6667-8ebd-4b9c-ac87-7070f76c1023.png">
Compute resource after

<img width="435" alt="Screenshot 2023-03-27 at 11 03 34" src="https://user-images.githubusercontent.com/3091286/227904684-4e17afd4-5f32-410c-a0c8-e0d676e6a363.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
