### PR TITLE
Format status indicators according to guidelines

### DIFF
--- a/frontend/src/components/Status.tsx
+++ b/frontend/src/components/Status.tsx
@@ -52,7 +52,7 @@ function ClusterStatusIndicator({
 
   return (
     <StatusIndicator type={statusMap[clusterStatus]}>
-      {clusterStatus.replaceAll('_', ' ')}
+      {formatStatus(clusterStatus)}
     </StatusIndicator>
   )
 }
@@ -87,7 +87,7 @@ function JobStatusIndicator({status}: {status: JobStateCode}) {
 
   return (
     <StatusIndicator type={statusMap[status]}>
-      {status.replaceAll('_', ' ')}
+      {formatStatus(status)}
     </StatusIndicator>
   )
 }
@@ -108,7 +108,7 @@ function ComputeFleetStatusIndicator({status}: {status: ComputeFleetStatus}) {
 
   return (
     <StatusIndicator type={statusMap[status]}>
-      {status.replaceAll('_', ' ')}
+      {formatStatus(status)}
     </StatusIndicator>
   )
 }
@@ -129,7 +129,7 @@ function InstanceStatusIndicator({
 
   return (
     <StatusIndicator type={statusMap[instance.state]}>
-      {instance.state.replaceAll('-', ' ').toUpperCase()}
+      {formatStatus(instance.state)}
     </StatusIndicator>
   )
 }
@@ -158,7 +158,7 @@ function StackEventStatusIndicator({stackEvent}: {stackEvent: StackEvent}) {
   }
   return (
     <StatusIndicator type={statusMap[stackEvent.resourceStatus]}>
-      {stackEvent.resourceStatus.replaceAll('_', ' ')}
+      {formatStatus(stackEvent.resourceStatus)}
     </StatusIndicator>
   )
 }

--- a/frontend/src/components/Status.tsx
+++ b/frontend/src/components/Status.tsx
@@ -16,6 +16,7 @@ import {
   ComputeFleetStatus,
 } from '../types/clusters'
 import {InstanceState, Instance, EC2Instance} from '../types/instances'
+import {ImageBuildStatus} from '../types/images'
 import {StackEvent} from '../types/stackevents'
 import {JobStateCode} from '../types/jobs'
 import capitalize from 'lodash/capitalize'
@@ -163,10 +164,32 @@ function StackEventStatusIndicator({stackEvent}: {stackEvent: StackEvent}) {
   )
 }
 
+function CustomImageStatusIndicator({
+  buildStatus,
+}: {
+  buildStatus: ImageBuildStatus
+}) {
+  const statusMap: Record<ImageBuildStatus, StatusIndicatorProps.Type> = {
+    BUILD_COMPLETE: 'success',
+    BUILD_FAILED: 'error',
+    BUILD_IN_PROGRESS: 'in-progress',
+    DELETE_COMPLETE: 'success',
+    DELETE_IN_PROGRESS: 'in-progress',
+    DELETE_FAILED: 'error',
+  }
+
+  return (
+    <StatusIndicator type={statusMap[buildStatus]}>
+      {formatStatus(buildStatus)}
+    </StatusIndicator>
+  )
+}
+
 export {
   ClusterStatusIndicator,
   ComputeFleetStatusIndicator,
   InstanceStatusIndicator,
   JobStatusIndicator,
   StackEventStatusIndicator,
+  CustomImageStatusIndicator,
 }

--- a/frontend/src/components/Status.tsx
+++ b/frontend/src/components/Status.tsx
@@ -129,13 +129,7 @@ function InstanceStatusIndicator({
   )
 }
 
-function StackEventStatusIndicator({
-  stackEvent,
-  children,
-}: {
-  stackEvent: StackEvent
-  children?: React.ReactNode
-}) {
+function StackEventStatusIndicator({stackEvent}: {stackEvent: StackEvent}) {
   const statusMap: Record<
     CloudFormationResourceStatus,
     StatusIndicatorProps.Type
@@ -160,7 +154,6 @@ function StackEventStatusIndicator({
   return (
     <StatusIndicator type={statusMap[stackEvent.resourceStatus]}>
       {stackEvent.resourceStatus.replaceAll('_', ' ')}
-      {children}
     </StatusIndicator>
   )
 }

--- a/frontend/src/components/Status.tsx
+++ b/frontend/src/components/Status.tsx
@@ -18,6 +18,7 @@ import {
 import {InstanceState, Instance, EC2Instance} from '../types/instances'
 import {StackEvent} from '../types/stackevents'
 import {JobStateCode} from '../types/jobs'
+import capitalize from 'lodash/capitalize'
 import React from 'react'
 import {
   StatusIndicator,
@@ -25,6 +26,10 @@ import {
 } from '@cloudscape-design/components'
 
 export type StatusMap = Record<string, StatusIndicatorProps.Type>
+
+export function formatStatus(status?: string): string {
+  return capitalize(status?.replaceAll(/[_-]/g, ' '))
+}
 
 function ClusterStatusIndicator({
   cluster,

--- a/frontend/src/components/__tests__/Status.test.tsx
+++ b/frontend/src/components/__tests__/Status.test.tsx
@@ -1,0 +1,33 @@
+import {formatStatus} from '../Status'
+
+describe('Given a resource status', () => {
+  describe('when the status has a dash', () => {
+    it('should be removed', () => {
+      expect(formatStatus('shutting-down')).toBe('Shutting down')
+    })
+  })
+
+  describe('when the status has an underscore', () => {
+    it('should be removed', () => {
+      expect(formatStatus('shutting_down')).toBe('Shutting down')
+    })
+  })
+
+  describe('when the status is lowercase', () => {
+    it('should be capitalized', () => {
+      expect(formatStatus('created')).toBe('Created')
+    })
+  })
+
+  describe('when the status is uppercase', () => {
+    it('should be capitalized', () => {
+      expect(formatStatus('CREATE_COMPLETE')).toBe('Create complete')
+    })
+  })
+
+  describe('when given an undefined string', () => {
+    it('should return an empty string', () => {
+      expect(formatStatus()).toBe('')
+    })
+  })
+})

--- a/frontend/src/old-pages/Clusters/__tests__/Clusters.test.tsx
+++ b/frontend/src/old-pages/Clusters/__tests__/Clusters.test.tsx
@@ -68,7 +68,7 @@ describe('given a component to show the clusters list', () => {
       )
 
       expect(getByText('test-cluster')).toBeTruthy()
-      expect(getByText('CREATE COMPLETE')).toBeTruthy()
+      expect(getByText('Create complete')).toBeTruthy()
       expect(getByText('3.1.4')).toBeTruthy()
     })
 

--- a/frontend/src/old-pages/Images/CustomImages/CustomImageDetails.tsx
+++ b/frontend/src/old-pages/Images/CustomImages/CustomImageDetails.tsx
@@ -39,6 +39,7 @@ import EmptyState from '../../../components/EmptyState'
 import {truncate} from 'lodash'
 import {ReadonlyConfigView} from '../../../components/ConfigView'
 import {extendCollectionsOptions} from '../../../shared/extendCollectionsOptions'
+import {CustomImageStatusIndicator} from '../../../components/Status'
 
 const customImagesPath = ['app', 'customImages']
 
@@ -135,7 +136,7 @@ function CustomImageProperties() {
           <ValueWithLabel
             label={t('customImages.imageDetails.properties.buildStatus')}
           >
-            {image.imageBuildStatus}
+            <CustomImageStatusIndicator buildStatus={image.imageBuildStatus} />
           </ValueWithLabel>
           <ValueWithLabel
             label={t('customImages.imageDetails.properties.amiId.label')}

--- a/frontend/src/old-pages/Images/CustomImages/CustomImages.tsx
+++ b/frontend/src/old-pages/Images/CustomImages/CustomImages.tsx
@@ -38,6 +38,7 @@ import {TFunction, Trans, useTranslation} from 'react-i18next'
 import InfoLink from '../../../components/InfoLink'
 import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
 import {extendCollectionsOptions} from '../../../shared/extendCollectionsOptions'
+import {CustomImageStatusIndicator} from '../../../components/Status'
 
 const imageBuildPath = ['app', 'customImages', 'imageBuild']
 
@@ -167,7 +168,9 @@ function CustomImagesList() {
         {
           id: 'status',
           header: t('customImages.list.columns.status'),
-          cell: image => image.imageBuildStatus || '-',
+          cell: image => (
+            <CustomImageStatusIndicator buildStatus={image.imageBuildStatus} />
+          ),
           sortingField: 'imageBuildStatus',
         },
         {


### PR DESCRIPTION
## Changes

- extracted a function to apply sentence case formatting to statuses
- added `StatusIndicator` to Custom images

## How Has This Been Tested?

Verified locally status indicators under:
- cluster list and details
- stack events
- custom images list and details

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
