### PR TITLE
Set queue subnet to the same HeadNode subnet

### DIFF
--- a/frontend/src/old-pages/Configure/Cluster.tsx
+++ b/frontend/src/old-pages/Configure/Cluster.tsx
@@ -19,7 +19,6 @@ import {findFirst, getIn} from '../../util'
 
 // UI Elements
 import {
-  Checkbox,
   CheckboxProps,
   Container,
   FormField,
@@ -319,41 +318,6 @@ function VpcSelect() {
   const setVpc = (vpcId: any) => {
     setState(['app', 'wizard', 'vpc'], vpcId)
     setState([...errorsPath, 'vpc'], null)
-    const headNodeSubnetPath = [
-      'app',
-      'wizard',
-      'config',
-      'HeadNode',
-      'Networking',
-      'SubnetId',
-    ]
-
-    const filteredSubnets =
-      subnets &&
-      subnets.filter((s: any) => {
-        return s.VpcId === vpcId
-      })
-    if (filteredSubnets.length > 0) {
-      const subnetSet = new Set(filteredSubnets)
-      var subnet = filteredSubnets[0]
-      if (!subnetSet.has(getState(headNodeSubnetPath)))
-        setState(headNodeSubnetPath, subnet.SubnetId)
-      if (queues)
-        queues.forEach((_queue: any, i: any) => {
-          const queueSubnetPath = [
-            'app',
-            'wizard',
-            'config',
-            'Scheduling',
-            'SlurmQueues',
-            i,
-            'Networking',
-            'SubnetIds',
-          ]
-          if (!subnetSet.has(getState(queueSubnetPath)))
-            setState(queueSubnetPath, [subnet.SubnetId])
-        })
-    }
   }
 
   return (

--- a/frontend/src/old-pages/Configure/HeadNode.tsx
+++ b/frontend/src/old-pages/Configure/HeadNode.tsx
@@ -19,9 +19,7 @@ import safeGet from 'lodash/get'
 
 // UI Elements
 import {
-  Alert,
   Box,
-  Checkbox,
   ColumnLayout,
   Container,
   ExpandableSection,
@@ -55,7 +53,6 @@ import {
   CheckboxWithHelpPanel,
 } from './Components'
 import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
-import InfoLink from '../../components/InfoLink'
 import TitleDescriptionHelpPanel from '../../components/help-panel/TitleDescriptionHelpPanel'
 import {useHelpPanel} from '../../components/help-panel/HelpPanel'
 
@@ -413,6 +410,15 @@ function IMDSSecuredSettings() {
   )
 }
 
+const headNodeSubnetPath = [
+  'app',
+  'wizard',
+  'config',
+  'HeadNode',
+  'Networking',
+  'SubnetId',
+]
+
 function HeadNode() {
   const {t} = useTranslation()
 
@@ -422,6 +428,23 @@ function HeadNode() {
   const subnetValue = useState(subnetPath) || ''
   const editing = useState(['app', 'wizard', 'editing'])
   const isOnNodeUpdatedActive = useFeatureFlag('on_node_updated')
+
+  const subnets = useState(['aws', 'subnets'])
+  const vpcId = useState(['app', 'wizard', 'vpc'])
+  const currentHeadNodeSubnet = useState(headNodeSubnetPath)
+
+  React.useEffect(() => {
+    if (currentHeadNodeSubnet) {
+      return
+    }
+    const filteredSubnets = (subnets || []).filter(
+      (s: any) => s.VpcId === vpcId,
+    )
+    if (filteredSubnets.length > 0) {
+      var subnet = filteredSubnets[0]
+      setState(headNodeSubnetPath, subnet.SubnetId)
+    }
+  }, [subnets, vpcId, currentHeadNodeSubnet])
 
   useHelpPanel(<HeadNodePropertiesHelpPanel />)
 

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -16,7 +16,6 @@ import {findFirst} from '../../../util'
 // UI Elements
 import {
   Button,
-  Box,
   Container,
   ColumnLayout,
   ExpandableSection,
@@ -49,7 +48,7 @@ import {
 } from '../../../feature-flags/useFeatureFlag'
 import * as SingleInstanceCR from './SingleInstanceComputeResource'
 import * as MultiInstanceCR from './MultiInstanceComputeResource'
-import {AllocationStrategy, ComputeResource} from './queues.types'
+import {AllocationStrategy, ComputeResource, Queue} from './queues.types'
 import {SubnetMultiSelect} from './SubnetMultiSelect'
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
 import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
@@ -656,8 +655,41 @@ function Queue({index}: any) {
   )
 }
 
+const headNodeSubnetPath = [
+  'app',
+  'wizard',
+  'config',
+  'HeadNode',
+  'Networking',
+  'SubnetId',
+]
+
+const DEFAULT_QUEUES: Queue[] = []
+
 function QueuesView() {
-  const queues = useState(queuesPath) || []
+  const queues = useState(queuesPath) || DEFAULT_QUEUES
+  const headNodeSubnet = useState(headNodeSubnetPath)
+
+  React.useEffect(() => {
+    queues.forEach((queue: Queue, i: number) => {
+      if (!queue.Networking?.SubnetIds) {
+        setState(
+          [
+            'app',
+            'wizard',
+            'config',
+            'Scheduling',
+            'SlurmQueues',
+            i,
+            'Networking',
+            'SubnetIds',
+          ],
+          [headNodeSubnet],
+        )
+      }
+    })
+  }, [headNodeSubnet, queues])
+
   return (
     <SpaceBetween direction="vertical" size="l">
       {queues.map((queue: any, i: any) => (

--- a/frontend/src/old-pages/Configure/Queues/queues.types.ts
+++ b/frontend/src/old-pages/Configure/Queues/queues.types.ts
@@ -2,6 +2,9 @@ export type Queue = {
   Name: string
   AllocationStrategy: AllocationStrategy
   ComputeResources: MultiInstanceComputeResource[]
+  Networking?: {
+    SubnetIds: string[]
+  }
 }
 
 export type QueueValidationErrors = Record<


### PR DESCRIPTION
## Description

Reduce cross-AZs costs by selecting the same subnet of the HeadNode for the queues.

## How Has This Been Tested?

- Kept the default subnet assigned to the Head node: the same subnet is assigned to the queue and dry run succeeds
- Changed the default subnet assigned to the Head node: the same subnet is assigned to the queue and dry run succeeds

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
