### PR TITLE
Disable region selector in TopBar when in Wizard

### DIFF
--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -16,8 +16,9 @@ import {LoadInitialState} from '../model'
 // UI Elements
 import TopNavigation from '@cloudscape-design/components/top-navigation'
 import {useQueryClient} from 'react-query'
-import {NavigateFunction, useNavigate} from 'react-router-dom'
+import {NavigateFunction, useLocation, useNavigate} from 'react-router-dom'
 import {ButtonDropdownProps} from '@cloudscape-design/components'
+import {colorTextInteractiveDisabled} from '@cloudscape-design/design-tokens'
 import {useTranslation} from 'react-i18next'
 
 export function regions(selected: string) {
@@ -103,16 +104,23 @@ export const clearClusterOnRegionChange = (
   }
 }
 
+export const isRegionSelectionDisabled = (path: string) => {
+  return path.indexOf('/configure') !== -1
+}
+
 export default function Topbar() {
   const {t} = useTranslation()
   let username = useState(['identity', 'attributes', 'email'])
   const queryClient = useQueryClient()
   const navigate = useNavigate()
+  const location = useLocation()
 
   const defaultRegionText = t('global.topBar.regionSelector.defaultRegionText')
   const defaultRegion = useState(['aws', 'region']) || defaultRegionText
   const selectedRegion = useState(['app', 'selectedRegion']) || defaultRegion
   const displayedRegions = regions(selectedRegion)
+
+  const isRegionDropdownDisabled = isRegionSelectionDisabled(location.pathname)
 
   const selectRegion = (region: any) => {
     let newRegion = region.detail.id
@@ -164,8 +172,18 @@ export default function Topbar() {
               type: 'menu-dropdown',
               ariaLabel: t('global.topBar.regionSelector.ariaLabel'),
               disableUtilityCollapse: true,
+              disabled: isRegionDropdownDisabled,
               text: (
-                <span style={{fontWeight: 'normal'}}>{selectedRegion}</span>
+                <span
+                  style={{
+                    fontWeight: 'normal',
+                    color: isRegionDropdownDisabled
+                      ? colorTextInteractiveDisabled
+                      : undefined,
+                  }}
+                >
+                  {selectedRegion}
+                </span>
               ),
               onItemClick: selectRegion,
               items: regionsToDropdownItems(displayedRegions, selectedRegion),

--- a/frontend/src/components/__tests__/TopBar.test.tsx
+++ b/frontend/src/components/__tests__/TopBar.test.tsx
@@ -1,5 +1,9 @@
 import {NavigateFunction} from 'react-router-dom'
-import {clearClusterOnRegionChange, regions} from '../TopBar'
+import {
+  clearClusterOnRegionChange,
+  isRegionSelectionDisabled,
+  regions,
+} from '../TopBar'
 
 describe('Given a TopBar component', () => {
   let navigate: NavigateFunction
@@ -7,7 +11,7 @@ describe('Given a TopBar component', () => {
     navigate = jest.fn()
   })
 
-  describe('when changing the region', () => {
+  describe('when the region has been changed', () => {
     describe('when inside the clusters section', () => {
       it('should clear the selected cluster', () => {
         clearClusterOnRegionChange('/clusters/selected-cluster', navigate)
@@ -20,6 +24,19 @@ describe('Given a TopBar component', () => {
         clearClusterOnRegionChange('/custom-images', navigate)
 
         expect(navigate).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('when user tries to change the region', () => {
+    describe('when inside the wizard', () => {
+      it('should disable the region selection', () => {
+        expect(isRegionSelectionDisabled('/configure')).toBe(true)
+      })
+    })
+    describe('when inside another section', () => {
+      it('should enable the region selection', () => {
+        expect(isRegionSelectionDisabled('/any-page')).toBe(false)
       })
     })
   })


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR disabled the region selector in the TopNavigation bar, when user is in the cluster creation wizard. The region can still be changed via the dedicated region selector in the Cluster section of the wizard.

## Changes

- disable region selector only in `/configure` page
- use CloudScape disabled text color 

## Screenshot
![image](https://user-images.githubusercontent.com/11457067/232081293-029cb9f1-6470-43ec-9cb8-b55a267955f3.png)

## How Has This Been Tested?

- manually, by changing region in Clusters, Images and Users section
- manually, by checking that users cannot change regions in both create and edit cluster
- unit test

## References

- [Design tokens](https://cloudscape.design/foundation/visual-foundation/design-tokens/)

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
