### PR TITLE
Upgrade pytest to 7.2.2 to remove dependency on py module affected by security issue

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ boto3==1.24.30
 requests==2.28.1
 python-jose==3.3.0
 PyYAML==6.0
-pytest==7.1.2
+pytest==7.2.2
 pytest-mock==3.8.2
 itsdangerous==2.1.2
 marshmallow==3.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ click==8.1.3
     # via flask
 ecdsa==0.18.0
     # via python-jose
+exceptiongroup==1.1.1
+    # via pytest
 flask==2.1.2
     # via
     #   -r requirements.in
@@ -48,13 +50,11 @@ packaging==23.1
     #   pytest
 pluggy==1.0.0
     # via pytest
-py==1.11.0
-    # via pytest
 pyasn1==0.5.0
     # via
     #   python-jose
     #   rsa
-pytest==7.1.2
+pytest==7.2.2
     # via
     #   -r requirements.in
     #   pytest-mock


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description
Upgraded pytest to 7.2.2
<!-- Summary of what this PR introduces and possibly why -->

## How Has This Been Tested?
- manually, launching unit tests and seeing them all green
<!-- The tests you ran to verify your changes -->

## References
- https://github.com/aws/aws-parallelcluster-ui/security/dependabot/8

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
