### PR TITLE
Update and activate increased resource limits for PC >= 3.6.0

### DIFF
--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -44,7 +44,7 @@ describe('given a feature flags provider and a list of rules', () => {
     })
   })
 
-  describe('when the version is above 3.3.0', () => {
+  describe('when the version is between 3.3.0 and 3.4.0', () => {
     it('should return the list of available features', async () => {
       const features = await subject('3.3.2')
       expect(features).toEqual<AvailableFeature[]>([
@@ -62,6 +62,56 @@ describe('given a feature flags provider and a list of rules', () => {
         'efs_deletion_policy',
         'lustre_deletion_policy',
         'imds_support',
+      ])
+    })
+  })
+
+  describe('when the version is between 3.4.0 and 3.6.0', () => {
+    it('should return the list of available features', async () => {
+      const features = await subject('3.4.1')
+      expect(features).toEqual<AvailableFeature[]>([
+        'multiuser_cluster',
+        'fsx_ontap',
+        'fsx_openzsf',
+        'lustre_persistent2',
+        'memory_based_scheduling',
+        'slurm_queue_update_strategy',
+        'ebs_deletion_policy',
+        'cost_monitoring',
+        'slurm_accounting',
+        'queues_multiple_instance_types',
+        'dynamic_fs_mount',
+        'efs_deletion_policy',
+        'lustre_deletion_policy',
+        'imds_support',
+        'multi_az',
+        'on_node_updated',
+      ])
+    })
+  })
+
+  describe('when the version is above and 3.6.0', () => {
+    it('should return the list of available features', async () => {
+      const features = await subject('3.6.0')
+      expect(features).toEqual<AvailableFeature[]>([
+        'multiuser_cluster',
+        'fsx_ontap',
+        'fsx_openzsf',
+        'lustre_persistent2',
+        'memory_based_scheduling',
+        'slurm_queue_update_strategy',
+        'ebs_deletion_policy',
+        'cost_monitoring',
+        'slurm_accounting',
+        'queues_multiple_instance_types',
+        'dynamic_fs_mount',
+        'efs_deletion_policy',
+        'lustre_deletion_policy',
+        'imds_support',
+        'multi_az',
+        'on_node_updated',
+        'rhel8',
+        'new_resources_limits',
       ])
     })
   })

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -31,7 +31,7 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
     'imds_support',
   ],
   '3.4.0': ['multi_az', 'on_node_updated'],
-  '3.6.0': ['rhel8'],
+  '3.6.0': ['rhel8', 'new_resources_limits'],
 }
 
 function composeFlagsListByVersion(currentVersion: string): AvailableFeature[] {

--- a/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
@@ -361,6 +361,20 @@ describe('Given a list of queues', () => {
         expect.anything(),
       )
     })
+    it('should not allow to add more queues', () => {
+      const {getAllByText} = render(
+        <MockProviders store={mockStore}>
+          <Queues />
+        </MockProviders>,
+      )
+
+      const button = getAllByText('Add queue')[0]
+      fireEvent.click(button)
+      expect(setState).not.toHaveBeenCalledWith(
+        ['app', 'wizard', 'config', 'Scheduling', 'SlurmQueues'],
+        expect.anything(),
+      )
+    })
   })
 })
 

--- a/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.test.tsx
@@ -80,13 +80,6 @@ describe('Given a list of queues', () => {
     'when the PC version is $version and they are $maxQueues or more',
     ({version, maxQueues}) => {
       beforeEach(() => {
-        window.sessionStorage.clear()
-        if (version === '3.6.0') {
-          window.sessionStorage.setItem(
-            'additionalFeatures',
-            '["new_resources_limits"]',
-          )
-        }
         const queues = new Array(maxQueues).fill(null).map((_, index) => ({
           Name: `queue-${index + 1}`,
           ComputeResources: [],
@@ -152,13 +145,6 @@ describe('Given a list of queues', () => {
         },
       }))
       beforeEach(() => {
-        window.sessionStorage.clear()
-        if (version === '3.6.0') {
-          window.sessionStorage.setItem(
-            'additionalFeatures',
-            '["new_resources_limits"]',
-          )
-        }
         mockStore.getState.mockReturnValue({
           aws: {
             subnets: [],
@@ -198,14 +184,6 @@ describe('Given a list of queues', () => {
     'when the PC version is $version and the compute resources of a queue are $maxComputeResources',
     ({version, maxComputeResources}) => {
       beforeEach(() => {
-        window.sessionStorage.clear()
-        if (version === '3.6.0') {
-          window.sessionStorage.setItem(
-            'additionalFeatures',
-            '["new_resources_limits"]',
-          )
-        }
-
         mockStore.getState.mockReturnValue({
           aws: {
             subnets: [],
@@ -258,13 +236,6 @@ describe('Given a list of queues', () => {
     'when the PC version is $version and the compute resources of a queue are less then $maxComputeResources',
     ({version, maxComputeResources}) => {
       beforeEach(() => {
-        window.sessionStorage.clear()
-        if (version === '3.6.0') {
-          window.sessionStorage.setItem(
-            'additionalFeatures',
-            '["new_resources_limits"]',
-          )
-        }
         mockStore.getState.mockReturnValue({
           aws: {
             subnets: [],

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -366,7 +366,7 @@ const useAllocationStrategyOptions = () => {
 function Queue({index}: any) {
   const {t} = useTranslation()
   const queues = useState(queuesPath)
-  const {maxQueues} = useClusterResourcesLimits()
+  const {maxQueues, maxCRPerCluster} = useClusterResourcesLimits()
   const computeResourceAdapter = useComputeResourceAdapter()
   const queue = useState([...queuesPath, index])
   const enablePlacementGroupPath = React.useMemo(
@@ -501,6 +501,20 @@ function Queue({index}: any) {
     [t],
   )
 
+  const totalComputeResources = React.useMemo(
+    () =>
+      queues
+        .map((queue: Queue) => queue.ComputeResources.length)
+        .reduce(
+          (total: number, computeResources: number) => total + computeResources,
+          0,
+        ),
+    [queues],
+  )
+
+  const canAddQueue =
+    queues.length < maxQueues && totalComputeResources < maxCRPerCluster
+
   return (
     <Container
       header={
@@ -508,7 +522,7 @@ function Queue({index}: any) {
           variant="h2"
           actions={
             <SpaceBetween direction="horizontal" size="xs">
-              <Button disabled={queues.length >= maxQueues} onClick={addQueue}>
+              <Button disabled={!canAddQueue} onClick={addQueue}>
                 {t('wizard.queues.addQueueButton.label')}
               </Button>
               {queues.length > 1 && (

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -51,7 +51,9 @@ import * as MultiInstanceCR from './MultiInstanceComputeResource'
 import {
   AllocationStrategy,
   ClusterResourcesLimits,
-  ComputeResource, Queue} from './queues.types'
+  ComputeResource,
+  Queue,
+} from './queues.types'
 import {SubnetMultiSelect} from './SubnetMultiSelect'
 import {NonCancelableEventHandler} from '@cloudscape-design/components/internal/events'
 import TitleDescriptionHelpPanel from '../../../components/help-panel/TitleDescriptionHelpPanel'
@@ -70,7 +72,7 @@ const queuesErrorsPath = ['app', 'wizard', 'errors', 'queues']
 export function useClusterResourcesLimits(): ClusterResourcesLimits {
   const newResourcesLimits = useFeatureFlag('new_resources_limits')
   return newResourcesLimits
-    ? {maxQueues: 100, maxCRPerQueue: 40, maxCRPerCluster: 150}
+    ? {maxQueues: 50, maxCRPerQueue: 50, maxCRPerCluster: 50}
     : {maxQueues: 10, maxCRPerQueue: 5, maxCRPerCluster: 50}
 }
 


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR updates the scheduling resources limits introduced with #211. It also activates the feature for PC versions greater or equal to 3.6.0

## Changes

- update limits
- disallow creation of a new queue when the per-cluster total has been reached

## How Has This Been Tested?

- manually, by activating the feature and testing the limits
- manually, by disablign the feature and testing the limits
- unit tests

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
