### PR TITLE
Don't set PerUnitStorageThroughput on SCRATCH FSx

### DIFF
--- a/frontend/src/old-pages/Configure/__tests__/storage.test.tsx
+++ b/frontend/src/old-pages/Configure/__tests__/storage.test.tsx
@@ -16,7 +16,7 @@ import {initReactI18next} from 'react-i18next'
 import mock from 'jest-mock-extended/lib/Mock'
 import {Store} from '@reduxjs/toolkit'
 import {Provider} from 'react-redux'
-import {setState} from '../../../store'
+import {setState, clearState} from '../../../store'
 import {EbsSettings, EfsSettings, FsxLustreSettings} from '../Storage'
 
 jest.mock('../../../store', () => {
@@ -26,6 +26,7 @@ jest.mock('../../../store', () => {
     __esModule: true, // Use it when dealing with esModules
     ...originalModule,
     setState: jest.fn(),
+    clearState: jest.fn(),
   }
 })
 
@@ -119,6 +120,101 @@ describe('Given a Lustre storage component', () => {
             'PerUnitStorageThroughput',
           ],
           125,
+        )
+      })
+    })
+
+    describe('with a SCRATCH_1 type', () => {
+      beforeEach(() => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            wizard: {
+              config: {
+                SharedStorage: [
+                  {
+                    FsxLustreSettings: {
+                      DeploymentType: 'SCRATCH_1',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        })
+      })
+      it('should not set the PerUnitStorageThroughPut value in the config', () => {
+        render(
+          <MockProviders>
+            <FsxLustreSettings index={0} />
+          </MockProviders>,
+        )
+        expect(setState).not.toHaveBeenCalledWith(
+          [
+            'app',
+            'wizard',
+            'config',
+            'SharedStorage',
+            0,
+            'FsxLustreSettings',
+            'PerUnitStorageThroughput',
+          ],
+          expect.anything(),
+        )
+      })
+
+      it('should clear an existing PerUnitStorageThroughput value if available', () => {
+        render(
+          <MockProviders>
+            <FsxLustreSettings index={0} />
+          </MockProviders>,
+        )
+        expect(clearState).toHaveBeenCalledWith([
+          'app',
+          'wizard',
+          'config',
+          'SharedStorage',
+          0,
+          'FsxLustreSettings',
+          'PerUnitStorageThroughput',
+        ])
+      })
+    })
+
+    describe('with a SCRATCH_2 type', () => {
+      beforeEach(() => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            wizard: {
+              config: {
+                SharedStorage: [
+                  {
+                    FsxLustreSettings: {
+                      DeploymentType: 'SCRATCH_2',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        })
+      })
+      it('should not set the PerUnitStorageThroughPut value in the config', () => {
+        render(
+          <MockProviders>
+            <FsxLustreSettings index={0} />
+          </MockProviders>,
+        )
+        expect(setState).not.toHaveBeenCalledWith(
+          [
+            'app',
+            'wizard',
+            'config',
+            'SharedStorage',
+            0,
+            'FsxLustreSettings',
+            'PerUnitStorageThroughput',
+          ],
+          expect.anything(),
         )
       })
     })


### PR DESCRIPTION
## Description

Fixes #116.

## How Has This Been Tested?

- added an FSx storage type
- switched the type to SCRATCH_1
- dry run passed
- went back to the storage to switch the type back to PERSISTENT_1
- PerUnitStorageThroughput is appended correctly and dry run passes

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
