### PR TITLE
Point E2E to the new custom domain

### DIFF
--- a/e2e/configs/environment.ts
+++ b/e2e/configs/environment.ts
@@ -9,5 +9,5 @@
 // limitations under the License.
 
 export const ENVIRONMENT_CONFIG = {
-  URL: process.env.E2E_TEST_URL || 'https://q10roayfre.execute-api.eu-west-1.amazonaws.com'
+  URL: process.env.E2E_TEST_URL || 'https://pcui-demo.nuraghe.team'
 }


### PR DESCRIPTION
## Description

The `noMatch` tests are flaky because the Cognito redirection is pointing to the new URL without preserving the path.

## How Has This Been Tested?

- run e2e locally and verified the `noMatch` spec is working

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
