### PR TITLE
Fetch PC version during initial load

### DIFF
--- a/frontend/src/__tests__/GetVersion.test.ts
+++ b/frontend/src/__tests__/GetVersion.test.ts
@@ -1,0 +1,81 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {GetVersion} from '../model'
+import {setState} from '../store'
+import {PCVersion} from '../types/base'
+
+const mockGet = jest.fn()
+
+jest.mock('axios', () => ({
+  create: () => ({
+    get: (...args: unknown[]) => mockGet(...args),
+  }),
+}))
+
+jest.mock('../store', () => ({
+  ...(jest.requireActual('../store') as any),
+  setState: jest.fn(),
+}))
+
+describe('given a GetVersion command', () => {
+  describe('when the PC version can be retrieved successfully', () => {
+    beforeEach(() => {
+      const mockResponse = {
+        version: '3.5.0',
+      }
+
+      mockGet.mockResolvedValueOnce({data: mockResponse})
+    })
+
+    it('should return the PC version', async () => {
+      const data = await GetVersion()
+
+      expect(data).toEqual<PCVersion>({full: '3.5.0'})
+    })
+
+    it('should store the PC version', async () => {
+      await GetVersion()
+
+      expect(setState).toHaveBeenCalledWith(['app', 'version'], {full: '3.5.0'})
+    })
+  })
+
+  describe('when the call fails', () => {
+    let mockError: any
+
+    beforeEach(() => {
+      mockError = {
+        response: {
+          data: {
+            message: 'some-error-messasge',
+          },
+        },
+      }
+
+      mockGet.mockRejectedValueOnce(mockError)
+    })
+
+    it('should re-throw the error', async () => {
+      try {
+        await GetVersion()
+      } catch (e) {
+        expect(e).toEqual({
+          response: {
+            data: {
+              message: 'some-error-messasge',
+            },
+          },
+        })
+      }
+    })
+  })
+})

--- a/frontend/src/components/useLoadingState.tsx
+++ b/frontend/src/components/useLoadingState.tsx
@@ -1,11 +1,12 @@
 import {Box, Spinner} from '@cloudscape-design/components'
 import React from 'react'
-import {GetAppConfig, GetIdentity} from '../model'
+import {GetAppConfig, GetIdentity, GetVersion} from '../model'
 import {AxiosError} from 'axios'
 import {BoxProps} from '@cloudscape-design/components/box/interfaces'
 import {useState} from '../store'
 import {AppConfig} from '../app-config/types'
 import {UserIdentity} from '../auth/types'
+import {PCVersion} from '../types/base'
 
 const loadingSpinnerMargin: BoxProps.Spacing = {top: 'xxxl'}
 
@@ -25,15 +26,16 @@ function useLoadingState(
 ): UseLoadingStateResponse {
   const identity: UserIdentity | null = useState(['identity'])
   const appConfig: AppConfig | null = useState(['app', 'appConfig'])
+  const version: PCVersion | null = useState(['app', 'version', 'full'])
 
-  const shouldLoadData = !identity || !appConfig
+  const shouldLoadData = !identity || !appConfig || !version
 
   const [loading, setLoading] = React.useState(shouldLoadData)
 
   React.useEffect(() => {
     const getPreliminaryInfo = async () => {
       setLoading(true)
-      await GetAppConfig()
+      await Promise.all([GetAppConfig(), GetVersion()])
 
       try {
         await GetIdentity()

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -841,7 +841,6 @@ async function GetAppConfig() {
 async function LoadInitialState() {
   const region = getState(['app', 'selectedRegion'])
   clearState(['app', 'aws'])
-  GetVersion()
   ListUsers()
   ListClusters()
   ListCustomImages()

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -25,6 +25,7 @@ import {
 } from './types/logs'
 import {AxiosError} from 'axios'
 import {UserIdentity} from './auth/types'
+import {PCVersion} from './types/base'
 
 // Types
 type Callback = (arg?: any) => void
@@ -642,30 +643,21 @@ const extractFsxVolumes = (volumes: any) => {
   }
 }
 
-function GetVersion() {
+async function GetVersion(): Promise<PCVersion> {
   var url = `manager/get_version`
-  request('get', url)
-    .then((response: any) => {
-      if (response.status === 200) {
-        console.log('api_version', response.data)
-        var [major, minor, patch] = response.data.version.split('.')
-        var major_int = parseInt(major)
-        var minor_int = parseInt(minor)
-        setState(['app', 'version'], {
-          full: response.data.version,
-          major: major_int,
-          minor: minor_int,
-          patch: patch,
-        })
-      }
-    })
-    .catch((error: any) => {
-      if (error.response) {
-        console.log(error.response)
-        notify(`Error: ${error.response.data.message}`, 'error')
-      }
-      console.log(error)
-    })
+  try {
+    const {data} = await request('get', url)
+    const versionObject = {
+      full: data.version,
+    }
+    setState(['app', 'version'], versionObject)
+    return versionObject
+  } catch (error) {
+    if ((error as AxiosError).response) {
+      notify(`Error: ${(error as any).response.data.message}`, 'error')
+    }
+    throw error
+  }
 }
 
 function Ec2Action(instanceId: any, action: any, callback?: Callback) {
@@ -891,4 +883,5 @@ export {
   DeleteUser,
   GetIdentity,
   GetAppConfig,
+  GetVersion,
 }

--- a/frontend/src/old-pages/Clusters/FromClusterModal/__tests__/useClustersToCopyFrom.test.tsx
+++ b/frontend/src/old-pages/Clusters/FromClusterModal/__tests__/useClustersToCopyFrom.test.tsx
@@ -60,7 +60,7 @@ describe('given a hook to list the clusters that can be copied from', () => {
                 clusterName: 'some-name',
                 clusterStatus: ClusterStatus.CreateComplete,
               },
-            ] as ClusterInfoSummary[],
+            ] as Partial<ClusterInfoSummary>[],
           },
         })
       })
@@ -91,7 +91,7 @@ describe('given a hook to list the clusters that can be copied from', () => {
                   clusterName: 'some-name',
                   version: '3.5.1',
                 },
-              ] as ClusterInfoSummary[],
+              ] as Partial<ClusterInfoSummary>[],
             },
           })
         })
@@ -124,7 +124,7 @@ describe('given a hook to list the clusters that can be copied from', () => {
                   clusterName: 'some-name-different-major',
                   version: '2.5.0',
                 },
-              ] as ClusterInfoSummary[],
+              ] as Partial<ClusterInfoSummary>[],
             },
           })
         })
@@ -157,7 +157,7 @@ describe('given a hook to list the clusters that can be copied from', () => {
                   clusterName: 'some-name-different-minor',
                   version: '3.6.0',
                 },
-              ] as ClusterInfoSummary[],
+              ] as Partial<ClusterInfoSummary>[],
             },
           })
         })

--- a/frontend/src/types/base.tsx
+++ b/frontend/src/types/base.tsx
@@ -55,7 +55,11 @@ export enum CloudFormationResourceStatus {
 
 export type Region = string
 
-export type Version = string
+export type Version = `${string}.${string}.${string}`
+
+export interface PCVersion {
+  full: Version
+}
 
 // Token to use for paginated requests.
 export type PaginationToken = string


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR moves the request for the PC version into the initial load happening before booting the app. This is due to the fact that the rest of the app behaves as if the version is always present, and could crash if the version is not there for some reason.

This also fixes a crash happening whenever the `get_version` call takes too much time to respond, causing the code accessing the version to crash unexpectedly. In order to reproduce, simply add a timeout in the `GetVersion` command

## Changes

- refactor `GetVersion` to an async function
- remove major, minor and patch values from the store, since they are never accessed
- call `GetVersion` in `useLoadingState`
- remove `GetVersion` call from the `LoadInitialState`

## How Has This Been Tested?

- manually, by verifying the crash does not happen anymore
- unit tests
- e2e tests locally

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
