### PR TITLE
Add modal to help users to manually activate Cost Explorer

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -434,8 +434,16 @@
   "costMonitoring": {
     "activateButton": {
       "label": "Activate cost monitoring",
-      "activationSuccess": "Cost monitoring activation may take up to 24 hours to be enabled. Your request is being processed!",
-      "costExplorerCannotBeAccessed": "In order to use cost monitoring with PCUI, you must enable Cost Explorer for your account by opening Cost Explorer for the first time in the AWS Cost Management console." 
+      "activationSuccess": "Cost monitoring activation might take up to 24 hours to complete. We are processing your request."
+    },
+    "enableCostExplorerModal": {
+      "title": "Activating Cost Explorer",
+      "description": "To use cost monitoring in the PCUI, open Cost Explorer in your account:<p>1. Log in to the AWS Management console and navigate to AWS Cost Management.<br/>2. In the navigation pane, choose Cost Explorer.<br/>3. In the Welcome page, choose Launch Cost Explorer.</p>",
+      "closeAriaLabel": "Close",
+      "actions": {
+        "cancel": "Not now",
+        "goToCostExplorer": "Activate Cost Explorer"
+      }
     },
     "costData": {
       "title": "Spending analysis",

--- a/frontend/src/old-pages/Clusters/Costs/EnableCostMonitoringButton.tsx
+++ b/frontend/src/old-pages/Clusters/Costs/EnableCostMonitoringButton.tsx
@@ -9,32 +9,106 @@
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Button} from '@cloudscape-design/components'
-import {useCallback} from 'react'
-import {useTranslation} from 'react-i18next'
+import {Box, Button, Modal, SpaceBetween} from '@cloudscape-design/components'
+import React, {useCallback} from 'react'
+import {Trans, useTranslation} from 'react-i18next'
 import {notify} from '../../../model'
 import {
+  CostMonitoringActivationErrorKind,
   useActivateCostMonitoringMutation,
   useCostMonitoringStatus,
 } from './costs.queries'
+import {consoleDomain, useState} from '../../../store'
 import {useFeatureFlag} from '../../../feature-flags/useFeatureFlag'
 
 export function EnableCostMonitoringButton() {
   const {t} = useTranslation()
   const isCostMonitoringActive = useFeatureFlag('cost_monitoring')
+  const defaultRegion = useState(['aws', 'region'])
+  const region = useState(['app', 'selectedRegion']) || defaultRegion
+  const [modalVisible, setModalVisible] = React.useState(false)
+
+  const showModal = useCallback(() => {
+    setModalVisible(true)
+  }, [setModalVisible])
+
+  const dismissModal = useCallback(() => {
+    setModalVisible(false)
+  }, [setModalVisible])
+
+  const onActivationError = useCallback(
+    (kind: CostMonitoringActivationErrorKind, message?: string) => {
+      switch (kind) {
+        case 'costExplorerCannotBeAccessed':
+          showModal()
+          break
+        case 'genericError':
+          notify(message, 'error')
+          break
+      }
+    },
+    [showModal],
+  )
+
+  const onActivationSuccess = useCallback(() => {
+    notify(t('costMonitoring.activateButton.activationSuccess'))
+  }, [t])
 
   const {data: costMonitoringStatus, isLoading} = useCostMonitoringStatus()
-  const costMonitoringStatusMutation = useActivateCostMonitoringMutation(notify)
+  const costMonitoringStatusMutation = useActivateCostMonitoringMutation(
+    onActivationError,
+    onActivationSuccess,
+  )
 
   const onClick = useCallback(() => {
     costMonitoringStatusMutation.mutate()
   }, [costMonitoringStatusMutation])
 
+  const domain = consoleDomain(region)
+  const costExplorerHref = `${domain}/cost-management/home#/cost-explorer`
+
   if (isLoading || costMonitoringStatus || !isCostMonitoringActive) return null
 
   return (
-    <Button onClick={onClick}>
-      {t('costMonitoring.activateButton.label')}
-    </Button>
+    <>
+      <Button
+        onClick={onClick}
+        loading={costMonitoringStatusMutation.isLoading}
+      >
+        {t('costMonitoring.activateButton.label')}
+      </Button>
+      {modalVisible && (
+        <Modal
+          onDismiss={dismissModal}
+          visible={modalVisible}
+          closeAriaLabel={t(
+            'costMonitoring.enableCostExplorerModal.closeAriaLabel',
+          )}
+          footer={
+            <Box float="right">
+              <SpaceBetween direction="horizontal" size="xs">
+                <Button onClick={dismissModal} variant="link">
+                  {t('costMonitoring.enableCostExplorerModal.actions.cancel')}
+                </Button>
+                <Button
+                  variant="primary"
+                  iconName="external"
+                  target="_blank"
+                  href={costExplorerHref}
+                  onClick={dismissModal}
+                >
+                  {t(
+                    'costMonitoring.enableCostExplorerModal.actions.goToCostExplorer',
+                  )}
+                </Button>
+              </SpaceBetween>
+            </Box>
+          }
+          header={t('costMonitoring.enableCostExplorerModal.title')}
+        >
+          <Trans i18nKey="costMonitoring.enableCostExplorerModal.description" />
+        </Modal>
+      )}
+    </>
   )
 }

--- a/frontend/src/old-pages/Clusters/Costs/__tests__/useActivateCostMonitoringMutation.test.tsx
+++ b/frontend/src/old-pages/Clusters/Costs/__tests__/useActivateCostMonitoringMutation.test.tsx
@@ -36,11 +36,13 @@ jest.mock('../../../../model', () => ({
 }))
 
 describe('given a mutation to activate cost monitoring', () => {
-  let mockNotify: jest.Mock
+  let mockOnSuccess: jest.Mock
+  let mockOnError: jest.Mock
 
   beforeEach(() => {
     mockActivateCostMonitoring.mockClear()
-    mockNotify = jest.fn()
+    mockOnSuccess = jest.fn()
+    mockOnError = jest.fn()
   })
 
   describe('when cost monitoring can be activated successfully', () => {
@@ -50,7 +52,7 @@ describe('given a mutation to activate cost monitoring', () => {
 
     it('should set the cost monitoring status to true', async () => {
       const {result} = renderHook(
-        () => useActivateCostMonitoringMutation(mockNotify),
+        () => useActivateCostMonitoringMutation(mockOnError, mockOnSuccess),
         {wrapper},
       )
 
@@ -64,7 +66,7 @@ describe('given a mutation to activate cost monitoring', () => {
 
     it('should notify the user about the success', async () => {
       const {result} = renderHook(
-        () => useActivateCostMonitoringMutation(mockNotify),
+        () => useActivateCostMonitoringMutation(mockOnError, mockOnSuccess),
         {wrapper},
       )
 
@@ -72,10 +74,7 @@ describe('given a mutation to activate cost monitoring', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-      expect(mockNotify).toHaveBeenCalledTimes(1)
-      expect(mockNotify).toHaveBeenCalledWith(
-        'costMonitoring.activateButton.activationSuccess',
-      )
+      expect(mockOnSuccess).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -87,17 +86,16 @@ describe('given a mutation to activate cost monitoring', () => {
 
       it('should notify the user about the failure', async () => {
         const {result} = renderHook(
-          () => useActivateCostMonitoringMutation(mockNotify),
+          () => useActivateCostMonitoringMutation(mockOnError, mockOnSuccess),
           {wrapper},
         )
 
         result.current.mutate()
 
-        await waitFor(() => expect(mockNotify).toHaveBeenCalledTimes(1))
+        await waitFor(() => expect(mockOnError).toHaveBeenCalledTimes(1))
         await waitFor(() =>
-          expect(mockNotify).toHaveBeenCalledWith(
-            'costMonitoring.activateButton.costExplorerCannotBeAccessed',
-            'error',
+          expect(mockOnError).toHaveBeenCalledWith(
+            'costExplorerCannotBeAccessed',
           ),
         )
       })
@@ -112,17 +110,17 @@ describe('given a mutation to activate cost monitoring', () => {
 
       it('should notify the user about the failure', async () => {
         const {result} = renderHook(
-          () => useActivateCostMonitoringMutation(mockNotify),
+          () => useActivateCostMonitoringMutation(mockOnError, mockOnSuccess),
           {wrapper},
         )
 
         result.current.mutate()
 
-        await waitFor(() => expect(mockNotify).toHaveBeenCalledTimes(1))
+        await waitFor(() => expect(mockOnError).toHaveBeenCalledTimes(1))
         await waitFor(() =>
-          expect(mockNotify).toHaveBeenCalledWith(
+          expect(mockOnError).toHaveBeenCalledWith(
+            'genericError',
             'some-error-message',
-            'error',
           ),
         )
       })


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR adds a modal to help users who need [to manually enable Cost Explorer](https://docs.aws.amazon.com/cost-management/latest/userguide/ce-enable.html).

Following PRs will:
- enable the whole cost monitoring feature with a non-experimental flag
- add e2e spec

## Changes

- update `useActivateCostMonitoringMutation` to delegate handling of error and success
- when Cost Explorer needs to be manually activated, show modal

## Screenshot
<img width="931" alt="Screenshot 2023-05-10 at 12 08 22" src="https://github.com/aws/aws-parallelcluster-ui/assets/11457067/6c4ccdbe-7d33-42a0-adb6-72f732f36ef5">

## How Has This Been Tested?

- manually, by mocking both a 400 and a 405
- manually, by mocking a 204
- unit tests

## References

- https://docs.aws.amazon.com/cost-management/latest/userguide/ce-enable.html

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
