### PR TITLE
Update link pointing to Cost Explorer with pre-filled filters

### DIFF
--- a/frontend/src/old-pages/Clusters/Costs/CostData.tsx
+++ b/frontend/src/old-pages/Clusters/Costs/CostData.tsx
@@ -83,6 +83,12 @@ const months = [
   i18next.t('costMonitoring.costData.chart.months.dec'),
 ]
 
+function buildCostExplorerLink(domain: string, clusterName: string) {
+  const uri = `${domain}/cost-management/home#/cost-explorer?granularity=Monthly&historicalRelativeRange=LAST_12_MONTHS&groupBy=[]&filter=[{"dimension":{"id":"TagKey","displayValue":"Tag"},"operator":"INCLUDES","values":[{"value":"${clusterName}"}],"growableValue":{"value":"parallelcluster:cluster-name","displayValue":"parallelcluster:cluster-name"}}]`
+
+  return encodeURI(uri)
+}
+
 export function CostData({clusterName}: Props) {
   const {t} = useTranslation()
   const defaultRegion = useState(['aws', 'region'])
@@ -112,7 +118,8 @@ export function CostData({clusterName}: Props) {
   )
 
   const domain = consoleDomain(region)
-  const costExplorerHref = `${domain}/cost-management/home#/cost-explorer`
+  const costExplorerHref = buildCostExplorerLink(domain, clusterName)
+
   const budgetsHref = `${domain}/billing/home#/budgets`
 
   const i18nStrings: BarChartProps<XAxisValueType>['i18nStrings'] = useMemo(


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

This PR updates the link pointing to Cost Explorer, so that it opens up with the following pre-filled filters:
- granularity: monthly
- time range: last 12 months
- cluster-name: selected cluster
- no groupby

## How Has This Been Tested?

- manually, by clicking the link and verifying the chart is the last 12 months, for the selected cluster

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
