### PR TITLE
Add support for RHEL 8 os for PC API >= 3.6.0

### DIFF
--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -30,6 +30,7 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
     'imds_support',
   ],
   '3.4.0': ['multi_az', 'on_node_updated'],
+  '3.6.0': ['rhel8'],
 }
 
 function composeFlagsListByVersion(currentVersion: string): AvailableFeature[] {

--- a/frontend/src/feature-flags/types.ts
+++ b/frontend/src/feature-flags/types.ts
@@ -24,3 +24,4 @@ export type AvailableFeature =
   | 'efs_deletion_policy'
   | 'lustre_deletion_policy'
   | 'imds_support'
+  | 'rhel8'

--- a/frontend/src/old-pages/Configure/Cluster/OsFormField.tsx
+++ b/frontend/src/old-pages/Configure/Cluster/OsFormField.tsx
@@ -13,6 +13,7 @@ import {FormField, Tiles, TilesProps} from '@cloudscape-design/components'
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
 import {useCallback} from 'react'
 import {useTranslation} from 'react-i18next'
+import {useFeatureFlag} from '../../../feature-flags/useFeatureFlag'
 import {setState, useState} from '../../../store'
 
 const osPath = ['app', 'wizard', 'config', 'Image', 'Os']
@@ -23,15 +24,17 @@ const SUPPORTED_OSES_LIST: TilesProps.TilesDefinition[] = [
   {value: 'ubuntu1804', label: 'Ubuntu 18.04'},
   {value: 'ubuntu2004', label: 'Ubuntu 20.04'},
 ]
+const RHEL8_OS = {value: 'rhel8', label: 'Red Hat Enterprise Linux 8'}
 
 export function OsFormField() {
   const {t} = useTranslation()
   const editing = useState(['app', 'wizard', 'editing'])
   const selectedOsValue = useState(osPath) || 'alinux2'
 
-  const osesList = editing
-    ? SUPPORTED_OSES_LIST.map(os => ({...os, disabled: true}))
+  let osesList = useFeatureFlag('rhel8')
+    ? SUPPORTED_OSES_LIST.concat(RHEL8_OS)
     : SUPPORTED_OSES_LIST
+  osesList = editing ? osesList.map(os => ({...os, disabled: true})) : osesList
 
   const handleChange: NonCancelableEventHandler<TilesProps.ChangeDetail> =
     useCallback(({detail}) => {

--- a/frontend/src/old-pages/Configure/Cluster/__tests__/OsFormField.test.tsx
+++ b/frontend/src/old-pages/Configure/Cluster/__tests__/OsFormField.test.tsx
@@ -90,4 +90,48 @@ describe('given a component to select an Operating System', () => {
       })
     })
   })
+
+  describe('when the version is >= 3.6.0', () => {
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        app: {version: {full: '3.6.0'}},
+      })
+    })
+
+    describe('when the user choose between supported oses', () => {
+      beforeEach(() => {
+        screen = render(
+          <MockProviders>
+            <OsFormField />
+          </MockProviders>,
+        )
+      })
+
+      it('should have RHEL 8 as an available option', () => {
+        expect(screen.getByLabelText('Red Hat Enterprise Linux 8')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('when the version is < 3.6.0', () => {
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        app: {version: {full: '3.3.0'}},
+      })
+    })
+
+    describe('when the user choose between supported oses', () => {
+      beforeEach(() => {
+        screen = render(
+          <MockProviders>
+            <OsFormField />
+          </MockProviders>,
+        )
+      })
+
+      it('should not have RHEL 8 as an available option', () => {
+        expect(screen.queryByText('Red Hat Enterprise Linux 8')).toBeNull()
+      })
+    })
+  })
 })


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

Added support for 

## How Has This Been Tested?
* Unit tests
* Manual tests

## References
* https://github.com/aws/aws-parallelcluster/blob/develop/pc_support/os_3.6.0.json

## Screenshots
<img width="1725" alt="Screenshot 2023-04-21 at 00 35 26" src="https://user-images.githubusercontent.com/25930133/233578571-d9c5213e-9e1c-40fe-9dfd-0300fe35d900.png">


## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
