### PR TITLE
Fix EBS SnapshotId still present in the config after removing the property

### DIFF
--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -11,7 +11,7 @@
 // limitations under the License.
 
 // Fameworks
-import React, {useCallback} from 'react'
+import React, {useCallback, useState as reactUseState} from 'react'
 import i18next from 'i18next'
 import {Trans, useTranslation} from 'react-i18next'
 import {clamp} from '../../util'
@@ -691,7 +691,7 @@ export function EbsSettings({index}: any) {
   const volumeSizePath = [...ebsPath, 'Size']
   const encryptedPath = [...ebsPath, 'Encrypted']
   const kmsPath = [...ebsPath, 'KmsKeyId']
-  const snapshotIdPath = [...ebsPath, 'SnapshotId']
+  const snapshotIdPath = useMemo(() => [...ebsPath, 'SnapshotId'], [ebsPath])
 
   const deletionPolicyPath = [...ebsPath, 'DeletionPolicy']
   const supportedDeletionPolicies: EbsDeletionPolicy[] = [
@@ -707,6 +707,7 @@ export function EbsSettings({index}: any) {
   let encrypted = useState(encryptedPath)
   let kmsId = useState(kmsPath)
   let snapshotId = useState(snapshotIdPath)
+  const [snapshostVisible, setSnapshotVisible] = reactUseState(!!snapshotId)
   let deletionPolicy = useState(deletionPolicyPath)
 
   let validated = useState([...errorsPath, 'validated'])
@@ -726,6 +727,11 @@ export function EbsSettings({index}: any) {
     setState(encryptedPath, setEncrypted)
     if (!setEncrypted) clearState(kmsPath)
   }
+
+  const toggleSnapshotVisibility = useCallback(() => {
+    clearState(snapshotIdPath)
+    setSnapshotVisible(!snapshostVisible)
+  }, [setSnapshotVisible, snapshostVisible, snapshotIdPath])
 
   const encryptionFooterLinks = useMemo(
     () => [
@@ -817,10 +823,8 @@ export function EbsSettings({index}: any) {
       <ColumnLayout columns={2}>
         <SpaceBetween direction="vertical" size="xxs">
           <CheckboxWithHelpPanel
-            checked={snapshotId !== null}
-            onChange={_event => {
-              setState(snapshotIdPath, snapshotId === null ? '' : null)
-            }}
+            checked={snapshostVisible}
+            onChange={toggleSnapshotVisibility}
             helpPanel={
               <TitleDescriptionHelpPanel
                 title={t('wizard.storage.Ebs.snapshotId.label')}
@@ -831,7 +835,7 @@ export function EbsSettings({index}: any) {
           >
             {t('wizard.storage.Ebs.snapshotId.label')}
           </CheckboxWithHelpPanel>
-          {snapshotId !== null && (
+          {snapshostVisible && (
             <Input
               value={snapshotId}
               placeholder={t('wizard.storage.Ebs.snapshotId.placeholder')}

--- a/frontend/src/old-pages/Configure/__tests__/storage.test.tsx
+++ b/frontend/src/old-pages/Configure/__tests__/storage.test.tsx
@@ -9,7 +9,7 @@
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {render, RenderResult} from '@testing-library/react'
+import {fireEvent, render, RenderResult} from '@testing-library/react'
 import {I18nextProvider} from 'react-i18next'
 import i18n from 'i18next'
 import {initReactI18next} from 'react-i18next'
@@ -441,6 +441,50 @@ describe('given a component to display an Ebs storage instance', () => {
       expect(
         screen.queryByLabelText('wizard.storage.instance.deletionPolicy.label'),
       ).toBeNull()
+    })
+  })
+
+  describe('when the snapshot id property is unchecked', () => {
+    beforeEach(() => {
+      mockStore.getState.mockReturnValue({
+        app: {
+          version: {
+            full: '3.2.0',
+          },
+          wizard: {
+            config: {
+              SharedStorage: [
+                {
+                  Name: 'ebs-0',
+                  EbsSettings: {
+                    SnapshotId: 'test-snapshot',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      })
+    })
+
+    it('should be removed from the store too', () => {
+      let {getByText} = render(
+        <MockProviders>
+          <EbsSettings index={0} />
+        </MockProviders>,
+      )
+
+      fireEvent.click(getByText('wizard.storage.Ebs.snapshotId.label'))
+
+      expect(clearState).toHaveBeenCalledWith([
+        'app',
+        'wizard',
+        'config',
+        'SharedStorage',
+        0,
+        'EbsSettings',
+        'SnapshotId',
+      ])
     })
   })
 })


### PR DESCRIPTION
## How Has This Been Tested?

- Set the property and unchecked, no SnapshotId in the YAML
- Set the property, SnapshotId in the YAML
- Just created an empty EBS volume, no SnapshotId in the YAML

## PR Quality Checklist

- [x] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
