### PR TITLE
Bump default PCluster version to 3.5.1

### DIFF
--- a/infrastructure/environments/demo-cfn-update-args.yaml
+++ b/infrastructure/environments/demo-cfn-update-args.yaml
@@ -1,7 +1,7 @@
 TemplateURL: BUCKET_URL_PLACEHOLDER/parallelcluster-ui.yaml
 Parameters:
   - ParameterKey: Version
-    ParameterValue: 3.5.0
+    ParameterValue: 3.5.1
   - ParameterKey: InfrastructureBucket
     ParameterValue: BUCKET_URL_PLACEHOLDER
   - ParameterKey: UserPoolId

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -22,7 +22,7 @@ Parameters:
   Version:
     Description: Version of AWS ParallelCluster to deploy
     Type: String
-    Default: 3.5.0
+    Default: 3.5.1
   ImageBuilderVpcId:
     Description: (Optional) Select the VPC to use for building the container images. If not selected, default VPC will be used.
     Type: String


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR bumps the default PC version installed with PCUI to 3.5.1 (as per the screenshot below)

<img width="268" alt="Screenshot 2023-04-12 at 14 53 04" src="https://user-images.githubusercontent.com/11457067/231464819-ccac4ecb-775e-422e-803c-2dbb0042bf37.png">

## Changes

- bump default PC version in CFN template
- bump PC version deployed to our demo env

## How Has This Been Tested?

- manually, by updating the demo environment with the `./infrastructure/update-environment-infra.sh demo` script
- manually, by uploading the CFN template via the console (see screenshot)

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
