### PR TITLE
Clear ProvisionedThroughput in EFS storage when corresponding checkbox is unchecked

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -772,9 +772,6 @@
           }
         }
       },
-      "validation": {
-        "volumeSize": "You must specify a valid volume size."
-      },
       "Fsx": {
         "existing": {
           "fsxLustre": "FSx Lustre Filesystem",
@@ -838,6 +835,9 @@
             "title": "ThroughputMode section",
             "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-EfsSettings-ThroughputMode"
           }
+        },
+        "validation": {
+          "provisionedThroughput": "You must specify a valid provisioned throughput value."
         }
       },
       "Ebs": {
@@ -867,6 +867,9 @@
             "title": "SnapshotID",
             "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-EbsSettings-SnapshotId"
           }
+        },
+        "validation": {
+          "volumeSize": "You must specify a valid volume size."
         }
       },
       "instance": {

--- a/frontend/src/old-pages/Configure/Storage/__tests__/validateEfs.test.ts
+++ b/frontend/src/old-pages/Configure/Storage/__tests__/validateEfs.test.ts
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+// with the License. A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {EfsStorage} from '../../Storage.types'
+import {validateEfs} from '../storage.validators'
+
+describe('Given a function to validate an EFS storage', () => {
+  describe('When the throughput mode is "provisioned"', () => {
+    describe('when the provisioned throughput is NaN', () => {
+      const efsStorage: EfsStorage = {
+        Name: 'Efs',
+        MountDir: '/moundDir',
+        StorageType: 'Efs',
+        EfsSettings: {
+          ThroughputMode: 'provisioned',
+          ProvisionedThroughput: NaN,
+        },
+      }
+      it('should fail the validation', () => {
+        expect(validateEfs(efsStorage)).toEqual([
+          false,
+          'provisioned_throughput_undefined',
+        ])
+      })
+    })
+
+    describe('when the provisioned throughput is between 1 and 1024', () => {
+      const efsStorage: EfsStorage = {
+        Name: 'Efs',
+        MountDir: '/moundDir',
+        StorageType: 'Efs',
+        EfsSettings: {
+          ThroughputMode: 'provisioned',
+          ProvisionedThroughput: 256,
+        },
+      }
+      it('should be validated', () => {
+        expect(validateEfs(efsStorage)).toEqual([true])
+      })
+    })
+  })
+})

--- a/frontend/src/old-pages/Configure/Storage/storage.validators.ts
+++ b/frontend/src/old-pages/Configure/Storage/storage.validators.ts
@@ -1,4 +1,4 @@
-import {EbsStorage, Storage} from '../Storage.types'
+import {EbsStorage, EfsStorage, Storage} from '../Storage.types'
 import {mapStorageToExternalFileSystem} from './storage.mapper'
 
 export const STORAGE_NAME_MAX_LENGTH = 30
@@ -11,9 +11,15 @@ export const storageNameErrorsMapping = {
 type StorageNameErrorKind = keyof typeof storageNameErrorsMapping
 
 export const ebsErrorsMapping = {
-  invalid_ebs_size: 'wizard.storage.validation.volumeSize',
+  invalid_ebs_size: 'wizard.storage.Ebs.validation.volumeSize',
 }
 type EbsErrorKind = keyof typeof ebsErrorsMapping
+
+export const efsErrorsMapping = {
+  provisioned_throughput_undefined:
+    'wizard.storage.Efs.validation.provisionedThroughput',
+}
+type EfsErrorKind = keyof typeof efsErrorsMapping
 
 export const externalFsErrorsMapping = {
   external_fs_undefined: 'wizard.storage.instance.useExisting.error',
@@ -43,6 +49,17 @@ export function validateEbs(ebsStorage: EbsStorage): [boolean, EbsErrorKind?] {
 
   if (volumeSize === undefined || volumeSize < 35 || volumeSize > 2048) {
     return [false, 'invalid_ebs_size']
+  } else {
+    return [true]
+  }
+}
+
+export function validateEfs(efsStorage: EfsStorage): [boolean, EfsErrorKind?] {
+  const throughputMode = efsStorage.EfsSettings?.ThroughputMode
+  const provisionedThroughput = efsStorage.EfsSettings?.ProvisionedThroughput
+
+  if (throughputMode === 'provisioned' && !provisionedThroughput) {
+    return [false, 'provisioned_throughput_undefined']
   } else {
     return [true]
   }


### PR DESCRIPTION
## Description
Currently in EFS storage settings, if the provisioned throughput checkbox is selected and then deselected, the corresponding parameter `ProvisionedThroughput` is not cleared from the state, resulting in the final YAML.

This PR aims at solving the aforementioned issue, by:
* Clearing the state when the checkbox is unselected
* Set the provisioned throughput as `number` and not `string`, as specified in [ParallelCluster Docs](https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-EfsSettings-ProvisionedThroughput)
* Adding a validator (and a corresponding error message) to check that the provided value is not null

## How Has This Been Tested?
* Unit tests
* Manual tests
   * Verified that when checkbox is checked default value is `128`
   * Verified that when checkbox is checked and value is changed it is reflected in the state correctly
   * Verified that when checkbox is unchecked the corresponding state is cleared and reflected in the final YAML

## References
* https://docs.aws.amazon.com/parallelcluster/latest/ug/SharedStorage-v3.html#yaml-SharedStorage-EfsSettings-ProvisionedThroughput

## Screenshots
<img width="1728" alt="Screenshot 2023-04-14 at 15 59 55" src="https://user-images.githubusercontent.com/25930133/232065768-7040dde1-d128-4a2c-a443-ffc997227944.png">


## PR Quality Checklist

- [x] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
