### PR TITLE
Remove dedicated cost monitoring page

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -291,8 +291,7 @@
         "shell": "Shell",
         "filesystem": "View file system",
         "dcv": "DCV",
-        "logs": "View logs",
-        "costs": "View costs"
+        "logs": "View logs"
       },
       "actionsLabel": "Actions",
       "filtering": {

--- a/frontend/src/old-pages/Clusters/Actions.tsx
+++ b/frontend/src/old-pages/Clusters/Actions.tsx
@@ -32,8 +32,6 @@ import {ButtonDropdown} from '@cloudscape-design/components'
 import {CancelableEventHandler} from '@cloudscape-design/components/internal/events'
 import {ButtonDropdownProps} from '@cloudscape-design/components/button-dropdown/interfaces'
 import {loadTemplateFromCluster} from '../Configure/util'
-import {useCostMonitoringStatus} from './Costs/costs.queries'
-import {useFeatureFlag} from '../../feature-flags/useFeatureFlag'
 
 export default function Actions() {
   const clusterName = useState(['app', 'clusters', 'selected'])
@@ -69,9 +67,6 @@ export default function Actions() {
     'AdditionalIamPolicies',
   ])
   const ssmEnabled = iamPolicies && findFirst(iamPolicies, isSsmPolicy)
-
-  const isCostMonitoringFeatureEnabled = useFeatureFlag('cost_monitoring')
-  const {data: isCostMonitoringStatusActive} = useCostMonitoringStatus()
 
   const isHeadNode =
     headNode && headNode.publicIpAddress && headNode.publicIpAddress !== ''
@@ -175,9 +170,6 @@ export default function Actions() {
           case 'logs':
             navigate(`/clusters/${clusterName}/logs`)
             break
-          case 'costs':
-            navigate(`/clusters/${clusterName}/costs`)
-            break
           case 'delete':
             showDialog('deleteCluster')
             break
@@ -193,13 +185,6 @@ export default function Actions() {
           id: 'logs',
           text: t('cluster.list.actions.logs'),
         },
-        isCostMonitoringFeatureEnabled
-          ? {
-              id: 'costs',
-              text: t('cluster.list.actions.costs'),
-              disabled: !isCostMonitoringStatusActive,
-            }
-          : null,
         {
           id: 'filesystem',
           text: t('cluster.list.actions.filesystem'),
@@ -217,15 +202,8 @@ export default function Actions() {
           text: t('cluster.list.actions.delete'),
           disabled: isDeleteDisabled,
         },
-      ].filter(Boolean) as ButtonDropdownProps.ItemOrGroup[]
-    }, [
-      t,
-      isCostMonitoringFeatureEnabled,
-      isCostMonitoringStatusActive,
-      isSsmDisabled,
-      isEditDisabled,
-      isDeleteDisabled,
-    ])
+      ]
+    }, [t, isSsmDisabled, isEditDisabled, isDeleteDisabled])
 
   const isActionsDisabled = isSsmDisabled && isEditDisabled && isDeleteDisabled
 

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -23,7 +23,6 @@ import {NoMatch} from '../components/NoMatch'
 import {Images} from '../old-pages/Images'
 import {Logs} from '../old-pages/Logs'
 import {useLoadingState} from '../components/useLoadingState'
-import {Costs} from '../old-pages/Clusters/Costs'
 
 export default function App() {
   const {loading, content} = useLoadingState(
@@ -40,7 +39,6 @@ export default function App() {
           </Route>
         </Route>
         <Route path="clusters/:clusterName/logs" element={<Logs />} />
-        <Route path="clusters/:clusterName/costs" element={<Costs />} />
         <Route path="configure" element={<Configure />} />
         <Route path="images" element={<Images />} />
         <Route path="users" element={<Users />} />


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR removes the dedicated cost monitoring page. It is related to #218 , but can be safely merged in any order since the whole feature is behind an experimental flag

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
