### PR TITLE
Fix copy in Cluster, Head node and Storage wizard pages

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -129,6 +129,11 @@
         "help": "Locally install mSSH helper and copy the provided command to connect to the head node with EC2 Instance Connect.",
         "copySuccess": "mSSH command copied",
         "copyAria": "Copy the mSSH command."
+      },
+      "configDialog": {
+        "title": "Cluster configuration",
+        "download": "Download",
+        "close": "Close"
       }
     },
     "instances": {
@@ -508,7 +513,7 @@
           "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/DirectoryService-v3.html?icmpid=docs_parallelcluster_hp_multi_user_v1"
         },
         "checkbox": {
-          "label": "Allow multiple users on a cluster"
+          "label": "Manage multiple users on a cluster"
         },
         "domainName": {
           "name": "Domain name",
@@ -681,13 +686,13 @@
         },
         "database": {
           "label": "Database",
-          "description": "Enter the path to the Slurm database.",
+          "description": "The path to the Slurm database.",
           "placeholder": "DNSName/ip:port"
         },
         "username": {
           "label": "Username",
           "placeholder": "Username",
-          "description": "Enter the user ID for access to the database."
+          "description": "The user ID for access to the database."
         },
         "password": {
           "label": "Password secret ARN",
@@ -718,8 +723,8 @@
       "container": {
         "title": "Storage settings",
         "noStorageSelected": "No shared storage options selected.",
-        "storageType": "Storage type",
-        "storageTypePlaceholder": "Select one or more storage types",
+        "storageTypes": "Storage types",
+        "storageTypesPlaceholder": "Select file system types",
         "volumePlaceholder": "Select a volume",
         "addStorage": "Add storage",
         "removeStorage": "Remove storage",

--- a/frontend/src/old-pages/Clusters/ConfigDialog.tsx
+++ b/frontend/src/old-pages/Clusters/ConfigDialog.tsx
@@ -20,6 +20,7 @@ import {Box, Button, Modal, SpaceBetween} from '@cloudscape-design/components'
 // Components
 import Loading from '../../components/Loading'
 import ConfigView from '../../components/ConfigView'
+import {useTranslation} from 'react-i18next'
 
 function downloadBlob(blob: any, filename: any) {
   const url = URL.createObjectURL(blob)
@@ -38,6 +39,7 @@ function downloadBlob(blob: any, filename: any) {
 }
 
 export default function ConfigDialog() {
+  const {t} = useTranslation()
   const open = useState(['app', 'clusters', 'clusterConfig', 'dialog'])
 
   const clusterName = useState(['app', 'clusters', 'selected'])
@@ -70,13 +72,15 @@ export default function ConfigDialog() {
                 })
               }}
             >
-              Download
+              {t('cluster.properties.configDialog.download')}
             </Button>
-            <Button onClick={close}>Close</Button>
+            <Button onClick={close}>
+              {t('cluster.properties.configDialog.close')}
+            </Button>
           </SpaceBetween>
         </Box>
       }
-      header="Cluster Configuration"
+      header={t('cluster.properties.configDialog.title')}
     >
       {configYaml ? <ConfigView config={configYaml} /> : <Loading />}
     </Modal>

--- a/frontend/src/old-pages/Configure/Storage/AddStorageForm.tsx
+++ b/frontend/src/old-pages/Configure/Storage/AddStorageForm.tsx
@@ -56,10 +56,10 @@ export function AddStorageForm({storageTypes, onSubmit}: Props) {
 
   return (
     <SpaceBetween size="s">
-      <FormField label={t('wizard.storage.container.storageType')}>
+      <FormField label={t('wizard.storage.container.storageTypes')}>
         <Multiselect
           tokenLimit={0}
-          placeholder={t('wizard.storage.container.storageTypePlaceholder')}
+          placeholder={t('wizard.storage.container.storageTypesPlaceholder')}
           selectedOptions={selectedStorages}
           onChange={onSelectChange}
           options={storageTypesToDisplay}


### PR DESCRIPTION
## Description

* Apply minor fixes to copywriting in Cluster, Head node and Storage wizard pages

## How Has This Been Tested?

* Manually inspected affected pages on local environment

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
