### PR TITLE
Enable additional features by using sessionStorage

### DIFF
--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -62,4 +62,25 @@ describe('given a feature flags provider and a list of rules', () => {
       ])
     })
   })
+
+  describe('when an additional feature has been enabled through the browser session storage', () => {
+    beforeEach(() => {
+      window.sessionStorage.clear()
+      window.sessionStorage.setItem('additionalFeatures', '["cost_monitoring"]')
+    })
+    it('should be included in the list of features', async () => {
+      const features = await subject('3.1.5')
+      expect(features).toEqual(['multiuser_cluster', 'cost_monitoring'])
+    })
+  })
+
+  describe('when no additional features have been enabled through the browser session storage', () => {
+    beforeEach(() => {
+      window.sessionStorage.clear()
+    })
+    it('should not be included in the list of features', async () => {
+      const features = await subject('3.1.5')
+      expect(features).toEqual(['multiuser_cluster'])
+    })
+  })
 })

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -46,6 +46,12 @@ function composeFlagsListByVersion(currentVersion: string): AvailableFeature[] {
 
 export function featureFlagsProvider(version: string): AvailableFeature[] {
   const features: AvailableFeature[] = []
+  const additionalFeatures = window.sessionStorage.getItem('additionalFeatures')
+  const additionalFeaturesParsed = additionalFeatures
+    ? JSON.parse(additionalFeatures)
+    : []
 
-  return features.concat(composeFlagsListByVersion(version))
+  return features
+    .concat(composeFlagsListByVersion(version))
+    .concat(additionalFeaturesParsed)
 }


### PR DESCRIPTION
## Description

Enable flagged features by acting on `sessionStorage`. For example:

Define a new feature flag
```typescript
export type AvailableFeature = 'cost'
```
Open a browser tab with PCUI, then go to the console and type
```typescript
window.sessionStorage.setItem('additionalFeatures', '["cost"]')
```
Reload the page and the `cost` flag will be active!
## How Has This Been Tested?

Repeated the same procedure explained in the description (on Chrome)

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
