### PR TITLE
Add default sorting field to Tables

### DIFF
--- a/frontend/src/old-pages/Clusters/Accounting.tsx
+++ b/frontend/src/old-pages/Clusters/Accounting.tsx
@@ -460,7 +460,13 @@ export default function ClusterAccounting() {
           />
         ),
       },
-      sorting: {},
+      sorting: {
+        defaultState: {
+          sortingColumn: {
+            sortingField: 'job_id',
+          },
+        },
+      },
       selection: {},
     }),
   )

--- a/frontend/src/old-pages/Clusters/Clusters.tsx
+++ b/frontend/src/old-pages/Clusters/Clusters.tsx
@@ -128,7 +128,13 @@ function ClusterList({clusters}: {clusters: ClusterInfoSummary[]}) {
           />
         ),
       },
-      sorting: {},
+      sorting: {
+        defaultState: {
+          sortingColumn: {
+            sortingField: 'clusterName',
+          },
+        },
+      },
       selection: {},
     }),
   )

--- a/frontend/src/old-pages/Clusters/Filesystems.tsx
+++ b/frontend/src/old-pages/Clusters/Filesystems.tsx
@@ -149,7 +149,13 @@ export default function Filesystems() {
           />
         ),
       },
-      sorting: {},
+      sorting: {
+        defaultState: {
+          sortingColumn: {
+            sortingField: 'Name',
+          },
+        },
+      },
       selection: {},
     }),
   )

--- a/frontend/src/old-pages/Clusters/Instances.tsx
+++ b/frontend/src/old-pages/Clusters/Instances.tsx
@@ -156,7 +156,13 @@ export default function ClusterInstances() {
           />
         ),
       },
-      sorting: {},
+      sorting: {
+        defaultState: {
+          sortingColumn: {
+            sortingField: 'instanceId',
+          },
+        },
+      },
       selection: {},
     }),
   )

--- a/frontend/src/old-pages/Clusters/Scheduling.tsx
+++ b/frontend/src/old-pages/Clusters/Scheduling.tsx
@@ -343,7 +343,13 @@ export default function ClusterScheduling() {
           />
         ),
       },
-      sorting: {},
+      sorting: {
+        defaultState: {
+          sortingColumn: {
+            sortingField: 'job_id',
+          },
+        },
+      },
       selection: {},
     }),
   )

--- a/frontend/src/old-pages/Clusters/StackEvents.tsx
+++ b/frontend/src/old-pages/Clusters/StackEvents.tsx
@@ -139,7 +139,14 @@ export default function ClusterStackEvents() {
       ),
     },
     pagination: {pageSize: pageSize},
-    sorting: {},
+    sorting: {
+      defaultState: {
+        sortingColumn: {
+          sortingField: 'timestamp',
+        },
+        isDescending: true,
+      },
+    },
     selection: {},
   })
 

--- a/frontend/src/old-pages/Images/CustomImages/CustomImageDetails.tsx
+++ b/frontend/src/old-pages/Images/CustomImages/CustomImageDetails.tsx
@@ -232,7 +232,13 @@ function CustomImageTags({image}: CustomImageTagsProps) {
           />
         ),
       },
-      sorting: {},
+      sorting: {
+        defaultState: {
+          sortingColumn: {
+            sortingField: 'key',
+          },
+        },
+      },
       selection: {},
     }),
   )

--- a/frontend/src/old-pages/Images/CustomImages/CustomImages.tsx
+++ b/frontend/src/old-pages/Images/CustomImages/CustomImages.tsx
@@ -106,7 +106,13 @@ function CustomImagesList() {
           />
         ),
       },
-      sorting: {},
+      sorting: {
+        defaultState: {
+          sortingColumn: {
+            sortingField: 'imageId',
+          },
+        },
+      },
       selection: {},
     }),
   )

--- a/frontend/src/old-pages/Images/OfficialImages/OfficialImages.tsx
+++ b/frontend/src/old-pages/Images/OfficialImages/OfficialImages.tsx
@@ -92,7 +92,13 @@ function OfficialImagesList({images}: {images: Image[]}) {
           />
         ),
       },
-      sorting: {},
+      sorting: {
+        defaultState: {
+          sortingColumn: {
+            sortingField: 'amiId',
+          },
+        },
+      },
       selection: {},
     }),
   )

--- a/frontend/src/old-pages/Logs/LogMessagesTable.tsx
+++ b/frontend/src/old-pages/Logs/LogMessagesTable.tsx
@@ -87,7 +87,14 @@ export function LogMessagesTable({clusterName, logStreamName}: Props) {
           />
         ),
       },
-      sorting: {},
+      sorting: {
+        defaultState: {
+          sortingColumn: {
+            sortingField: 'timestamp',
+          },
+          isDescending: true,
+        },
+      },
       selection: {},
     }),
   )

--- a/frontend/src/old-pages/Logs/LogStreamsTable.tsx
+++ b/frontend/src/old-pages/Logs/LogStreamsTable.tsx
@@ -171,7 +171,13 @@ export function LogStreamsTable({clusterName, onLogStreamSelect}: Props) {
          */
         pageSize: 5,
       },
-      sorting: {},
+      sorting: {
+        defaultState: {
+          sortingColumn: {
+            sortingField: 'logIdentifier',
+          },
+        },
+      },
       selection: {},
     }),
   )

--- a/frontend/src/old-pages/Users/Users.tsx
+++ b/frontend/src/old-pages/Users/Users.tsx
@@ -135,7 +135,13 @@ export default function Users() {
           />
         ),
       },
-      sorting: {},
+      sorting: {
+        defaultState: {
+          sortingColumn: {
+            sortingField: 'email',
+          },
+        },
+      },
       selection: {},
     }),
   )


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR adds default sorting field to all Tables

## Changes

- add default sorting field to the following tables:
  - Accounting
  - Clusters
  - Filesystems
  - Instances
  - Scheduling
  - StackEvents
  - CustomImageDetails
  - CustomImages
  - OfficialImages
  - LogMessagesTable
  - LogStreamsTable
  - Users

## How Has This Been Tested?

- manually, by verifying every edited table

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
