### PR TITLE
Add StatusIndicator to AMI state inside custom images

### DIFF
--- a/frontend/src/components/Status.tsx
+++ b/frontend/src/components/Status.tsx
@@ -16,7 +16,7 @@ import {
   ComputeFleetStatus,
 } from '../types/clusters'
 import {InstanceState, Instance, EC2Instance} from '../types/instances'
-import {ImageBuildStatus} from '../types/images'
+import {Ec2AmiState, ImageBuildStatus} from '../types/images'
 import {StackEvent} from '../types/stackevents'
 import {JobStateCode} from '../types/jobs'
 import capitalize from 'lodash/capitalize'
@@ -185,6 +185,24 @@ function CustomImageStatusIndicator({
   )
 }
 
+function AMIStatusIndicator({state}: {state: Ec2AmiState}) {
+  const statusMap: Record<Ec2AmiState, StatusIndicatorProps.Type> = {
+    AVAILABLE: 'success',
+    DEREGISTERED: 'error',
+    ERROR: 'error',
+    FAILED: 'error',
+    INVALID: 'error',
+    PENDING: 'in-progress',
+    TRANSIENT: 'in-progress',
+  }
+
+  return (
+    <StatusIndicator type={statusMap[state]}>
+      {formatStatus(state)}
+    </StatusIndicator>
+  )
+}
+
 export {
   ClusterStatusIndicator,
   ComputeFleetStatusIndicator,
@@ -192,4 +210,5 @@ export {
   JobStatusIndicator,
   StackEventStatusIndicator,
   CustomImageStatusIndicator,
+  AMIStatusIndicator,
 }

--- a/frontend/src/old-pages/Images/CustomImages/CustomImageDetails.tsx
+++ b/frontend/src/old-pages/Images/CustomImages/CustomImageDetails.tsx
@@ -39,7 +39,10 @@ import EmptyState from '../../../components/EmptyState'
 import {truncate} from 'lodash'
 import {ReadonlyConfigView} from '../../../components/ConfigView'
 import {extendCollectionsOptions} from '../../../shared/extendCollectionsOptions'
-import {CustomImageStatusIndicator} from '../../../components/Status'
+import {
+  AMIStatusIndicator,
+  CustomImageStatusIndicator,
+} from '../../../components/Status'
 
 const customImagesPath = ['app', 'customImages']
 
@@ -98,7 +101,9 @@ function CustomImageProperties() {
           <ValueWithLabel
             label={t('customImages.imageDetails.properties.state')}
           >
-            {image.ec2AmiInfo && image.ec2AmiInfo.state}
+            {image.ec2AmiInfo && (
+              <AMIStatusIndicator state={image.ec2AmiInfo.state} />
+            )}
             {!image.ec2AmiInfo && loadingText}
           </ValueWithLabel>
         </SpaceBetween>


### PR DESCRIPTION
## How Has This Been Tested?

Inspected an existing custom image and the AMI state is displayed correctly

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
