### PR TITLE
Introduce 'new_resources_limits' feature flag for versions >= 3.6.0 and set limits accordingly

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -972,7 +972,10 @@
     },
     "queues": {
       "title": "Queues",
-      "description": "Configure up to {{limit}} cluster queues.",
+      "description": {
+        "default": "Configure up to {{limit}} cluster queues.",
+        "newResourcesLimits": "Configure up to {{limit}} queues, with a total of {{maxCRPerCluster}} compute resources for each cluster."
+      },
       "container": {
         "title": "Queue {{index}} - {{queueName}}"
       },

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -30,7 +30,7 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
     'imds_support',
   ],
   '3.4.0': ['multi_az', 'on_node_updated'],
-  '3.6.0': ['rhel8'],
+  '3.6.0': ['rhel8', 'new_resources_limits'],
 }
 
 function composeFlagsListByVersion(currentVersion: string): AvailableFeature[] {

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -30,7 +30,7 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
     'imds_support',
   ],
   '3.4.0': ['multi_az', 'on_node_updated'],
-  '3.6.0': ['rhel8', 'new_resources_limits'],
+  '3.6.0': ['rhel8'],
 }
 
 function composeFlagsListByVersion(currentVersion: string): AvailableFeature[] {

--- a/frontend/src/feature-flags/types.ts
+++ b/frontend/src/feature-flags/types.ts
@@ -26,3 +26,4 @@ export type AvailableFeature =
   | 'imds_support'
   | 'rhel8'
   | 'cost_monitoring'
+  | 'new_resources_limits'

--- a/frontend/src/old-pages/Configure/Configure.tsx
+++ b/frontend/src/old-pages/Configure/Configure.tsx
@@ -29,7 +29,7 @@ import {
 } from './HeadNode'
 import {Storage, StorageHelpPanel, storageValidate} from './Storage'
 import {
-  MAX_QUEUES,
+  useClusterResourcesLimits,
   Queues,
   QueuesHelpPanel,
   queuesValidate,
@@ -57,6 +57,7 @@ import {
 import {ComputeFleetStatus} from '../../types/clusters'
 import {useClusterPoll} from '../../components/useClusterPoll'
 import InfoLink from '../../components/InfoLink'
+import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
 
 const validators: {[key: string]: (...args: any[]) => boolean} = {
   cluster: clusterValidate,
@@ -117,6 +118,7 @@ function Configure() {
   ])
 
   const clusterPoll = useClusterPoll(clusterName, false)
+  const {maxQueues, maxCRPerCluster} = useClusterResourcesLimits()
 
   useEffect(() => {
     if (fleetStatus === 'STOP_REQUESTED') {
@@ -258,7 +260,12 @@ function Configure() {
           },
           {
             title: t('wizard.queues.title'),
-            description: t('wizard.queues.description', {limit: MAX_QUEUES}),
+            description: useFeatureFlag('new_resources_limits')
+              ? t('wizard.queues.description.newResourcesLimits', {
+                  limit: maxQueues,
+                  maxCRPerCluster: maxCRPerCluster,
+                })
+              : t('wizard.queues.description.default', {limit: maxQueues}),
             content: <Queues />,
             info: <InfoLink helpPanel={<QueuesHelpPanel />} />,
           },

--- a/frontend/src/old-pages/Configure/Queues/queues.types.ts
+++ b/frontend/src/old-pages/Configure/Queues/queues.types.ts
@@ -42,3 +42,9 @@ export type Subnet = {
   VpcId: string
   Tags?: Tag[]
 }
+
+export type ClusterResourcesLimits = {
+  maxQueues: number
+  maxCRPerQueue: number
+  maxCRPerCluster: number
+}


### PR DESCRIPTION
## Description
This PR introduce a new  `new_resources_limits` feature flag for versions >= 3.6.0. If feature flag is enabled, resources limits are set as follows:
* Max queues: 100
* Max compute resources: 40

Furthermore, a cluster can have a maximum of a total of 150 compute resources.

## How Has This Been Tested?

* Unit tests
* Manual tests on Queues page
   * Verified that queues and compute resources buttons are enabled/disabled as expected

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
