### PR TITLE
Remove success loading bar after creating a cluster

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -1130,7 +1130,6 @@
       "title": "Create",
       "description": "Review or edit your cluster configuration and create your cluster.",
       "pending": "<strong>{{clusterName}}</strong> create is in progress. In <strong>Clusters</strong>, view <strong>{{clusterName}}</strong> create status.",
-      "success": "<strong>{{clusterName}}</strong> successfully created.",
       "configuration": {
         "title": "Cluster configuration YAML file",
         "description": "Review or edit the YAML file that is used to create your cluster.",

--- a/frontend/src/old-pages/Configure/Create.tsx
+++ b/frontend/src/old-pages/Configure/Create.tsx
@@ -71,7 +71,7 @@ function setClusterLoadingMsg(
       />
     )
   }
-  notify(content, 'success', clusterLoadingMsgId, true, true)
+  notify(content, 'info', clusterLoadingMsgId, true, true)
 }
 
 function removeClusterLoadingMsg() {
@@ -109,13 +109,6 @@ function handleCreate(
 
     ListClusters()
     clearWizardState()
-    notify(
-      <Trans
-        i18nKey={'wizard.create.success'}
-        values={{clusterName: clusterName}}
-      />,
-      'success',
-    )
     navigate(href)
   }
   setState(['app', 'wizard', 'errors', 'create'], null)


### PR DESCRIPTION
## Description

Remove the misleading success flashbar after the create cluster request is completed. It's misleading because cluster creation is an asynchronous process that can fail.

## How Has This Been Tested?

Created a cluster and no green flashbar is displayed

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
