### PR TITLE
Don't reload the page when clicking on a breadcrumb

### DIFF
--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -46,6 +46,8 @@ import {
   Multiselect,
   MultiselectProps,
   ColumnLayout,
+  BreadcrumbGroupProps,
+  BreadcrumbGroup,
 } from '@cloudscape-design/components'
 
 // Components
@@ -59,6 +61,7 @@ import {
   InstanceType,
   InstanceTypeOption,
 } from './Components.types'
+import {useNavigate} from 'react-router-dom'
 
 // Helper Functions
 function strToOption(str: any) {
@@ -750,6 +753,26 @@ const CheckboxWithHelpPanel = ({
       <InfoLink helpPanel={helpPanel} />
     </SpaceBetween>
   )
+}
+
+export const BreadcrumbGroupNavigate = ({
+  onFollow,
+  ...props
+}: BreadcrumbGroupProps) => {
+  const navigate = useNavigate()
+
+  const handleNavigate = React.useCallback(
+    event => {
+      event.preventDefault()
+      if (onFollow) {
+        onFollow(event)
+      } else {
+        navigate(event.detail.href)
+      }
+    },
+    [navigate, onFollow],
+  )
+  return <BreadcrumbGroup {...props} onFollow={handleNavigate} />
 }
 
 export {

--- a/frontend/src/old-pages/Layout.tsx
+++ b/frontend/src/old-pages/Layout.tsx
@@ -27,9 +27,9 @@ import {
   NonCancelableEventHandler,
 } from '@cloudscape-design/components/internal/events'
 import {BreadcrumbGroupProps} from '@cloudscape-design/components/breadcrumb-group/interfaces'
-import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group'
 import {useTranslation} from 'react-i18next'
 import map from 'lodash/map'
+import {BreadcrumbGroupNavigate} from './Configure/Components'
 
 type Slug = 'clusters' | 'images' | 'users' | 'clusterCreate' | 'clusterUpdate'
 type BreadcrumbsProps = {
@@ -79,10 +79,10 @@ export function Breadcrumbs({
   )
 
   return (
-    <BreadcrumbGroup
+    <BreadcrumbGroupNavigate
       items={items}
       ariaLabel={t('global.menu.header')}
-      onClick={onClick}
+      onFollow={onClick}
     />
   )
 }

--- a/frontend/src/old-pages/Logs/index.tsx
+++ b/frontend/src/old-pages/Logs/index.tsx
@@ -10,7 +10,6 @@
 // limitations under the License.
 
 import {
-  BreadcrumbGroup,
   BreadcrumbGroupProps,
   ContentLayout,
   Header,
@@ -26,6 +25,7 @@ import InfoLink from '../../components/InfoLink'
 import Layout from '../Layout'
 import {LogMessagesTable} from './LogMessagesTable'
 import {LogStreamsTable} from './LogStreamsTable'
+import {BreadcrumbGroupNavigate} from '../Configure/Components'
 
 function LogsHelpPanel({clusterName}: {clusterName: string}) {
   const {t} = useTranslation()
@@ -81,7 +81,7 @@ export function Logs() {
   }, [])
 
   return (
-    <Layout breadcrumbs={<BreadcrumbGroup items={breadcrumbItems} />}>
+    <Layout breadcrumbs={<BreadcrumbGroupNavigate items={breadcrumbItems} />}>
       <ContentLayout
         header={
           <Header


### PR DESCRIPTION
## Description

Fixes #181.

## Changes

Override breadcrumb navigation using `react-router-dom` instead of a page reload (took inspiration from the sidebar).

## How Has This Been Tested?

- Clicked on many breadcrumb items: no page reload and the region is preserved
- Started a cluster creation and clicked on a breadcrumb: the user is redirected to cluster and form data is resetted

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
