### PR TITLE
Parse update errors correctly

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -1078,7 +1078,8 @@
         "forceUpdate": "Force update: Edit the cluster while the compute fleet is still running."
       },
       "flashBar": {
-        "success": "Success"
+        "success": "Success",
+        "error": "Error"
       },
       "helpPanel": {
         "title": "Cluster configuration",

--- a/frontend/src/old-pages/Configure/Create.types.ts
+++ b/frontend/src/old-pages/Configure/Create.types.ts
@@ -8,8 +8,10 @@ export type ConfigError = {
 }
 
 export type UpdateError = {
+  parameter: string
+  currentValue: string
+  requestedValue: string
   message: string
-  level: ErrorLevel
 }
 
 export type CreateErrors = {

--- a/frontend/src/old-pages/Configure/__tests__/errorsToFlashbarItems.test.ts
+++ b/frontend/src/old-pages/Configure/__tests__/errorsToFlashbarItems.test.ts
@@ -183,12 +183,10 @@ describe('Given a function to map create/dry-run errors to FlashbarItems', () =>
   describe('when errors contain update errors', () => {
     const updateErrors: UpdateError[] = [
       {
-        level: 'ERROR',
         message: 'ErrorMessage',
-      },
-      {
-        level: 'WARNING',
-        message: 'WarningMessage',
+        parameter: '',
+        currentValue: '',
+        requestedValue: '',
       },
     ]
     const errors: CreateErrors = {
@@ -201,16 +199,9 @@ describe('Given a function to map create/dry-run errors to FlashbarItems', () =>
         {
           type: 'error',
           dismissible: true,
-          header: 'Error',
+          header: 'wizard.create.flashBar.error',
           content: updateErrors[0].message,
           id: 'update-err-0',
-        },
-        {
-          type: 'warning',
-          dismissible: true,
-          header: 'Warning',
-          content: updateErrors[1].message,
-          id: 'update-err-1',
         },
       ]
       expect(errorsToFlashbarItems(errors, setFlashbarItems)).toMatchObject(
@@ -220,47 +211,47 @@ describe('Given a function to map create/dry-run errors to FlashbarItems', () =>
   })
 
   describe('when errors contain messages with different types', () => {
-    const updateErrors: UpdateError[] = [
+    const configErrors: ConfigError[] = [
       {
         level: 'INFO',
         message: 'InfoMessage',
+        id: '0',
+        type: '',
       },
       {
         level: 'ERROR',
         message: 'ErrorMessage',
+        id: '1',
+        type: '',
       },
       {
         level: 'WARNING',
         message: 'WarningMessage',
+        id: '2',
+        type: '',
       },
     ]
     const errors: CreateErrors = {
       message: 'Invalid cluster configuration',
-      updateValidationErrors: updateErrors,
+      configurationValidationErrors: configErrors,
     }
 
-    it('should return error items, with expected type and content, ordered by the following priority: ["success", "error", "warning", "info"]', () => {
+    it('should return items ordered by the following priority: ["error", "success", "warning", "info"]', () => {
       const expected: FlashbarProps.MessageDefinition[] = [
         {
           type: 'error',
           dismissible: true,
           header: 'Error',
-          content: updateErrors[1].message,
-          id: 'update-err-1',
         },
         {
           type: 'warning',
           dismissible: true,
           header: 'Warning',
-          content: updateErrors[2].message,
-          id: 'update-err-2',
         },
         {
           type: 'info',
           dismissible: true,
           header: 'Info',
-          content: updateErrors[0].message,
-          id: 'update-err-0',
         },
       ]
       expect(errorsToFlashbarItems(errors, setFlashbarItems)).toMatchObject(
@@ -270,54 +261,53 @@ describe('Given a function to map create/dry-run errors to FlashbarItems', () =>
   })
 
   describe('when errors contain messages with different types, including a success message', () => {
-    const updateErrors: UpdateError[] = [
+    const configErrors: ConfigError[] = [
       {
         level: 'INFO',
-        message: 'InfoMessage1',
+        message: 'InfoMessage',
+        id: '0',
+        type: 'Type',
+      },
+      {
+        level: 'ERROR',
+        message: 'ErrorMessage',
+        id: '1',
+        type: 'Type',
       },
       {
         level: 'WARNING',
         message: 'WarningMessage',
-      },
-      {
-        level: 'INFO',
-        message: 'InfoMessage2',
+        id: '2',
+        type: 'Type',
       },
     ]
     const errors: CreateErrors = {
       message: 'Request would have succeeded, but DryRun flag is set.',
-      updateValidationErrors: updateErrors,
+      configurationValidationErrors: configErrors,
     }
 
-    it('should return error items, with expected type and content, ordered by the following priority: ["success", "error", "warning", "info"]', () => {
+    it('should return items ordered by the following priority: ["error", "success", "warning", "info"]', () => {
       const expected: FlashbarProps.MessageDefinition[] = [
+        {
+          type: 'error',
+          dismissible: true,
+          header: 'Error',
+        },
         {
           type: 'success',
           dismissible: true,
           header: 'wizard.create.flashBar.success',
-          content: errors.message,
           id: 'success',
         },
         {
           type: 'warning',
           dismissible: true,
           header: 'Warning',
-          content: updateErrors[1].message,
-          id: 'update-err-1',
         },
         {
           type: 'info',
           dismissible: true,
           header: 'Info',
-          content: updateErrors[0].message,
-          id: 'update-err-0',
-        },
-        {
-          type: 'info',
-          dismissible: true,
-          header: 'Info',
-          content: updateErrors[2].message,
-          id: 'update-err-2',
         },
       ]
       expect(errorsToFlashbarItems(errors, setFlashbarItems)).toMatchObject(
@@ -340,7 +330,7 @@ describe('Given a function to map create/dry-run errors to FlashbarItems', () =>
         {
           type: 'error',
           dismissible: true,
-          header: 'Error',
+          header: 'wizard.create.flashBar.error',
           content:
             'Bad Request: Configuration must be a valid YAML document. Parsed config is not a dict',
         },

--- a/frontend/src/old-pages/Configure/errorsToFlashbarItems.ts
+++ b/frontend/src/old-pages/Configure/errorsToFlashbarItems.ts
@@ -80,8 +80,8 @@ export function errorsToFlashbarItems(
     items.push(
       dismissableMessage(
         {
-          type: error.level.toLowerCase() as FlashbarProps.Type,
-          header: capitalize(error.level.toLowerCase()),
+          type: 'error',
+          header: i18next.t('wizard.create.flashBar.error'),
           content: error.message,
           id: `update-err-${index}`,
         },
@@ -95,7 +95,7 @@ export function errorsToFlashbarItems(
       dismissableMessage(
         {
           type: 'error',
-          header: 'Error',
+          header: i18next.t('wizard.create.flashBar.error'),
           content: errors.message,
           id: 'config-err-0',
         },


### PR DESCRIPTION
## Description
Fixes a crash happening when running a dry-run during an edit cluster operation.

## How Has This Been Tested?

- Started editing a cluster with the wizard
- Edited a queues property
- Dry run fails with the right error and the app doesn't crash

![Screenshot 2023-04-14 at 16 47 06](https://user-images.githubusercontent.com/3091286/232082239-9615c5b7-c70a-4c8b-9f8f-1170e50f9e56.png)

## PR Quality Checklist

- [x] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
