### PR TITLE
Add ImdsSupport setting in cluster configuration

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -491,6 +491,15 @@
         "description": "The VPC for the cluster instances.",
         "selectedAriaLabel": "Selected"
       },
+      "imdsSupport": {
+        "label": "IMDS support",
+        "description": "The IMDS versions that are supported in the cluster nodes.",
+        "placeholder": "Select an IMDS version",
+        "values": {
+          "version10": "Version 1.0",
+          "version20": "Version 2.0"
+        }
+      },
       "multiUser": {
         "title": "Multiple user management properties",
         "description": "Configure Active Directory access settings for multiple users on a cluster.",

--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -58,6 +58,7 @@ describe('given a feature flags provider and a list of rules', () => {
         'dynamic_fs_mount',
         'efs_deletion_policy',
         'lustre_deletion_policy',
+        'imds_support',
       ])
     })
   })

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -27,6 +27,7 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
     'dynamic_fs_mount',
     'efs_deletion_policy',
     'lustre_deletion_policy',
+    'imds_support',
   ],
   '3.4.0': ['multi_az', 'on_node_updated'],
 }

--- a/frontend/src/feature-flags/types.ts
+++ b/frontend/src/feature-flags/types.ts
@@ -23,3 +23,4 @@ export type AvailableFeature =
   | 'ebs_deletion_policy'
   | 'efs_deletion_policy'
   | 'lustre_deletion_policy'
+  | 'imds_support'

--- a/frontend/src/old-pages/Configure/Cluster.tsx
+++ b/frontend/src/old-pages/Configure/Cluster.tsx
@@ -55,6 +55,7 @@ import InfoLink from '../../components/InfoLink'
 import {ClusterNameField} from './Cluster/ClusterNameField'
 import {validateClusterNameAndSetErrors} from './Cluster/clusterName.validators'
 import Loading from '../../components/Loading'
+import {ImdsSupportFormField} from './Cluster/ImdsSupportFormField'
 
 // Constants
 const errorsPath = ['app', 'wizard', 'errors', 'cluster']
@@ -448,6 +449,7 @@ function Cluster() {
             validate={clusterValidate}
           />
           <VpcSelect />
+          <ImdsSupportFormField />
           {isMultiuserClusterActive && (
             <FormField>
               <CheckboxWithHelpPanel

--- a/frontend/src/old-pages/Configure/Cluster/ImdsSupportFormField.tsx
+++ b/frontend/src/old-pages/Configure/Cluster/ImdsSupportFormField.tsx
@@ -1,0 +1,68 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {FormField, Select, SelectProps} from '@cloudscape-design/components'
+import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
+import {useCallback, useEffect, useMemo} from 'react'
+import {useTranslation} from 'react-i18next'
+import {useFeatureFlag} from '../../../feature-flags/useFeatureFlag'
+import {setState, useState} from '../../../store'
+
+const imdsSupportPath = ['app', 'wizard', 'config', 'Imds', 'ImdsSupport']
+
+const DEFAULT_IMDS_SUPPORT_VALUE = 'v2.0'
+
+export function ImdsSupportFormField() {
+  const {t} = useTranslation()
+  const isImdsSupportActive = useFeatureFlag('imds_support')
+  const editing: boolean = useState(['app', 'wizard', 'editing'])
+  const imdsSupport: string | null = useState(imdsSupportPath)
+
+  useEffect(() => {
+    if (isImdsSupportActive && imdsSupport === null)
+      setState(imdsSupportPath, DEFAULT_IMDS_SUPPORT_VALUE)
+  }, [imdsSupport, isImdsSupportActive])
+
+  const options = useMemo(
+    () => [
+      {value: 'v1.0', label: t('wizard.cluster.imdsSupport.values.version10')},
+      {value: 'v2.0', label: t('wizard.cluster.imdsSupport.values.version20')},
+    ],
+    [t],
+  )
+
+  const selectedOption =
+    options.find(({value}) => value === imdsSupport) || null
+
+  const onChange: NonCancelableEventHandler<SelectProps.ChangeDetail> =
+    useCallback(({detail}) => {
+      setState(imdsSupportPath, detail.selectedOption.value)
+    }, [])
+
+  if (!isImdsSupportActive) {
+    return null
+  }
+
+  return (
+    <FormField
+      label={t('wizard.cluster.imdsSupport.label')}
+      description={t('wizard.cluster.imdsSupport.description')}
+    >
+      <Select
+        disabled={editing}
+        selectedOption={selectedOption}
+        onChange={onChange}
+        options={options}
+        placeholder={t('wizard.cluster.imdsSupport.placeholder')}
+      />
+    </FormField>
+  )
+}

--- a/frontend/src/old-pages/Configure/Cluster/__tests__/ImdsSupportFormField.test.tsx
+++ b/frontend/src/old-pages/Configure/Cluster/__tests__/ImdsSupportFormField.test.tsx
@@ -1,0 +1,181 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import wrapper from '@cloudscape-design/components/test-utils/dom'
+import {Store} from '@reduxjs/toolkit'
+import {render, RenderResult} from '@testing-library/react'
+import i18n from 'i18next'
+import {mock} from 'jest-mock-extended'
+import {I18nextProvider, initReactI18next} from 'react-i18next'
+import {Provider} from 'react-redux'
+import {setState as mockSetState, setState} from '../../../../store'
+import {ImdsSupportFormField} from '../ImdsSupportFormField'
+
+jest.mock('../../../../store', () => {
+  const originalModule = jest.requireActual('../../../../store')
+
+  return {
+    __esModule: true, // Use it when dealing with esModules
+    ...originalModule,
+    setState: jest.fn(),
+  }
+})
+
+i18n.use(initReactI18next).init({
+  resources: {},
+  lng: 'en',
+})
+
+const mockStore = mock<Store>()
+const MockProviders = (props: any) => (
+  <Provider store={mockStore}>
+    <I18nextProvider i18n={i18n}>{props.children}</I18nextProvider>
+  </Provider>
+)
+
+describe('given a component to select the IMDS supported version', () => {
+  let screen: RenderResult
+
+  beforeEach(() => {
+    ;(mockSetState as jest.Mock).mockClear()
+  })
+
+  describe('when the version is at least 3.3.0', () => {
+    describe('when no value has been selected yet', () => {
+      beforeEach(() => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            version: {
+              full: '3.3.0',
+            },
+            wizard: {
+              config: {Imds: null},
+            },
+          },
+        })
+        screen = render(
+          <MockProviders>
+            <ImdsSupportFormField />
+          </MockProviders>,
+        )
+      })
+
+      it('should initialize ImdsSupport to v2.0', () => {
+        expect(setState).toHaveBeenCalledWith(
+          ['app', 'wizard', 'config', 'Imds', 'ImdsSupport'],
+          'v2.0',
+        )
+      })
+    })
+
+    describe('when ImdsSupport is already set', () => {
+      beforeEach(() => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            version: {
+              full: '3.3.0',
+            },
+            wizard: {
+              config: {
+                Imds: {ImdsSupport: 'v2.0'},
+              },
+            },
+          },
+        })
+        screen = render(
+          <MockProviders>
+            <ImdsSupportFormField />
+          </MockProviders>,
+        )
+      })
+
+      it('should not initialize ImdsSupport', () => {
+        expect(setState).not.toHaveBeenCalledWith(
+          ['app', 'wizard', 'config', 'Imds', 'ImdsSupport'],
+          expect.any(String),
+        )
+      })
+
+      describe('when user selects an option', () => {
+        beforeEach(() => {
+          const selectComponent = wrapper(screen.container).findSelect()!
+          selectComponent.openDropdown()
+          selectComponent.selectOptionByValue('v1.0')
+        })
+
+        it('should store the selection in the cluster config', () => {
+          expect(mockSetState).toHaveBeenCalledTimes(1)
+          expect(mockSetState).toHaveBeenCalledWith(
+            ['app', 'wizard', 'config', 'Imds', 'ImdsSupport'],
+            'v1.0',
+          )
+        })
+      })
+    })
+
+    describe('when user is editing a cluster', () => {
+      beforeEach(() => {
+        mockStore.getState.mockReturnValue({
+          app: {
+            version: {
+              full: '3.3.0',
+            },
+            wizard: {
+              editing: true,
+            },
+          },
+        })
+
+        screen = render(
+          <MockProviders>
+            <ImdsSupportFormField />
+          </MockProviders>,
+        )
+      })
+
+      it('should be disabled', () => {
+        const selectComponent = wrapper(screen.container).findSelect()!
+        expect(selectComponent.isDisabled()).toBe(true)
+      })
+    })
+  })
+
+  describe('when the version is lesser than 3.3.0', () => {
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {
+            full: '3.2.0',
+          },
+        },
+      })
+
+      screen = render(
+        <MockProviders>
+          <ImdsSupportFormField />
+        </MockProviders>,
+      )
+    })
+
+    it('should not render anything', () => {
+      expect(
+        screen.queryByLabelText('wizard.cluster.imdsSupport.label'),
+      ).toBeNull()
+    })
+
+    it('should not initialize ImdsSupport', () => {
+      expect(setState).not.toHaveBeenCalledWith(
+        ['app', 'wizard', 'config', 'Imds', 'ImdsSupport'],
+        expect.any(String),
+      )
+    })
+  })
+})


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR adds support for the `ImdsSupport` global setting, which lets users specify which IMDS versions are supported in the cluster nodes

## Changes

- add ImdsSupportFormField component
- only show the selctor for PC >= 3.3.0

## Screenshot

<img width="477" alt="image" src="https://user-images.githubusercontent.com/11457067/228877756-42eeb8ab-d6ee-4f22-8f84-3527f671bcef.png">

## How Has This Been Tested?

- manually, by checking dry run passes with both v1.0 and v2.0
- unit tests

## References

[ImdsSupport docs](https://docs.aws.amazon.com/parallelcluster/latest/ug/Imds-cluster-v3.html)

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
