### PR TITLE
Fixes for wizard when in edit mode

### DIFF
--- a/frontend/src/old-pages/Clusters/Actions.tsx
+++ b/frontend/src/old-pages/Clusters/Actions.tsx
@@ -41,6 +41,8 @@ import {ButtonDropdown} from '@cloudscape-design/components'
 import {CancelableEventHandler} from '@cloudscape-design/components/internal/events'
 import {ButtonDropdownProps} from '@cloudscape-design/components/button-dropdown/interfaces'
 
+const loadingPath = ['app', 'wizard', 'source', 'loading']
+
 export default function Actions() {
   const clusterName = useState(['app', 'clusters', 'selected'])
   const clusterPath = ['clusters', 'index', clusterName]
@@ -106,8 +108,11 @@ export default function Actions() {
 
     navigate('/configure')
 
+    setState(loadingPath, true)
     GetConfiguration(clusterName, (configuration: any) => {
-      loadTemplate(jsyaml.load(configuration))
+      loadTemplate(jsyaml.load(configuration), () =>
+        setState(loadingPath, false),
+      )
     })
   }, [clusterName, navigate])
 

--- a/frontend/src/old-pages/Clusters/Actions.tsx
+++ b/frontend/src/old-pages/Clusters/Actions.tsx
@@ -12,18 +12,9 @@ import {ClusterStatus} from '../../types/clusters'
 import React from 'react'
 import {useNavigate} from 'react-router-dom'
 
-// @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'js-y... Remove this comment to see the full error message
-import jsyaml from 'js-yaml'
-
 import {setState, useState, ssmPolicy, consoleDomain} from '../../store'
-import {
-  UpdateComputeFleet,
-  GetConfiguration,
-  GetDcvSession,
-  DeleteCluster,
-} from '../../model'
+import {UpdateComputeFleet, GetDcvSession, DeleteCluster} from '../../model'
 import {findFirst, clusterDefaultUser} from '../../util'
-import {loadTemplate} from '../Configure/util'
 import {useTranslation} from 'react-i18next'
 
 import Button from '@cloudscape-design/components/button'
@@ -40,8 +31,7 @@ import {wizardShow} from '../Configure/Configure'
 import {ButtonDropdown} from '@cloudscape-design/components'
 import {CancelableEventHandler} from '@cloudscape-design/components/internal/events'
 import {ButtonDropdownProps} from '@cloudscape-design/components/button-dropdown/interfaces'
-
-const loadingPath = ['app', 'wizard', 'source', 'loading']
+import {loadTemplateFromCluster} from '../Configure/util'
 
 export default function Actions() {
   const clusterName = useState(['app', 'clusters', 'selected'])
@@ -107,13 +97,7 @@ export default function Actions() {
     setState(['app', 'wizard', 'editing'], true)
 
     navigate('/configure')
-
-    setState(loadingPath, true)
-    GetConfiguration(clusterName, (configuration: any) => {
-      loadTemplate(jsyaml.load(configuration), () =>
-        setState(loadingPath, false),
-      )
-    })
+    loadTemplateFromCluster(clusterName)
   }, [clusterName, navigate])
 
   const deleteCluster = React.useCallback(() => {

--- a/frontend/src/old-pages/Clusters/CreateButtonDropdown/CreateButtonDropdown.tsx
+++ b/frontend/src/old-pages/Clusters/CreateButtonDropdown/CreateButtonDropdown.tsx
@@ -17,23 +17,14 @@ import {CancelableEventHandler} from '@cloudscape-design/components/internal/eve
 import React, {useCallback, useMemo} from 'react'
 import {useTranslation} from 'react-i18next'
 import {NavigateFunction, useNavigate} from 'react-router-dom'
-import {GetConfiguration} from '../../../model'
 import {setState} from '../../../store'
-import loadTemplate from '../../Configure/util'
+import loadTemplate, {loadTemplateFromCluster} from '../../Configure/util'
 import {HiddenFileUpload} from '../../../components/HiddenFileUpload'
 // @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'js-y... Remove this comment to see the full error message
 import jsyaml from 'js-yaml'
 import {FromClusterModal} from '../FromClusterModal/FromClusterModal'
 
 const loadingPath = ['app', 'wizard', 'source', 'loading']
-
-function copyFrom(sourceClusterName: any) {
-  setState(loadingPath, true)
-  GetConfiguration(sourceClusterName, (configuration: any) => {
-    loadTemplate(jsyaml.load(configuration), () => setState(loadingPath, false))
-  })
-}
-
 interface Props {
   openWizard: (navigate: NavigateFunction) => void
 }
@@ -51,7 +42,7 @@ export const CreateButtonDropdown: React.FC<Props> = ({openWizard}) => {
 
   const onCreate = useCallback(
     (name: string) => {
-      copyFrom(name)
+      loadTemplateFromCluster(name)
       openWizard(navigate)
     },
     [navigate, openWizard],

--- a/frontend/src/old-pages/Configure/Configure.tsx
+++ b/frontend/src/old-pages/Configure/Configure.tsx
@@ -106,6 +106,7 @@ function Configure() {
   const clusterName = useState(['app', 'wizard', 'clusterName'])
   const editing = useState(['app', 'wizard', 'editing'])
   const currentPage = useState(['app', 'wizard', 'page']) || INITIAL_WIZARD_PAGE
+  const loadingExistingConfiguration = useState(loadingPath)
   const [refreshing, setRefreshing] = React.useState(false)
   let navigate = useNavigate()
 
@@ -242,7 +243,7 @@ function Configure() {
         onSubmit={handleSubmit}
         activeStepIndex={pages.indexOf(currentPage)}
         secondaryActions={showSecondaryActions()}
-        isLoadingNextStep={refreshing}
+        isLoadingNextStep={refreshing || loadingExistingConfiguration}
         steps={[
           {
             title: t('wizard.cluster.title'),

--- a/frontend/src/old-pages/Configure/__tests__/Configure.test.tsx
+++ b/frontend/src/old-pages/Configure/__tests__/Configure.test.tsx
@@ -1,0 +1,78 @@
+import {Store} from '@reduxjs/toolkit'
+import {mock} from 'jest-mock-extended'
+import i18n from '../../../i18n'
+import {I18nextProvider} from 'react-i18next'
+import {QueryClient, QueryClientProvider} from 'react-query'
+import {Provider} from 'react-redux'
+import {BrowserRouter} from 'react-router-dom'
+import {render} from '@testing-library/react'
+import Configure from '../Configure'
+
+const queryClient = new QueryClient()
+const mockStore = mock<Store>()
+
+const MockProviders = (props: any) => (
+  <QueryClientProvider client={queryClient}>
+    <I18nextProvider i18n={i18n}>
+      <Provider store={mockStore}>
+        <BrowserRouter>{props.children}</BrowserRouter>
+      </Provider>
+    </I18nextProvider>
+  </QueryClientProvider>
+)
+
+describe('Given a configure component (wizard)', () => {
+  describe("when it's being loaded (edit mode or from template)", () => {
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        app: {
+          wizard: {
+            source: {
+              loading: true,
+            },
+          },
+        },
+      })
+    })
+    it('should disable the Next button', () => {
+      const {getByRole} = render(
+        <MockProviders>
+          <Configure />
+        </MockProviders>,
+      )
+
+      expect(
+        getByRole('button', {
+          name: 'Next',
+        }).getAttribute('aria-disabled'),
+      ).toBe('true')
+    })
+  })
+
+  describe("when it's loaded", () => {
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        app: {
+          wizard: {
+            source: {
+              loading: false,
+            },
+          },
+        },
+      })
+    })
+    it('should enable the Next button', () => {
+      const {getByRole} = render(
+        <MockProviders>
+          <Configure />
+        </MockProviders>,
+      )
+
+      expect(
+        getByRole('button', {
+          name: 'Next',
+        }).getAttribute('aria-disabled'),
+      ).toBeNull()
+    })
+  })
+})

--- a/frontend/src/old-pages/Configure/util.tsx
+++ b/frontend/src/old-pages/Configure/util.tsx
@@ -11,11 +11,13 @@
 // limitations under the License.
 
 import {setState, getState, clearState} from '../../store'
-import {LoadAwsConfig} from '../../model'
+import {GetConfiguration, LoadAwsConfig} from '../../model'
 import {getIn, setIn} from '../../util'
 import {mapComputeResources} from './Queues/queues.mapper'
 import {mapStorageToUiSettings} from './Storage/storage.mapper'
 import {Storages} from './Storage.types'
+// @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'js-y... Remove this comment to see the full error message
+import {load} from 'js-yaml'
 
 function loadTemplateLazy(config: any, callback?: () => void) {
   const loadingPath = ['app', 'wizard', 'source', 'loading']
@@ -154,4 +156,13 @@ function subnetName(subnet: any) {
   return tags.length > 0 ? tags[0].Value : null
 }
 
-export {loadTemplate, subnetName}
+const wizardLoadingPath = ['app', 'wizard', 'source', 'loading']
+
+function loadTemplateFromCluster(clusterName: string) {
+  setState(wizardLoadingPath, true)
+  GetConfiguration(clusterName, (configuration: any) => {
+    loadTemplate(load(configuration), () => setState(wizardLoadingPath, false))
+  })
+}
+
+export {loadTemplate, subnetName, loadTemplateFromCluster}


### PR DESCRIPTION
## Description

Fixes #180.

## Changes

- disable Next button when a configuration will be fed to the wizard (edit or from another cluster)
- add loading to the wizard when editing a cluster

## How Has This Been Tested?

- Edit a cluster locally, spinner is shown instead of the wizard while loading the config
- From another cluster works just as before, but with the Next button disabled while loading the config

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
