### PR TITLE
Consistent styling of help panel links and copy buttons

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -126,7 +126,9 @@
       "versionLabel": "Version",
       "ec2InstanceConnect": {
         "label": "EC2 Instance Connect",
-        "help": "Locally install mSSH helper and copy the provided command to connect to the head node with EC2 Instance Connect."
+        "help": "Locally install mSSH helper and copy the provided command to connect to the head node with EC2 Instance Connect.",
+        "copySuccess": "mSSH command copied",
+        "copyAria": "Copy the mSSH command."
       }
     },
     "instances": {

--- a/frontend/src/components/help-panel/TitleDescriptionHelpPanel.tsx
+++ b/frontend/src/components/help-panel/TitleDescriptionHelpPanel.tsx
@@ -39,13 +39,7 @@ function TitleDescriptionHelpPanel({
         <ul>
           {footerLinks.map(link => (
             <li key={link.href}>
-              <Link
-                external
-                externalIconAriaLabel={t('global.openNewTab')}
-                href={link.href}
-              >
-                {link.title}
-              </Link>
+              <Link href={link.href}>{link.title}</Link>
             </li>
           ))}
         </ul>

--- a/frontend/src/old-pages/Clusters/Properties.tsx
+++ b/frontend/src/old-pages/Clusters/Properties.tsx
@@ -177,14 +177,18 @@ export default function ClusterProperties() {
                       triggerType="custom"
                       content={
                         <StatusIndicator type="success">
-                          mSSH command copied
+                          {t(
+                            'cluster.properties.ec2InstanceConnect.copySuccess',
+                          )}{' '}
                         </StatusIndicator>
                       }
                     >
                       <Button
                         variant="inline-icon"
                         iconName="copy"
-                        ariaLabel="Copy mSSH command"
+                        ariaLabel={t(
+                          'cluster.properties.ec2InstanceConnect.copyAria',
+                        )}
                         onClick={() => {
                           navigator.clipboard.writeText(
                             `mssh -r ${cluster.region} ${clusterDefaultUser(

--- a/frontend/src/old-pages/Clusters/Properties.tsx
+++ b/frontend/src/old-pages/Clusters/Properties.tsx
@@ -181,9 +181,6 @@ export default function ClusterProperties() {
                         </StatusIndicator>
                       }
                     >
-                      {`mssh -r ${cluster.region} ${clusterDefaultUser(
-                        cluster,
-                      )}@${headNode.instanceId}`}
                       <Button
                         variant="inline-icon"
                         iconName="copy"
@@ -195,9 +192,10 @@ export default function ClusterProperties() {
                             )}@${headNode.instanceId}`,
                           )
                         }}
-                      >
-                        copy
-                      </Button>
+                      />
+                      {`mssh -r ${cluster.region} ${clusterDefaultUser(
+                        cluster,
+                      )}@${headNode.instanceId}`}
                     </Popover>
                   </Box>
                 </ValueWithLabel>


### PR DESCRIPTION
## Changes

- [Consistently align to the left copy button icon](https://github.com/aws/aws-parallelcluster-ui/commit/18e81a989482f1005d2dab33cb0b9d64c00a0764)
- [Remove external icon from help panel links](https://github.com/aws/aws-parallelcluster-ui/commit/634b789b9b4deea78f0ed4f2e1d768c8696a87ee) 

## How Has This Been Tested?

- verified the affected components on my local environment

## References

https://cloudscape.design/patterns/general/help-system/

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
