### PR TITLE
Fix loading state triggering the ErrorBoundary before its completion

### DIFF
--- a/frontend/src/auth/types.ts
+++ b/frontend/src/auth/types.ts
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+export type UserRole = 'admin'
+
+export interface UserIdentity {
+  attributes: {email: string}
+  user_roles: UserRole[]
+  username: string
+}

--- a/frontend/src/components/useLoadingState.tsx
+++ b/frontend/src/components/useLoadingState.tsx
@@ -1,8 +1,11 @@
-import {Box, SpaceBetween, Spinner} from '@cloudscape-design/components'
+import {Box, Spinner} from '@cloudscape-design/components'
 import React from 'react'
 import {GetAppConfig, GetIdentity} from '../model'
 import {AxiosError} from 'axios'
 import {BoxProps} from '@cloudscape-design/components/box/interfaces'
+import {useState} from '../store'
+import {AppConfig} from '../app-config/types'
+import {UserIdentity} from '../auth/types'
 
 const loadingSpinnerMargin: BoxProps.Spacing = {top: 'xxxl'}
 
@@ -20,7 +23,12 @@ interface UseLoadingStateResponse {
 function useLoadingState(
   wrappedComponents: React.ReactNode,
 ): UseLoadingStateResponse {
-  const [loading, setLoading] = React.useState(false)
+  const identity: UserIdentity | null = useState(['identity'])
+  const appConfig: AppConfig | null = useState(['app', 'appConfig'])
+
+  const shouldLoadData = !identity || !appConfig
+
+  const [loading, setLoading] = React.useState(shouldLoadData)
 
   React.useEffect(() => {
     const getPreliminaryInfo = async () => {
@@ -38,8 +46,10 @@ function useLoadingState(
       setLoading(false)
     }
 
-    getPreliminaryInfo()
-  }, [])
+    if (shouldLoadData) {
+      getPreliminaryInfo()
+    }
+  }, [shouldLoadData])
 
   return {
     loading,

--- a/frontend/src/components/useLoadingState.tsx
+++ b/frontend/src/components/useLoadingState.tsx
@@ -37,13 +37,14 @@ function useLoadingState(
 
       try {
         await GetIdentity()
+        setLoading(false)
       } catch (error: any) {
         const status = (error as AxiosError)?.response?.status
         if (status != 403 && status != 401) {
+          setLoading(false)
           throw error // rethrow in case error is not authn/z related
         }
       }
-      setLoading(false)
     }
 
     if (shouldLoadData) {

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -24,6 +24,7 @@ import {
   LogStreamView,
 } from './types/logs'
 import {AxiosError} from 'axios'
+import {UserIdentity} from './auth/types'
 
 // Types
 type Callback = (arg?: any) => void
@@ -849,13 +850,12 @@ function SlurmAccounting(
     })
 }
 
-async function GetIdentity() {
+async function GetIdentity(): Promise<UserIdentity | undefined> {
   const response = await request('get', 'manager/get_identity')
   if (response.status === 200) {
     setState(['identity'], response.data)
     return response.data
   }
-  return undefined
 }
 
 async function GetAppConfig() {

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -14,8 +14,6 @@ import {BrowserRouter, Route, Routes, Navigate} from 'react-router-dom'
 
 import {LoadInitialState} from '../model'
 
-import {useState} from '../store'
-
 import Clusters from '../old-pages/Clusters/Clusters'
 import Configure from '../old-pages/Configure/Configure'
 import Users from '../old-pages/Users/Users'

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -37,7 +37,7 @@ function app(state = {}, action: any) {
 function aws(state = {}, action: any) {
   return state
 }
-function identity(state = {}, action: any) {
+function identity(state = null, action: any) {
   return state
 }
 


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR fixes an issue with the loading state inadvertently showing error messages while loading the data

## Changes

- only fire `useLoadingState` when the needed data is missing
- make sure loader is not removed in case of an authn/z error (which is handled with a redirect)

## How Has This Been Tested?

- manually, by testing both unauth and auth case
- unit test
- e2e locally

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
