### PR TITLE
Update Storage section layout 

### DIFF
--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -294,154 +294,157 @@ export function FsxLustreSettings({index}: any) {
   )
 
   return (
-    <ColumnLayout columns={2} borders="vertical">
-      <FormField
-        label={
-          <Trans
-            i18nKey="wizard.storage.Fsx.lustreType.label"
-            values={{storageCapacity: storageCapacity}}
-          />
-        }
-        info={
-          <InfoLink
-            helpPanel={
-              <TitleDescriptionHelpPanel
-                title={t('wizard.storage.Fsx.lustreType.label')}
-                description={
-                  <Trans i18nKey="wizard.storage.Fsx.lustreType.help">
-                    <a
-                      rel="noreferrer"
-                      target="_blank"
-                      href="https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-FsxLustreSettings-DeploymentType"
-                    ></a>
-                  </Trans>
-                }
-              />
-            }
-          />
-        }
-      >
-        <Select
-          selectedOption={strToOption(lustreType || 'PERSISTENT_1')}
-          onChange={({detail}) => {
-            setState(lustreTypePath, detail.selectedOption.value)
-            setDefaultStorageThroughput(
-              detail.selectedOption.value!,
-              storageThroughputPath,
-            )
-          }}
-          options={lustreTypes.map(strToOption)}
-        />
-      </FormField>
-      <FormField label={t('wizard.storage.Fsx.capacity.label')}>
-        <Input
-          value={storageCapacity}
-          placeholder={t('wizard.storage.Fsx.capacity.placeholder')}
-          step={1200}
-          onChange={({detail}) => {
-            setState(storageCapacityPath, detail.value)
-          }}
-          onBlur={_e => {
-            setState(storageCapacityPath, clampCapacity(storageCapacity))
-          }}
-          type="number"
-        />
-      </FormField>
-      {lustreType === 'PERSISTENT_1' && (
-        <>
-          <FormField
-            label={t('wizard.storage.Fsx.import.label')}
-            info={
-              <InfoLink
-                helpPanel={
-                  <TitleDescriptionHelpPanel
-                    title={t('wizard.storage.Fsx.import.label')}
-                    description={
-                      <Trans i18nKey="wizard.storage.Fsx.import.help">
-                        <a
-                          rel="noreferrer"
-                          target="_blank"
-                          href="https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-FsxLustreSettings-ImportPath"
-                        ></a>
-                      </Trans>
-                    }
-                  />
-                }
-              />
-            }
-          >
-            <Input
-              placeholder={t('wizard.storage.Fsx.import.placeholder')}
-              value={importPath}
-              onChange={({detail}) => setImportPath(detail.value)}
-            />
-          </FormField>
-          <FormField
-            label={t('wizard.storage.Fsx.export.label')}
-            info={
-              <InfoLink
-                helpPanel={
-                  <TitleDescriptionHelpPanel
-                    title={t('wizard.storage.Fsx.export.label')}
-                    description={
-                      <Trans i18nKey="wizard.storage.Fsx.export.help">
-                        <a
-                          rel="noreferrer"
-                          target="_blank"
-                          href="https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-FsxLustreSettings-ExportPath"
-                        ></a>
-                      </Trans>
-                    }
-                  />
-                }
-              />
-            }
-          >
-            <Input
-              placeholder={t('wizard.storage.Fsx.export.placeholder')}
-              value={exportPath}
-              onChange={({detail}) => {
-                setExportPath(detail.value)
-              }}
-            />
-          </FormField>
-        </>
-      )}
-
-      {isPersistentFsx(lustreType) && (
+    <SpaceBetween direction="vertical" size="m">
+      <ColumnLayout columns={2}>
         <FormField
-          label={t('wizard.storage.Fsx.throughput.label')}
+          label={
+            <Trans
+              i18nKey="wizard.storage.Fsx.lustreType.label"
+              values={{storageCapacity: storageCapacity}}
+            />
+          }
           info={
             <InfoLink
               helpPanel={
                 <TitleDescriptionHelpPanel
-                  title={t('wizard.storage.Fsx.throughput.label')}
-                  description={t('wizard.storage.Fsx.throughput.help')}
-                  footerLinks={throughputFooterLinks}
+                  title={t('wizard.storage.Fsx.lustreType.label')}
+                  description={
+                    <Trans i18nKey="wizard.storage.Fsx.lustreType.help">
+                      <a
+                        rel="noreferrer"
+                        target="_blank"
+                        href="https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-FsxLustreSettings-DeploymentType"
+                      ></a>
+                    </Trans>
+                  }
                 />
               }
             />
           }
         >
           <Select
-            selectedOption={strToOption(storageThroughput || '')}
+            selectedOption={strToOption(lustreType || 'PERSISTENT_1')}
             onChange={({detail}) => {
-              setState(storageThroughputPath, detail.selectedOption.value)
+              setState(lustreTypePath, detail.selectedOption.value)
+              setDefaultStorageThroughput(
+                detail.selectedOption.value!,
+                storageThroughputPath,
+              )
             }}
-            options={
-              lustreType == 'PERSISTENT_1'
-                ? storageThroughputsP1.map(strToOption)
-                : storageThroughputsP2.map(strToOption)
-            }
+            options={lustreTypes.map(strToOption)}
           />
         </FormField>
+      </ColumnLayout>
+      <ColumnLayout columns={2}>
+        <FormField label={t('wizard.storage.Fsx.capacity.label')}>
+          <Input
+            value={storageCapacity}
+            placeholder={t('wizard.storage.Fsx.capacity.placeholder')}
+            step={1200}
+            onChange={({detail}) => {
+              setState(storageCapacityPath, detail.value)
+            }}
+            onBlur={_e => {
+              setState(storageCapacityPath, clampCapacity(storageCapacity))
+            }}
+            type="number"
+          />
+        </FormField>
+      </ColumnLayout>
+      {lustreType === 'PERSISTENT_1' && (
+        <>
+          <ColumnLayout columns={2}>
+            <FormField
+              label={t('wizard.storage.Fsx.import.label')}
+              info={
+                <InfoLink
+                  helpPanel={
+                    <TitleDescriptionHelpPanel
+                      title={t('wizard.storage.Fsx.import.label')}
+                      description={
+                        <Trans i18nKey="wizard.storage.Fsx.import.help">
+                          <a
+                            rel="noreferrer"
+                            target="_blank"
+                            href="https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-FsxLustreSettings-ImportPath"
+                          ></a>
+                        </Trans>
+                      }
+                    />
+                  }
+                />
+              }
+            >
+              <Input
+                placeholder={t('wizard.storage.Fsx.import.placeholder')}
+                value={importPath}
+                onChange={({detail}) => setImportPath(detail.value)}
+              />
+            </FormField>
+          </ColumnLayout>
+          <ColumnLayout columns={2}>
+            <FormField
+              label={t('wizard.storage.Fsx.export.label')}
+              info={
+                <InfoLink
+                  helpPanel={
+                    <TitleDescriptionHelpPanel
+                      title={t('wizard.storage.Fsx.export.label')}
+                      description={
+                        <Trans i18nKey="wizard.storage.Fsx.export.help">
+                          <a
+                            rel="noreferrer"
+                            target="_blank"
+                            href="https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-FsxLustreSettings-ExportPath"
+                          ></a>
+                        </Trans>
+                      }
+                    />
+                  }
+                />
+              }
+            >
+              <Input
+                placeholder={t('wizard.storage.Fsx.export.placeholder')}
+                value={exportPath}
+                onChange={({detail}) => {
+                  setExportPath(detail.value)
+                }}
+              />
+            </FormField>
+          </ColumnLayout>
+        </>
       )}
-      {isDeletionPolicyEnabled && (
-        <DeletionPolicyFormField
-          options={supportedDeletionPolicies}
-          value={deletionPolicy}
-          onDeletionPolicyChange={onDeletionPolicyChange}
-        />
+
+      {isPersistentFsx(lustreType) && (
+        <ColumnLayout columns={2}>
+          <FormField
+            label={t('wizard.storage.Fsx.throughput.label')}
+            info={
+              <InfoLink
+                helpPanel={
+                  <TitleDescriptionHelpPanel
+                    title={t('wizard.storage.Fsx.throughput.label')}
+                    description={t('wizard.storage.Fsx.throughput.help')}
+                    footerLinks={throughputFooterLinks}
+                  />
+                }
+              />
+            }
+          >
+            <Select
+              selectedOption={strToOption(storageThroughput || '')}
+              onChange={({detail}) => {
+                setState(storageThroughputPath, detail.selectedOption.value)
+              }}
+              options={
+                lustreType == 'PERSISTENT_1'
+                  ? storageThroughputsP1.map(strToOption)
+                  : storageThroughputsP2.map(strToOption)
+              }
+            />
+          </FormField>
+        </ColumnLayout>
       )}
       <SpaceBetween direction="horizontal" size="xs">
         <Checkbox checked={compression !== null} onChange={toggleCompression}>
@@ -464,7 +467,16 @@ export function FsxLustreSettings({index}: any) {
           }
         />
       </SpaceBetween>
-    </ColumnLayout>
+      {isDeletionPolicyEnabled && (
+        <ColumnLayout columns={2}>
+          <DeletionPolicyFormField
+            options={supportedDeletionPolicies}
+            value={deletionPolicy}
+            onDeletionPolicyChange={onDeletionPolicyChange}
+          />
+        </ColumnLayout>
+      )}
+    </SpaceBetween>
   )
 }
 

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -549,8 +549,34 @@ export function EfsSettings({index}: any) {
   )
 
   return (
-    <SpaceBetween direction="vertical" size="s">
-      <ColumnLayout columns={2} borders="vertical">
+    <SpaceBetween direction="vertical" size="m">
+      <ColumnLayout columns={2}>
+        <SpaceBetween direction="vertical" size="xxs">
+          <CheckboxWithHelpPanel
+            checked={encrypted}
+            onChange={toggleEncrypted}
+            helpPanel={
+              <TitleDescriptionHelpPanel
+                title={t('wizard.storage.Efs.encrypted.label')}
+                description={t('wizard.storage.Efs.encrypted.help')}
+                footerLinks={encryptionFooterLinks}
+              />
+            }
+          >
+            {t('wizard.storage.Efs.encrypted.label')}
+          </CheckboxWithHelpPanel>
+          {encrypted ? (
+            <Input
+              value={kmsId}
+              placeholder={t('wizard.storage.Efs.encrypted.kmsId')}
+              onChange={({detail}) => {
+                setState(kmsPath, detail.value)
+              }}
+            />
+          ) : null}
+        </SpaceBetween>
+      </ColumnLayout>
+      <ColumnLayout columns={2}>
         <FormField label={t('wizard.storage.Efs.performanceMode.label')}>
           <Select
             selectedOption={strToOption(performanceMode)}
@@ -560,13 +586,8 @@ export function EfsSettings({index}: any) {
             options={performanceModes.map(strToOption)}
           />
         </FormField>
-        {isDeletionPolicyEnabled && (
-          <DeletionPolicyFormField
-            options={supportedDeletionPolicies}
-            value={deletionPolicy}
-            onDeletionPolicyChange={onDeletionPolicyChange}
-          />
-        )}
+      </ColumnLayout>
+      <ColumnLayout columns={2}>
         <SpaceBetween direction="vertical" size="xxs">
           <CheckboxWithHelpPanel
             helpPanel={
@@ -602,31 +623,16 @@ export function EfsSettings({index}: any) {
             />
           )}
         </SpaceBetween>
-        <SpaceBetween direction="vertical" size="xxs">
-          <CheckboxWithHelpPanel
-            checked={encrypted}
-            onChange={toggleEncrypted}
-            helpPanel={
-              <TitleDescriptionHelpPanel
-                title={t('wizard.storage.Efs.encrypted.label')}
-                description={t('wizard.storage.Efs.encrypted.help')}
-                footerLinks={encryptionFooterLinks}
-              />
-            }
-          >
-            {t('wizard.storage.Efs.encrypted.label')}
-          </CheckboxWithHelpPanel>
-          {encrypted ? (
-            <Input
-              value={kmsId}
-              placeholder={t('wizard.storage.Efs.encrypted.kmsId')}
-              onChange={({detail}) => {
-                setState(kmsPath, detail.value)
-              }}
-            />
-          ) : null}
-        </SpaceBetween>
       </ColumnLayout>
+      {isDeletionPolicyEnabled && (
+        <ColumnLayout columns={2}>
+          <DeletionPolicyFormField
+            options={supportedDeletionPolicies}
+            value={deletionPolicy}
+            onDeletionPolicyChange={onDeletionPolicyChange}
+          />
+        </ColumnLayout>
+      )}
     </SpaceBetween>
   )
 }

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -14,7 +14,7 @@
 import React, {useCallback} from 'react'
 import i18next from 'i18next'
 import {Trans, useTranslation} from 'react-i18next'
-import {findFirst, clamp} from '../../util'
+import {clamp} from '../../util'
 
 // UI Elements
 import {
@@ -901,8 +901,8 @@ function StorageInstance({index}: any) {
         </Header>
       }
     >
-      <div style={{display: 'flex', flexDirection: 'column', gap: '10px'}}>
-        <ColumnLayout columns={2} borders="vertical">
+      <SpaceBetween direction="vertical" size="m">
+        <ColumnLayout columns={2}>
           <FormField
             label={t('wizard.storage.instance.sourceName.label')}
             errorText={storageNameErrors}
@@ -913,6 +913,8 @@ function StorageInstance({index}: any) {
               placeholder={t('wizard.storage.instance.sourceName.placeholder')}
             />
           </FormField>
+        </ColumnLayout>
+        <ColumnLayout columns={2}>
           <FormField
             label={t('wizard.storage.instance.mountPoint.label')}
             info={
@@ -934,6 +936,8 @@ function StorageInstance({index}: any) {
               }}
             />
           </FormField>
+        </ColumnLayout>
+        <ColumnLayout columns={2}>
           <SpaceBetween direction="vertical" size="xxs">
             {STORAGE_TYPE_PROPS[storageType].maxToCreate > 0 ? (
               <SpaceBetween direction="horizontal" size="s">
@@ -1073,7 +1077,7 @@ function StorageInstance({index}: any) {
             FsxOntap: null,
             FsxOpenZfs: null,
           }[storageType]}
-      </div>
+      </SpaceBetween>
     </Container>
   )
 }

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -713,7 +713,7 @@ export function EbsSettings({index}: any) {
 
   return (
     <SpaceBetween direction="vertical" size="m">
-      <ColumnLayout columns={2} borders="vertical">
+      <ColumnLayout columns={2}>
         <FormField label={t('wizard.storage.Ebs.volumeType.label')}>
           <Select
             placeholder={t('wizard.queues.validation.scriptWithArgs', {
@@ -726,6 +726,8 @@ export function EbsSettings({index}: any) {
             options={volumeTypes.map(strToOption)}
           />
         </FormField>
+      </ColumnLayout>
+      <ColumnLayout columns={2}>
         <FormField
           label={t('wizard.storage.Ebs.volumeSize.label')}
           errorText={volumeErrors}
@@ -741,6 +743,8 @@ export function EbsSettings({index}: any) {
             }}
           />
         </FormField>
+      </ColumnLayout>
+      <ColumnLayout columns={2}>
         <SpaceBetween direction="vertical" size="xxs">
           <CheckboxWithHelpPanel
             checked={encrypted}
@@ -766,6 +770,8 @@ export function EbsSettings({index}: any) {
             />
           ) : null}
         </SpaceBetween>
+      </ColumnLayout>
+      <ColumnLayout columns={2}>
         <SpaceBetween direction="vertical" size="xxs">
           <CheckboxWithHelpPanel
             checked={snapshotId !== null}
@@ -792,14 +798,16 @@ export function EbsSettings({index}: any) {
             />
           )}
         </SpaceBetween>
-        {isDeletionPolicyEnabled && (
+      </ColumnLayout>
+      {isDeletionPolicyEnabled && (
+        <ColumnLayout columns={2}>
           <DeletionPolicyFormField
             options={supportedDeletionPolicies}
             value={deletionPolicy}
             onDeletionPolicyChange={onDeletionPolicyChange}
           />
-        )}
-      </ColumnLayout>
+        </ColumnLayout>
+      )}
     </SpaceBetween>
   )
 }

--- a/frontend/src/old-pages/Configure/Storage/AddStorageForm.tsx
+++ b/frontend/src/old-pages/Configure/Storage/AddStorageForm.tsx
@@ -14,10 +14,11 @@ import {useTranslation} from 'react-i18next'
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
 import {
   Button,
-  FormField,
   SpaceBetween,
   Multiselect,
   MultiselectProps,
+  ColumnLayout,
+  TextContent,
 } from '@cloudscape-design/components'
 import {StorageType} from '../Storage.types'
 import {useMemo} from 'react'
@@ -55,8 +56,11 @@ export function AddStorageForm({storageTypes, onSubmit}: Props) {
     }, [])
 
   return (
-    <SpaceBetween size="s">
-      <FormField label={t('wizard.storage.container.storageTypes')}>
+    <SpaceBetween direction="vertical" size="xxxs">
+      <TextContent>
+        <h5>{t('wizard.storage.container.storageTypes')}</h5>
+      </TextContent>
+      <ColumnLayout columns={2}>
         <Multiselect
           tokenLimit={0}
           placeholder={t('wizard.storage.container.storageTypesPlaceholder')}
@@ -64,10 +68,10 @@ export function AddStorageForm({storageTypes, onSubmit}: Props) {
           onChange={onSelectChange}
           options={storageTypesToDisplay}
         />
-      </FormField>
-      <Button onClick={onAddStorageClick} disabled={isAddStorageDisabled}>
-        {t('wizard.storage.container.addStorage')}
-      </Button>
+        <Button onClick={onAddStorageClick} disabled={isAddStorageDisabled}>
+          {t('wizard.storage.container.addStorage')}
+        </Button>
+      </ColumnLayout>
     </SpaceBetween>
   )
 }


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR updates the layout of the Storage section, with the goals of:
- grouping together related fields
- stacking fields vertically in a single-column layout

## Changes

- make the Multiselect of the Add Storage section the same size of the other fields
- reorganize shared fields
- reorganize fields in EBS, EFS and Fsx Lustre

**Please note:** introducing a single column layout also where a smaller second column had been designed (e.g. volume size). This is due to how responsive layouts are implemented in CloudScape, which makes it very hard to create a custom grid within a ColumnLayout, which is within a Wizard component itself.

## Screenshots

**Add storage section**
<img width="748" alt="Screenshot 2023-04-13 at 15 01 53" src="https://user-images.githubusercontent.com/11457067/231768443-a7f48fb7-a2cd-424e-bd57-0ec5a309e79c.png">

**Sample storage layout: EFS**
<img width="753" alt="Screenshot 2023-04-13 at 15 02 12" src="https://user-images.githubusercontent.com/11457067/231768055-381c52ea-ae28-46b3-b797-eca07af545be.png">

**Sample storage layout: FSX for Lustre**
<img width="749" alt="Screenshot 2023-04-13 at 15 09 54" src="https://user-images.githubusercontent.com/11457067/231768877-57b680f2-946c-49fd-9aa2-06c91c3269cb.png">

**Sample storage layout: EBS**
<img width="742" alt="Screenshot 2023-04-13 at 15 10 01" src="https://user-images.githubusercontent.com/11457067/231768979-4090ecf2-b2ce-4179-88cf-be0d00320a82.png">

**Sample storage layout: OpenZFS and ONTAP**
<img width="751" alt="Screenshot 2023-04-13 at 15 10 21" src="https://user-images.githubusercontent.com/11457067/231769045-9212892e-4628-45bf-8ee4-3db722def42c.png">

## How Has This Been Tested?

- manually, by checking all breakpoints
- manually, by toggling the "use existing" checkbox on and off
- run e2e locally

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
