### PR TITLE
Apply custom product tags before a cluster is created

### DIFF
--- a/frontend/src/__tests__/CreateCluster.test.ts
+++ b/frontend/src/__tests__/CreateCluster.test.ts
@@ -8,7 +8,7 @@ const mockRequest = executeRequest as jest.Mock
 
 describe('given a CreateCluster command and a cluster configuration', () => {
   const clusterName = 'any-name'
-  const clusterConfiguration = {}
+  const clusterConfiguration = ''
   const mockRegion = 'some-region'
   const mockSelectedRegion = 'some-region'
 

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -72,8 +72,8 @@ function request(method: HTTPMethod, url: string, body: any = undefined) {
 }
 
 function CreateCluster(
-  clusterName: any,
-  clusterConfig: any,
+  clusterName: string,
+  clusterConfig: string,
   region: string,
   selectedRegion: string,
   dryrun = false,

--- a/frontend/src/types/base.tsx
+++ b/frontend/src/types/base.tsx
@@ -85,3 +85,12 @@ export type ConfigValidationMessage = {
 }
 
 export type ValidationMessages = ConfigValidationMessage[]
+
+export type ConfigTag = {
+  Key: string
+  Value: string
+}
+
+export type ConfigObject = {[key: string]: unknown} & {
+  Tags?: ConfigTag[]
+}


### PR DESCRIPTION
## Description

Adds discoverability of clusters created through ParallelCluster UI.

## How Has This Been Tested?

- dry run passes with no tags specified in the YAML
- dry run passes with additional tags specified in the YAML
- the new tag is present in the cluster YAML config after it has been built and on the EC2 instances

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
