### PR TITLE
Remove disable rollback when creating a cluster

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -1053,8 +1053,7 @@
         "title": "Cluster configuration",
         "description": "Check/edit the yaml file that is used to create the cluster",
         "pending": "{{action}} request pending...",
-        "forceUpdate": "Force update: Edit the cluster while the compute fleet is still running.",
-        "disableRollback": "Disable rollback: Retain the cluster resources in case of a cluster create failure."
+        "forceUpdate": "Force update: Edit the cluster while the compute fleet is still running."
       },
       "flashBar": {
         "success": "Success"

--- a/frontend/src/__tests__/CreateCluster.test.ts
+++ b/frontend/src/__tests__/CreateCluster.test.ts
@@ -54,7 +54,6 @@ describe('given a CreateCluster command and a cluster configuration', () => {
         mockRegion,
         mockSelectedRegion,
         false,
-        false,
         mockSuccessCallback,
       )
       expect(mockSuccessCallback).toHaveBeenCalledTimes(1)
@@ -70,35 +69,12 @@ describe('given a CreateCluster command and a cluster configuration', () => {
           clusterConfiguration,
           mockRegion,
           mockSelectedRegion,
-          false,
           mockDryRun,
         )
         expect(mockRequest).toHaveBeenCalledTimes(1)
         expect(mockRequest).toHaveBeenCalledWith(
           'post',
           'api?path=/v3/clusters&dryrun=true&region=some-region',
-          expect.any(Object),
-          expect.any(Object),
-          expect.any(Object),
-        )
-      })
-    })
-
-    describe('when stack rollback on failure is disabled', () => {
-      const mockDisableRollback = true
-
-      it('should add set the rollbackOnFailure query parameter', async () => {
-        await CreateCluster(
-          clusterName,
-          clusterConfiguration,
-          mockRegion,
-          mockSelectedRegion,
-          mockDisableRollback,
-        )
-        expect(mockRequest).toHaveBeenCalledTimes(1)
-        expect(mockRequest).toHaveBeenCalledWith(
-          'post',
-          'api?path=/v3/clusters&rollbackOnFailure=false&region=some-region',
           expect.any(Object),
           expect.any(Object),
           expect.any(Object),
@@ -128,7 +104,6 @@ describe('given a CreateCluster command and a cluster configuration', () => {
         clusterConfiguration,
         mockRegion,
         mockSelectedRegion,
-        false,
         false,
         undefined,
         mockErrorCallback,

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -76,14 +76,12 @@ function CreateCluster(
   clusterConfig: any,
   region: string,
   selectedRegion: string,
-  disableRollback = false,
   dryrun = false,
   successCallback?: Callback,
   errorCallback?: Callback,
 ) {
   var url = 'api?path=/v3/clusters'
   url += dryrun ? '&dryrun=true' : ''
-  url += disableRollback ? '&rollbackOnFailure=false' : ''
   url += region ? `&region=${region}` : ''
   var body = {clusterName: clusterName, clusterConfiguration: clusterConfig}
   request('post', url, body)

--- a/frontend/src/old-pages/Configure/Create.tsx
+++ b/frontend/src/old-pages/Configure/Create.tsx
@@ -223,7 +223,9 @@ function Create() {
       }
     >
       <SpaceBetween direction="vertical" size="s">
-        <Flashbar {...flashbarProps} />
+        {flashbarProps.items.length > 0 ? (
+          <Flashbar {...flashbarProps} />
+        ) : null}
         <ConfigView
           config={clusterConfig}
           pending={!clusterConfig}

--- a/frontend/src/old-pages/Configure/Create.tsx
+++ b/frontend/src/old-pages/Configure/Create.tsx
@@ -58,8 +58,6 @@ function handleCreate(
 ) {
   const clusterName = getState(['app', 'wizard', 'clusterName'])
   const editing = getState(['app', 'wizard', 'editing'])
-  const disableRollback =
-    getState(['app', 'wizard', 'disableRollback']) || false
   const forceUpdate = getState(['app', 'wizard', 'forceUpdate'])
   const clusterConfig = getState(configPath) || ''
   const dryRun = false
@@ -99,7 +97,6 @@ function handleCreate(
       clusterConfig,
       region,
       selectedRegion,
-      disableRollback,
       dryRun,
       successHandler,
       errHandler,
@@ -114,7 +111,6 @@ function handleDryRun() {
   const clusterConfig = getState(configPath) || ''
   const region = getState(['app', 'wizard', 'config', 'Region'])
   const selectedRegion = getState(['app', 'selectedRegion'])
-  const disableRollback = false
   const dryRun = true
   var errHandler = (err: any) => {
     setState(['app', 'wizard', 'errors', 'create'], err)
@@ -141,7 +137,6 @@ function handleDryRun() {
       clusterConfig,
       region,
       selectedRegion,
-      disableRollback,
       dryRun,
       successHandler,
       errHandler,
@@ -196,8 +191,6 @@ function Create() {
   const {t} = useTranslation()
   const clusterConfig = useState(configPath)
   const forceUpdate = useState(['app', 'wizard', 'forceUpdate']) || false
-  const disableRollback =
-    useState(['app', 'wizard', 'disableRollback']) || false
   const errors = useState(['app', 'wizard', 'errors', 'create'])
   const pending = useState(['app', 'wizard', 'pending'])
   const editing = getState(['app', 'wizard', 'editing'])
@@ -252,16 +245,6 @@ function Create() {
             }
           >
             {t('wizard.create.configuration.forceUpdate')}
-          </Checkbox>
-        )}
-        {!editing && (
-          <Checkbox
-            checked={disableRollback}
-            onChange={() =>
-              setState(['app', 'wizard', 'disableRollback'], !disableRollback)
-            }
-          >
-            {t('wizard.create.configuration.disableRollback')}
           </Checkbox>
         )}
       </SpaceBetween>


### PR DESCRIPTION
## Changes

- [Remove disable rollback when creating a cluster](https://github.com/aws/aws-parallelcluster-ui/commit/68a90238bf4809a32d4b7729a7072a521502b2c7)
- [Remove extra spacing from Create container when no errors are shown](https://github.com/aws/aws-parallelcluster-ui/commit/48e7cd58eb9d4f08e201a6d5e362eb64ad082c97)

## How Has This Been Tested?

- Dry run and create works fine locally

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
