### PR TITLE
Enable Cost Monitoring starting from PC 3.2.0

### DIFF
--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -9,6 +9,7 @@
 // limitations under the License.
 
 import {featureFlagsProvider} from '../featureFlagsProvider'
+import {AvailableFeature} from '../types'
 
 describe('given a feature flags provider and a list of rules', () => {
   const subject = featureFlagsProvider
@@ -16,21 +17,21 @@ describe('given a feature flags provider and a list of rules', () => {
   describe('when the features list is retrieved', () => {
     it('should return the list', async () => {
       const features = await subject('0.0.0')
-      expect(features).toEqual([])
+      expect(features).toEqual<AvailableFeature[]>([])
     })
   })
 
   describe('when the version is between 3.1.0 and 3.2.0', () => {
     it('should return the list of available features', async () => {
       const features = await subject('3.1.5')
-      expect(features).toEqual(['multiuser_cluster'])
+      expect(features).toEqual<AvailableFeature[]>(['multiuser_cluster'])
     })
   })
 
   describe('when the version is between 3.2.0 and 3.3.0', () => {
     it('should return the list of available features', async () => {
       const features = await subject('3.2.5')
-      expect(features).toEqual([
+      expect(features).toEqual<AvailableFeature[]>([
         'multiuser_cluster',
         'fsx_ontap',
         'fsx_openzsf',
@@ -38,6 +39,7 @@ describe('given a feature flags provider and a list of rules', () => {
         'memory_based_scheduling',
         'slurm_queue_update_strategy',
         'ebs_deletion_policy',
+        'cost_monitoring',
       ])
     })
   })
@@ -45,7 +47,7 @@ describe('given a feature flags provider and a list of rules', () => {
   describe('when the version is above 3.3.0', () => {
     it('should return the list of available features', async () => {
       const features = await subject('3.3.2')
-      expect(features).toEqual([
+      expect(features).toEqual<AvailableFeature[]>([
         'multiuser_cluster',
         'fsx_ontap',
         'fsx_openzsf',
@@ -53,6 +55,7 @@ describe('given a feature flags provider and a list of rules', () => {
         'memory_based_scheduling',
         'slurm_queue_update_strategy',
         'ebs_deletion_policy',
+        'cost_monitoring',
         'slurm_accounting',
         'queues_multiple_instance_types',
         'dynamic_fs_mount',
@@ -70,7 +73,10 @@ describe('given a feature flags provider and a list of rules', () => {
     })
     it('should be included in the list of features', async () => {
       const features = await subject('3.1.5')
-      expect(features).toEqual(['multiuser_cluster', 'cost_monitoring'])
+      expect(features).toEqual<AvailableFeature[]>([
+        'multiuser_cluster',
+        'cost_monitoring',
+      ])
     })
   })
 
@@ -80,7 +86,7 @@ describe('given a feature flags provider and a list of rules', () => {
     })
     it('should not be included in the list of features', async () => {
       const features = await subject('3.1.5')
-      expect(features).toEqual(['multiuser_cluster'])
+      expect(features).toEqual<AvailableFeature[]>(['multiuser_cluster'])
     })
   })
 })

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -20,6 +20,7 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
     'multiuser_cluster',
     'slurm_queue_update_strategy',
     'ebs_deletion_policy',
+    'cost_monitoring',
   ],
   '3.3.0': [
     'slurm_accounting',

--- a/frontend/src/old-pages/Clusters/Costs/__tests__/EnableCostMonitoringButton.test.tsx
+++ b/frontend/src/old-pages/Clusters/Costs/__tests__/EnableCostMonitoringButton.test.tsx
@@ -53,12 +53,15 @@ describe('given a component to activate cost monitoring for the account', () => 
 
   beforeEach(() => {
     jest.clearAllMocks()
-    window.sessionStorage.clear()
   })
 
-  describe('when the cost monitoring feature is enabled', () => {
+  describe('when PC version is at least 3.2.0', () => {
     beforeEach(() => {
-      window.sessionStorage.setItem('additionalFeatures', '["cost_monitoring"]')
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {full: '3.2.0'},
+        },
+      })
 
       screen = render(
         <MockProviders>
@@ -84,7 +87,11 @@ describe('given a component to activate cost monitoring for the account', () => 
 
   describe('when cost monitoring is already active for the account', () => {
     beforeEach(() => {
-      window.sessionStorage.setItem('additionalFeatures', '["cost_monitoring"]')
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {full: '3.2.0'},
+        },
+      })
       mockGetCostMonitoringStatus.mockResolvedValue(true)
 
       screen = render(
@@ -104,8 +111,14 @@ describe('given a component to activate cost monitoring for the account', () => 
     })
   })
 
-  describe('when the cost monitoring feature is not enabled', () => {
+  describe('when PC version is less than 3.2.0', () => {
     beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {full: '3.1.5'},
+        },
+      })
+
       screen = render(
         <MockProviders>
           <EnableCostMonitoringButton />

--- a/frontend/src/old-pages/Clusters/Costs/__tests__/useCostMonitoringStatus.test.tsx
+++ b/frontend/src/old-pages/Clusters/Costs/__tests__/useCostMonitoringStatus.test.tsx
@@ -40,13 +40,16 @@ jest.mock('../../../../model', () => {
 
 describe('given a hook to get the cost monitoring status', () => {
   beforeEach(() => {
-    window.sessionStorage.clear()
-    mockGetCostMonitoringStatus.mockClear()
+    jest.clearAllMocks()
   })
 
-  describe('when the cost monitoring feature is enabled', () => {
+  describe('when PC version is at least 3.2.0', () => {
     beforeEach(() => {
-      window.sessionStorage.setItem('additionalFeatures', '["cost_monitoring"]')
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {full: '3.2.0'},
+        },
+      })
     })
 
     it('should request the cost monitoring status', async () => {
@@ -56,7 +59,14 @@ describe('given a hook to get the cost monitoring status', () => {
     })
   })
 
-  describe('when the cost monitoring feature is not enabled', () => {
+  describe('when PC version is less than 3.2.0', () => {
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {full: '3.1.5'},
+        },
+      })
+    })
     it('should not request the cost monitoring status', async () => {
       renderHook(() => useCostMonitoringStatus(), {wrapper})
 


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR activates Cost Monitoring starting from PC 3.2.0. 

## Changes

- bind the `cost_monitoring` flag to the PC version >= 3.2.0)

## How Has This Been Tested?

- verify CM activates with sessionStorage being empty
- verify CM does not activate mocking the version to 3.1.0
- unit tests

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
