### PR TITLE
Fix DateView test failing according to Node version

### DIFF
--- a/frontend/src/components/date/__tests__/DateView.test.tsx
+++ b/frontend/src/components/date/__tests__/DateView.test.tsx
@@ -24,7 +24,6 @@ describe('Given a DateView component', () => {
     const dateString = '2022-09-16T14:03:35.000Z'
     const locale = 'it-IT'
     const timeZone = TimeZone.UTC
-    const expectedResult = '16 settembre 2022 14:03 (UTC)'
 
     beforeEach(async () => {
       renderResult = await waitFor(() =>
@@ -35,7 +34,11 @@ describe('Given a DateView component', () => {
     })
 
     it('should render the date in the expeted absolute format with provided locales and timezone', async () => {
-      expect(renderResult.getByText(expectedResult)).toBeTruthy()
+      const renderedDateString = renderResult.getByTitle(dateString).textContent
+
+      expect(renderedDateString).toContain('16 settembre 2022')
+      expect(renderedDateString).toContain('14:03')
+      expect(renderedDateString).toContain('(UTC)')
     })
   })
 })


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR fixes a failure of the `DateView` test caused by different implementations of `toLocaleString` rendering different strings (e.g. connectors between year and hour)

## Changes

- instead of full string equality, just check the presence of localized date, hour and timezone components

## How Has This Been Tested?

- successful tests with Node 14, 16 and 19

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
