### PR TITLE
Fix Start and Stop instances button still enabled after being clicked once

### DIFF
--- a/frontend/src/old-pages/Clusters/Instances.tsx
+++ b/frontend/src/old-pages/Clusters/Instances.tsx
@@ -100,18 +100,20 @@ export default function ClusterInstances() {
   const {t} = useTranslation()
 
   const clusterName: ClusterName = useState(['app', 'clusters', 'selected'])
-  const instances: Instance[] = useState([
+  const instances: Instance[] | null = useState([
     'clusters',
     'index',
     clusterName,
     'instances',
   ])
-  const [selectedInstances, setSelectedInstances] = React.useState<Instance[]>(
-    [],
-  )
+  const [selectedInstanceId, setSelectedInstanceId] =
+    React.useState<Instance['instanceId']>()
+  const selectedInstances: Instance[] = instances
+    ? instances.filter(instance => instance.instanceId === selectedInstanceId)
+    : []
 
   const onSelectionChangeCallback = React.useCallback(({detail}) => {
-    setSelectedInstances(detail.selectedItems)
+    setSelectedInstanceId(detail.selectedItems[0].instanceId)
   }, [])
 
   React.useEffect(() => {
@@ -119,8 +121,7 @@ export default function ClusterInstances() {
       const clusterName = getState(['app', 'clusters', 'selected'])
       clusterName && GetClusterInstances(clusterName)
     }
-    const clusterName = getState(['app', 'clusters', 'selected'])
-    clusterName && GetClusterInstances(clusterName)
+    tick()
     const timerId = setInterval(tick, 10000)
     return () => {
       clearInterval(timerId)
@@ -174,7 +175,7 @@ export default function ClusterInstances() {
         <Header
           variant="h3"
           description=""
-          counter={instances && `(${instances.length})`}
+          counter={instances ? `(${instances.length})` : '(0)'}
           actions={<InstanceActions instance={selectedInstances[0]} />}
         >
           {t('cluster.instances.title')}


### PR DESCRIPTION

## Description

Currently when clicking Start or Stop button on a cluster instance, when loading is terminated the button is still in enabled state.

The issue is rooted in the fact that `instances` is continuously fetched from the backend, its content changes, but the `selectedInstances` keeps a reference to the old/stale value.

This PR aims at solving this issue by obtaining `selectedInstances` value directly from `instances` through a filter operation.

## How Has This Been Tested?
* Verified that when clicking Stop button after the loading state the button is disabled
* Verified that when clicking Start button after the loading state the button is disabled

## Screenshots

<img width="1726" alt="Screenshot 2023-04-12 at 16 16 38" src="https://user-images.githubusercontent.com/25930133/231487056-2e944558-76a3-4b01-8415-7917ff18ce24.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
