### PR TITLE
Remove unnecessary HTTP calls when changing region using the TopBar

### DIFF
--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -127,7 +127,6 @@ export default function Topbar() {
     setState(['app', 'selectedRegion'], newRegion)
     clearClusterOnRegionChange(location.pathname, navigate)
     clearAllState()
-    LoadInitialState()
     queryClient.invalidateQueries()
   }
 


### PR DESCRIPTION
## Description

Reduces the calls made when a user switches region using the top bar.

**N.B.: some calls are still duplicated (images) because they are loaded as a side effect of `/get_aws_configuration`. It will be fixed in a separate PR.**

## How Has This Been Tested?

Changed the region using the TopBar.

Before:

<img width="1792" alt="Screenshot 2023-04-20 at 17 20 48" src="https://user-images.githubusercontent.com/3091286/233415406-620c0ce5-c29e-4a5b-b50b-9568086c0f34.png">

After:

<img width="1790" alt="Screenshot 2023-04-20 at 17 19 26" src="https://user-images.githubusercontent.com/3091286/233415445-28c1dc0d-d86a-4d70-a82a-263989c75e7a.png">

Verified also that a cluster can be created after having switched the region.

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
