### PR TITLE
Queues UI fixes

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -1009,6 +1009,7 @@
         "enableEfa": "Use EFA"
       },
       "advancedOptions": {
+        "label": "Advanced options",
         "iamPolicies": {
           "label": "IAM Policies"
         },

--- a/frontend/src/old-pages/Configure/Components.module.css
+++ b/frontend/src/old-pages/Configure/Components.module.css
@@ -1,0 +1,5 @@
+.space-between-wrap {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}

--- a/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
@@ -218,7 +218,7 @@ export function ComputeResource({
             })}
           </h4>
         </TextContent>
-        {index > 0 && (
+        {computeResources.length > 1 && (
           <Button onClick={remove}>
             {t(
               'wizard.queues.computeResource.removeComputeResourceButton.label',

--- a/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
@@ -1,6 +1,4 @@
 import {
-  Box,
-  Button,
   ColumnLayout,
   FormField,
   Input,
@@ -8,7 +6,9 @@ import {
   MultiselectProps,
   Checkbox,
   SpaceBetween,
-  Header,
+  TextContent,
+  Button,
+  Box,
 } from '@cloudscape-design/components'
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
 import {useCallback, useEffect, useMemo} from 'react'
@@ -26,6 +26,7 @@ import {
 } from './queues.types'
 import {InstanceType} from '../Components.types'
 import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
+import componentsStyle from '../Components.module.css'
 
 const queuesPath = ['app', 'wizard', 'config', 'Scheduling', 'SlurmQueues']
 const queuesErrorsPath = ['app', 'wizard', 'errors', 'queues']
@@ -208,23 +209,23 @@ export function ComputeResource({
 
   return (
     <SpaceBetween direction="vertical" size="s">
-      <Header
-        variant="h3"
-        actions={
-          index > 0 && (
-            <Button onClick={remove}>
-              {t(
-                'wizard.queues.computeResource.removeComputeResourceButton.label',
-              )}
-            </Button>
-          )
-        }
-      >
-        {t('wizard.queues.computeResource.name', {
-          index: index + 1,
-          crName: computeResource.Name,
-        })}
-      </Header>
+      <div className={componentsStyle['space-between-wrap']}>
+        <TextContent>
+          <h4>
+            {t('wizard.queues.computeResource.name', {
+              index: index + 1,
+              crName: computeResource.Name,
+            })}
+          </h4>
+        </TextContent>
+        {index > 0 && (
+          <Button onClick={remove}>
+            {t(
+              'wizard.queues.computeResource.removeComputeResourceButton.label',
+            )}
+          </Button>
+        )}
+      </div>
       <ColumnLayout columns={2}>
         <SpaceBetween direction="horizontal" size="l">
           <FormField label={t('wizard.queues.computeResource.staticNodes')}>

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -484,6 +484,39 @@ function Queue({index}: any) {
               })}
             </Header>
           }
+          footer={
+            <ExpandableSection headerText="Advanced options" variant="footer">
+              <SpaceBetween direction="vertical" size="xs">
+                <FormField label={t('wizard.queues.securityGroups.label')}>
+                  <SecurityGroups basePath={[...queuesPath, index]} />
+                </FormField>
+                <CustomAMISettings
+                  basePath={[...queuesPath, index]}
+                  appPath={['app', 'wizard', 'queues', index]}
+                  errorsPath={errorsPath}
+                  validate={queuesValidate}
+                />
+                <Header variant="h3">
+                  {t('wizard.queues.advancedOptions.scripts.title')}
+                </Header>
+                <ActionsEditor
+                  basePath={[...queuesPath, index]}
+                  errorsPath={errorsPath}
+                />
+                <Header variant="h3">
+                  {t('wizard.queues.advancedOptions.rootVolume.title')}
+                </Header>
+                <RootVolume
+                  basePath={[...queuesPath, index, 'ComputeSettings']}
+                  errorsPath={errorsPath}
+                />
+                <Header variant="h3">
+                  {t('wizard.queues.advancedOptions.iamPolicies.label')}
+                </Header>
+                <IamPoliciesEditor basePath={[...queuesPath, index]} />
+              </SpaceBetween>
+            </ExpandableSection>
+          }
         >
           <SpaceBetween direction="vertical" size="s">
             <ColumnLayout borders="horizontal">
@@ -576,37 +609,6 @@ function Queue({index}: any) {
                 canUseEFA={canUseEFA}
               />
             </ColumnLayout>
-            <ExpandableSection headerText="Advanced options">
-              <SpaceBetween direction="vertical" size="xs">
-                <FormField label={t('wizard.queues.securityGroups.label')}>
-                  <SecurityGroups basePath={[...queuesPath, index]} />
-                </FormField>
-                <CustomAMISettings
-                  basePath={[...queuesPath, index]}
-                  appPath={['app', 'wizard', 'queues', index]}
-                  errorsPath={errorsPath}
-                  validate={queuesValidate}
-                />
-                <Header variant="h3">
-                  {t('wizard.queues.advancedOptions.scripts.title')}
-                </Header>
-                <ActionsEditor
-                  basePath={[...queuesPath, index]}
-                  errorsPath={errorsPath}
-                />
-                <Header variant="h3">
-                  {t('wizard.queues.advancedOptions.rootVolume.title')}
-                </Header>
-                <RootVolume
-                  basePath={[...queuesPath, index, 'ComputeSettings']}
-                  errorsPath={errorsPath}
-                />
-                <Header variant="h3">
-                  {t('wizard.queues.advancedOptions.iamPolicies.label')}
-                </Header>
-                <IamPoliciesEditor basePath={[...queuesPath, index]} />
-              </SpaceBetween>
-            </ExpandableSection>
           </SpaceBetween>
         </Container>
       </div>

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -456,166 +456,150 @@ function Queue({index}: any) {
   }
 
   return (
-    <div className="queue">
-      <div className="queue-properties">
-        <Container
-          header={
-            <Header
-              variant="h2"
-              actions={
-                <SpaceBetween direction="horizontal" size="xs">
-                  <Button
-                    disabled={queues.length >= MAX_QUEUES}
-                    onClick={addQueue}
-                  >
-                    {t('wizard.queues.addQueueButton.label')}
-                  </Button>
-                  {queues.length > 1 && (
-                    <Button onClick={remove}>
-                      {t('wizard.queues.removeQueueButton.label')}
-                    </Button>
-                  )}
-                </SpaceBetween>
-              }
-            >
-              {t('wizard.queues.container.title', {
-                index: index + 1,
-                queueName: queue.Name,
-              })}
-            </Header>
-          }
-          footer={
-            <ExpandableSection
-              headerText={t('wizard.queues.advancedOptions.label')}
-              variant="footer"
-            >
-              <SpaceBetween direction="vertical" size="xs">
-                <FormField label={t('wizard.queues.securityGroups.label')}>
-                  <SecurityGroups basePath={[...queuesPath, index]} />
-                </FormField>
-                <CustomAMISettings
-                  basePath={[...queuesPath, index]}
-                  appPath={['app', 'wizard', 'queues', index]}
-                  errorsPath={errorsPath}
-                  validate={queuesValidate}
-                />
-                <Header variant="h3">
-                  {t('wizard.queues.advancedOptions.scripts.title')}
-                </Header>
-                <ActionsEditor
-                  basePath={[...queuesPath, index]}
-                  errorsPath={errorsPath}
-                />
-                <Header variant="h3">
-                  {t('wizard.queues.advancedOptions.rootVolume.title')}
-                </Header>
-                <RootVolume
-                  basePath={[...queuesPath, index, 'ComputeSettings']}
-                  errorsPath={errorsPath}
-                />
-                <Header variant="h3">
-                  {t('wizard.queues.advancedOptions.iamPolicies.label')}
-                </Header>
-                <IamPoliciesEditor basePath={[...queuesPath, index]} />
-              </SpaceBetween>
-            </ExpandableSection>
+    <Container
+      header={
+        <Header
+          variant="h2"
+          actions={
+            <SpaceBetween direction="horizontal" size="xs">
+              <Button disabled={queues.length >= MAX_QUEUES} onClick={addQueue}>
+                {t('wizard.queues.addQueueButton.label')}
+              </Button>
+              {queues.length > 1 && (
+                <Button onClick={remove}>
+                  {t('wizard.queues.removeQueueButton.label')}
+                </Button>
+              )}
+            </SpaceBetween>
           }
         >
-          <SpaceBetween direction="vertical" size="s">
-            <ColumnLayout borders="horizontal">
-              <SpaceBetween direction="vertical" size="m">
-                <ColumnLayout columns={2}>
-                  <FormField
-                    label={t('wizard.queues.name.label')}
-                    errorText={nameError}
-                  >
-                    <Input
-                      value={queue.Name}
-                      placeholder={t('wizard.queues.name.placeholder')}
-                      onKeyDown={e => {
-                        if (
-                          e.detail.key === 'Enter' ||
-                          e.detail.key === 'Escape'
-                        ) {
-                          e.stopPropagation()
-                          queueValidate(index)
-                        }
-                      }}
-                      onChange={({detail}) => renameQueue(detail.value)}
-                    />
-                  </FormField>
-                </ColumnLayout>
-                <ColumnLayout columns={2}>
-                  <FormField
-                    label={
-                      isMultiAZActive
-                        ? t('wizard.queues.subnet.label.multiple')
-                        : t('wizard.queues.subnet.label.single')
+          {t('wizard.queues.container.title', {
+            index: index + 1,
+            queueName: queue.Name,
+          })}
+        </Header>
+      }
+      footer={
+        <ExpandableSection
+          headerText={t('wizard.queues.advancedOptions.label')}
+          variant="footer"
+        >
+          <SpaceBetween direction="vertical" size="xs">
+            <FormField label={t('wizard.queues.securityGroups.label')}>
+              <SecurityGroups basePath={[...queuesPath, index]} />
+            </FormField>
+            <CustomAMISettings
+              basePath={[...queuesPath, index]}
+              appPath={['app', 'wizard', 'queues', index]}
+              errorsPath={errorsPath}
+              validate={queuesValidate}
+            />
+            <Header variant="h3">
+              {t('wizard.queues.advancedOptions.scripts.title')}
+            </Header>
+            <ActionsEditor
+              basePath={[...queuesPath, index]}
+              errorsPath={errorsPath}
+            />
+            <Header variant="h3">
+              {t('wizard.queues.advancedOptions.rootVolume.title')}
+            </Header>
+            <RootVolume
+              basePath={[...queuesPath, index, 'ComputeSettings']}
+              errorsPath={errorsPath}
+            />
+            <Header variant="h3">
+              {t('wizard.queues.advancedOptions.iamPolicies.label')}
+            </Header>
+            <IamPoliciesEditor basePath={[...queuesPath, index]} />
+          </SpaceBetween>
+        </ExpandableSection>
+      }
+    >
+      <SpaceBetween direction="vertical" size="s">
+        <ColumnLayout borders="horizontal">
+          <SpaceBetween direction="vertical" size="m">
+            <ColumnLayout columns={2}>
+              <FormField
+                label={t('wizard.queues.name.label')}
+                errorText={nameError}
+              >
+                <Input
+                  value={queue.Name}
+                  placeholder={t('wizard.queues.name.placeholder')}
+                  onKeyDown={e => {
+                    if (e.detail.key === 'Enter' || e.detail.key === 'Escape') {
+                      e.stopPropagation()
+                      queueValidate(index)
                     }
-                    errorText={subnetError}
-                  >
-                    {isMultiAZActive ? (
-                      <SubnetMultiSelect
-                        value={subnetsList}
-                        onChange={onSubnetMultiSelectChange}
-                      />
-                    ) : (
-                      <SubnetSelect
-                        value={subnetsList[0]}
-                        onChange={onSubnetSelectChange}
-                      />
-                    )}
-                  </FormField>
-                  <FormField label={t('wizard.queues.purchaseType.label')}>
-                    <Select
-                      selectedOption={itemToOption(
-                        findFirst(
-                          capacityTypes,
-                          x => x[0] === capacityType,
-                        ) || ['', ''],
-                      )}
-                      onChange={({detail}) => {
-                        setState(capacityTypePath, detail.selectedOption.value)
-                      }}
-                      options={capacityTypes.map(itemToOption)}
-                    />
-                  </FormField>
-                  {isMultiInstanceTypesActive ? (
-                    <FormField
-                      label={t('wizard.queues.allocationStrategy.title')}
-                    >
-                      <Select
-                        options={allocationStrategyOptions}
-                        selectedOption={
-                          allocationStrategyOptions.find(
-                            as => as.value === allocationStrategy,
-                          )!
-                        }
-                        onChange={setAllocationStrategy}
-                      />
-                    </FormField>
-                  ) : null}
-                  <Checkbox
-                    checked={enablePlacementGroup}
-                    disabled={!canUsePlacementGroup}
-                    onChange={_e => {
-                      setEnablePG(!enablePlacementGroup)
-                    }}
-                  >
-                    <Trans i18nKey="wizard.queues.placementGroup.label" />
-                  </Checkbox>
-                </ColumnLayout>
-              </SpaceBetween>
-              <ComputeResources
-                queue={queue}
-                index={index}
-                canUseEFA={canUseEFA}
-              />
+                  }}
+                  onChange={({detail}) => renameQueue(detail.value)}
+                />
+              </FormField>
+            </ColumnLayout>
+            <ColumnLayout columns={2}>
+              <FormField
+                label={
+                  isMultiAZActive
+                    ? t('wizard.queues.subnet.label.multiple')
+                    : t('wizard.queues.subnet.label.single')
+                }
+                errorText={subnetError}
+              >
+                {isMultiAZActive ? (
+                  <SubnetMultiSelect
+                    value={subnetsList}
+                    onChange={onSubnetMultiSelectChange}
+                  />
+                ) : (
+                  <SubnetSelect
+                    value={subnetsList[0]}
+                    onChange={onSubnetSelectChange}
+                  />
+                )}
+              </FormField>
+              <FormField label={t('wizard.queues.purchaseType.label')}>
+                <Select
+                  selectedOption={itemToOption(
+                    findFirst(capacityTypes, x => x[0] === capacityType) || [
+                      '',
+                      '',
+                    ],
+                  )}
+                  onChange={({detail}) => {
+                    setState(capacityTypePath, detail.selectedOption.value)
+                  }}
+                  options={capacityTypes.map(itemToOption)}
+                />
+              </FormField>
+              {isMultiInstanceTypesActive ? (
+                <FormField label={t('wizard.queues.allocationStrategy.title')}>
+                  <Select
+                    options={allocationStrategyOptions}
+                    selectedOption={
+                      allocationStrategyOptions.find(
+                        as => as.value === allocationStrategy,
+                      )!
+                    }
+                    onChange={setAllocationStrategy}
+                  />
+                </FormField>
+              ) : null}
+              <Checkbox
+                checked={enablePlacementGroup}
+                disabled={!canUsePlacementGroup}
+                onChange={_e => {
+                  setEnablePG(!enablePlacementGroup)
+                }}
+              >
+                <Trans i18nKey="wizard.queues.placementGroup.label" />
+              </Checkbox>
             </ColumnLayout>
           </SpaceBetween>
-        </Container>
-      </div>
-    </div>
+          <ComputeResources queue={queue} index={index} canUseEFA={canUseEFA} />
+        </ColumnLayout>
+      </SpaceBetween>
+    </Container>
   )
 }
 

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -485,7 +485,10 @@ function Queue({index}: any) {
             </Header>
           }
           footer={
-            <ExpandableSection headerText="Advanced options" variant="footer">
+            <ExpandableSection
+              headerText={t('wizard.queues.advancedOptions.label')}
+              variant="footer"
+            >
               <SpaceBetween direction="vertical" size="xs">
                 <FormField label={t('wizard.queues.securityGroups.label')}>
                   <SecurityGroups basePath={[...queuesPath, index]} />

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -558,6 +558,15 @@ function Queue({index}: any) {
                   />
                 )}
               </FormField>
+              <Checkbox
+                checked={enablePlacementGroup}
+                disabled={!canUsePlacementGroup}
+                onChange={_e => {
+                  setEnablePG(!enablePlacementGroup)
+                }}
+              >
+                <Trans i18nKey="wizard.queues.placementGroup.label" />
+              </Checkbox>
               <FormField label={t('wizard.queues.purchaseType.label')}>
                 <Select
                   selectedOption={itemToOption(
@@ -585,15 +594,6 @@ function Queue({index}: any) {
                   />
                 </FormField>
               ) : null}
-              <Checkbox
-                checked={enablePlacementGroup}
-                disabled={!canUsePlacementGroup}
-                onChange={_e => {
-                  setEnablePG(!enablePlacementGroup)
-                }}
-              >
-                <Trans i18nKey="wizard.queues.placementGroup.label" />
-              </Checkbox>
             </ColumnLayout>
           </SpaceBetween>
           <ComputeResources queue={queue} index={index} canUseEFA={canUseEFA} />

--- a/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
@@ -186,7 +186,7 @@ export function ComputeResource({index, queueIndex, computeResource}: any) {
             </FormField>
           </div>
           <FormField
-            label={t('wizard.queues.computeResource.instanceType')}
+            label={t('wizard.queues.computeResource.instanceType.label')}
             errorText={typeError}
           >
             <InstanceSelect

--- a/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SingleInstanceComputeResource.tsx
@@ -6,6 +6,7 @@ import {
   Input,
   Checkbox,
   SpaceBetween,
+  TextContent,
 } from '@cloudscape-design/components'
 import {useEffect} from 'react'
 import {Trans, useTranslation} from 'react-i18next'
@@ -15,6 +16,7 @@ import {
   QueueValidationErrors,
   SingleInstanceComputeResource,
 } from './queues.types'
+import componentsStyle from '../Components.module.css'
 
 const queuesPath = ['app', 'wizard', 'config', 'Scheduling', 'SlurmQueues']
 const queuesErrorsPath = ['app', 'wizard', 'errors', 'queues']
@@ -147,23 +149,23 @@ export function ComputeResource({index, queueIndex, computeResource}: any) {
   return (
     <div className="compute-resource">
       <div style={{display: 'flex', flexDirection: 'column', gap: '10px'}}>
-        <ColumnLayout columns={2}>
-          <h3>
-            {t('wizard.queues.computeResource.name', {
-              index: index + 1,
-              crName: computeResource.Name,
-            })}
-          </h3>
-          <Box margin={{top: 'xs'}} textAlign="right">
-            {index > 0 && (
-              <Button onClick={remove}>
-                {t(
-                  'wizard.queues.computeResource.removeComputeResourceButton.label',
-                )}
-              </Button>
-            )}
-          </Box>
-        </ColumnLayout>
+        <div className={componentsStyle['space-between-wrap']}>
+          <TextContent>
+            <h4>
+              {t('wizard.queues.computeResource.name', {
+                index: index + 1,
+                crName: computeResource.Name,
+              })}
+            </h4>
+          </TextContent>
+          {computeResources.length > 1 && (
+            <Button onClick={remove}>
+              {t(
+                'wizard.queues.computeResource.removeComputeResourceButton.label',
+              )}
+            </Button>
+          )}
+        </div>
         <ColumnLayout columns={2}>
           <div style={{display: 'flex', flexDirection: 'row', gap: '20px'}}>
             <FormField label={t('wizard.queues.computeResource.staticNodes')}>


### PR DESCRIPTION
## Changes

- [Show the remove compute resource button also for the first item](https://github.com/aws/aws-parallelcluster-ui/commit/4ce5f15a6ef7614a54b78d3a041ac3afdcbbc227)
- [Move queues advanced options inside footer](https://github.com/aws/aws-parallelcluster-ui/commit/f312ff1277389c1341e352bcfd12f6e31821777d)
- [Move placement group checkbox near SubnetID](https://github.com/aws/aws-parallelcluster-ui/commit/09b23b7fbce085ce5fb35ae0cc5a85d8f196f8ea)
- [Use h4 header for compute resource name](https://github.com/aws/aws-parallelcluster-ui/commit/dfa62df63ee1e8627d8142d4f55c20b281bd0741)

## How Has This Been Tested?

![Screenshot 2023-04-12 at 17 00 11](https://user-images.githubusercontent.com/3091286/231501006-6a20082a-867b-40ae-8574-744f4a53c043.png)

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
