### PR TITLE
Add loading state to wizard action buttons

### DIFF
--- a/frontend/src/old-pages/Configure/Configure.tsx
+++ b/frontend/src/old-pages/Configure/Configure.tsx
@@ -82,6 +82,7 @@ function wizardShow(navigate: any) {
   navigate('/configure')
 }
 const loadingPath = ['app', 'wizard', 'source', 'loading']
+const wizardSubmissionLoading = ['app', 'wizard', 'submit', 'loading']
 
 function clearWizardState(
   clearState: (path: any) => void,
@@ -108,6 +109,7 @@ function Configure() {
   const editing = useState(['app', 'wizard', 'editing'])
   const currentPage = useState(['app', 'wizard', 'page']) || INITIAL_WIZARD_PAGE
   const loadingExistingConfiguration = useState(loadingPath)
+  const isSubmittingWizard = useState(wizardSubmissionLoading)
   const [refreshing, setRefreshing] = React.useState(false)
   let navigate = useNavigate()
 
@@ -201,7 +203,7 @@ function Configure() {
           </Button>
         )}
         {currentPage === 'create' && (
-          <Button onClick={wizardHandleDryRun}>
+          <Button disabled={isSubmittingWizard} onClick={wizardHandleDryRun}>
             {t('wizard.actions.dryRun')}
           </Button>
         )}
@@ -245,7 +247,9 @@ function Configure() {
         onSubmit={handleSubmit}
         activeStepIndex={pages.indexOf(currentPage)}
         secondaryActions={showSecondaryActions()}
-        isLoadingNextStep={refreshing || loadingExistingConfiguration}
+        isLoadingNextStep={
+          refreshing || loadingExistingConfiguration || isSubmittingWizard
+        }
         steps={[
           {
             title: t('wizard.cluster.title'),

--- a/frontend/src/old-pages/Configure/Create.tsx
+++ b/frontend/src/old-pages/Configure/Create.tsx
@@ -35,6 +35,7 @@ import {errorsToFlashbarItems} from './errorsToFlashbarItems'
 
 // Constants
 const configPath = ['app', 'wizard', 'clusterConfigYaml']
+const wizardSubmissionLoading = ['app', 'wizard', 'submit', 'loading']
 const clusterLoadingMsgId = 'cluster-loading'
 
 function handleWarnings(resp: any) {
@@ -96,16 +97,19 @@ function handleCreate(
   const region = getState(['app', 'wizard', 'config', 'Region'])
   const selectedRegion = getState(['app', 'selectedRegion'])
   setClusterLoadingMsg(clusterName, editing, dryRun)
+  setState(wizardSubmissionLoading, true)
 
   var errHandler = (err: any) => {
     setState(['app', 'wizard', 'errors', 'create'], err)
     removeClusterLoadingMsg()
+    setState(wizardSubmissionLoading, false)
   }
   var successHandler = (resp: any) => {
     let href = `/clusters/${clusterName}/stack-events`
     handleWarnings(resp)
     setState(['app', 'selectedRegion'], region)
     setState(['app', 'clusters', 'selected'], clusterName)
+    setState(wizardSubmissionLoading, false)
 
     ListClusters()
     clearWizardState()
@@ -144,13 +148,16 @@ function handleDryRun() {
   const selectedRegion = getState(['app', 'selectedRegion'])
   const dryRun = true
   setClusterLoadingMsg(clusterName, editing, dryRun)
+  setState(wizardSubmissionLoading, true)
 
   var errHandler = (err: any) => {
     setState(['app', 'wizard', 'errors', 'create'], err)
     removeClusterLoadingMsg()
+    setState(wizardSubmissionLoading, false)
   }
   var successHandler = (resp: any) => {
     handleWarnings(resp)
+    setState(wizardSubmissionLoading, false)
   }
   setState(['app', 'wizard', 'errors', 'create'], null)
   if (editing)


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR disables the action buttons in the cluster creation wizard while a dry-run/create/edit request is pending

## Changes

- add/remove loading state when performing a dry-run, a creation and an update
- bind both the wizard and the dryrun button to such loading state

## How Has This Been Tested?

- manually, by testing dry-run, create and edit

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
