### PR TITLE
Force dismiss of cluster loading message upon cluster creation and change current region to the one of the created cluster

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -1080,10 +1080,11 @@
     "create": {
       "title": "Create",
       "description": "Review or edit your cluster configuration and create your cluster.",
+      "pending": "<strong>{{clusterName}}</strong> create is in progress. In <strong>Clusters</strong>, view <strong>{{clusterName}}</strong> create status.",
+      "success": "<strong>{{clusterName}}</strong> successfully created.",
       "configuration": {
         "title": "Cluster configuration YAML file",
         "description": "Review or edit the YAML file that is used to create your cluster.",
-        "pending": "<strong>{{clusterName}}</strong> {{action}} is in progress. In <strong>Clusters</strong>, view <strong>{{clusterName}}</strong> {{action}} status.",
         "forceUpdate": "Force update: Edit the cluster while the compute fleet is still running."
       },
       "flashBar": {
@@ -1101,6 +1102,7 @@
     },
     "update": {
       "title": "Edit",
+      "pending": "<strong>{{clusterName}}</strong> update is in progress. In <strong>Clusters</strong>, view <strong>{{clusterName}}</strong> update status.",
       "helpPanel": {
         "title": "Cluster configuration",
         "description": "<p>Review, edit and test cluster configuration.</p><p>Choose <strong>Dry run</strong> to validate your configuration without editing your cluster.</p><p>Choose <strong>Edit cluster</strong> to validate your configuration and edit your cluster in one step.</p>",
@@ -1109,6 +1111,9 @@
           "href": "https://docs.aws.amazon.com/parallelcluster/latest/ug/cluster-configuration-file-v3.html?icmpid=docs_parallelcluster_hp_config_create_v1"
         }
       }
+    },
+    "dryRun": {
+      "pending": "<strong>{{clusterName}}</strong> dry-run is in progress."
     },
     "components": {
       "instanceSelect": {

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -34,12 +34,19 @@ import flowRight from 'lodash/flowRight'
 // Types
 type Callback = (arg?: any) => void
 
-function notify(text: any, type = 'info', id?: string, dismissible = true) {
+function notify(
+  text: any,
+  type = 'info',
+  id?: string,
+  dismissible = true,
+  loading = false,
+) {
   let messageId = id || generateRandomId()
   let newMessage = {
     type: type,
     content: text,
     id: messageId,
+    loading: loading,
     dismissible: dismissible,
     onDismiss: () =>
       updateState(['app', 'messages'], (currentMessages: Array<any>) =>
@@ -97,7 +104,6 @@ function CreateCluster(
     .then((response: any) => {
       if (response.status === 202) {
         if (!dryrun && region === selectedRegion) {
-          notify('Successfully created: ' + clusterName, 'success')
           updateState(['clusters', 'index', clusterName], (existing: any) => {
             return {...existing, ...response.data}
           })


### PR DESCRIPTION
## Description
* Make cluster loading flashbar message to be dismissable
* Closes #179 

<!-- List of relevant changes introduced -->

## How Has This Been Tested?
* Manually tested on local environment
   * Dry-run both successful and unsuccessful: verified that flashbar message is dismissed
   * Create successful: verified that flashbar message is not automatically dismissed and selected region is changed before redirect
   * Create unsuccessful: verified that flashbar message is dismissed

## Screenshot
<img width="1725" alt="Screenshot 2023-04-21 at 14 50 31" src="https://user-images.githubusercontent.com/25930133/233642023-9ac41164-54c5-45e1-80f8-a4459bb5f67b.png">


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [x] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
