### PR TITLE
Support PC API 3.6.0 cloudformation template

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -90,11 +90,17 @@ Conditions:
       - !Not [!Equals [!Ref SNSRole, ""]]
   UseNewCognito:
     !Not [ Condition: UseExistingCognito]
-  UseNonDockerizedPCAPI: !Or
-      - !Equals [!Ref Version, '3.6.0']
-      - !Equals [!Ref Version, '3.6.0b1']
-  UseDockerizedPCAPI:
-    !Not [ Condition: UseNonDockerizedPCAPI]
+  UseNonDockerizedPCAPI:
+    !Not [ Condition: UseDockerizedPCAPI]
+  UseDockerizedPCAPI: !And
+    - !Equals ['3', !Select [ 0, !Split ['.', !Ref Version] ] ] # Check PC version major is 3 and PC version minor is 0-5
+    - !Or
+      - !Equals ['0', !Select [ 1, !Split ['.', !Ref Version] ] ]
+      - !Equals ['1', !Select [ 1, !Split ['.', !Ref Version] ] ]
+      - !Equals ['2', !Select [ 1, !Split ['.', !Ref Version] ] ]
+      - !Equals ['3', !Select [ 1, !Split ['.', !Ref Version] ] ]
+      - !Equals ['4', !Select [ 1, !Split ['.', !Ref Version] ] ]
+      - !Equals ['5', !Select [ 1, !Split ['.', !Ref Version] ] ]
 
 Mappings:
   ParallelClusterUI:
@@ -126,10 +132,6 @@ Resources:
         ApiDefinitionS3Uri: !Sub s3://${AWS::Region}-aws-parallelcluster/parallelcluster/${Version}/api/ParallelCluster.openapi.yaml
         CreateApiUserRole: False
         EnableIamAdminAccess: True
-        PublicEcrImageUri: !If
-          - UseNonDockerizedPCAPI
-          - !Ref AWS::NoValue
-          - !Sub public.ecr.aws/parallelcluster/pcluster-api:${Version}
         ImageBuilderSubnetId: !If
           - UseNonDockerizedPCAPI
           - !Ref AWS::NoValue

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -90,6 +90,11 @@ Conditions:
       - !Not [!Equals [!Ref SNSRole, ""]]
   UseNewCognito:
     !Not [ Condition: UseExistingCognito]
+  UseNonDockerizedPCAPI: !Or
+      - !Equals [!Ref Version, '3.6.0']
+      - !Equals [!Ref Version, '3.6.0b1']
+  UseDockerizedPCAPI:
+    !Not [ Condition: UseNonDockerizedPCAPI]
 
 Mappings:
   ParallelClusterUI:
@@ -121,14 +126,21 @@ Resources:
         ApiDefinitionS3Uri: !Sub s3://${AWS::Region}-aws-parallelcluster/parallelcluster/${Version}/api/ParallelCluster.openapi.yaml
         CreateApiUserRole: False
         EnableIamAdminAccess: True
-        PublicEcrImageUri: !Sub public.ecr.aws/parallelcluster/pcluster-api:${Version}
-        ImageBuilderSubnetId:
-          Fn::If:
-            - NonDefaultVpc
-            - !Ref ImageBuilderSubnetId
-            - !Ref AWS::NoValue
-        ImageBuilderVpcId:
-          Fn::If:
+        PublicEcrImageUri: !If
+          - UseNonDockerizedPCAPI
+          - !Ref AWS::NoValue
+          - !Sub public.ecr.aws/parallelcluster/pcluster-api:${Version}
+        ImageBuilderSubnetId: !If
+          - UseNonDockerizedPCAPI
+          - !Ref AWS::NoValue
+          - Fn::If:
+              - NonDefaultVpc
+              - !Ref ImageBuilderSubnetId
+              - !Ref AWS::NoValue
+        ImageBuilderVpcId: !If
+          - UseNonDockerizedPCAPI
+          - !Ref AWS::NoValue
+          - Fn::If:
             - NonDefaultVpc
             - !Ref ImageBuilderVpcId
             - !Ref AWS::NoValue


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description
This PR adds support for PC API template version 3.6.0 onwards, since three parameters (related to the previous implementation) are not needed anymore and when passed to a 3.6.0 template, they cause an error.

<!-- Summary of what this PR introduces and possibly why -->

## Changes
- added two conditions to check if PCUI is getting deployed with a PC API template supporting docker or not
- added an IF statement for the three parameters that are not needed with PC API template version 3.6.0

NB: I didn't change the existing conditions (which would have resulted in a streamlined parameter passing) to make it super clear what happens when passing those three parameters.
<!-- List of relevant changes introduced -->

## How Has This Been Tested?
- manually on my account

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
