### PR TITLE
Fix deployment for GovCloud region us-gov-west-1

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -101,6 +101,7 @@ Conditions:
       - !Equals ['3', !Select [ 1, !Split ['.', !Ref Version] ] ]
       - !Equals ['4', !Select [ 1, !Split ['.', !Ref Version] ] ]
       - !Equals ['5', !Select [ 1, !Split ['.', !Ref Version] ] ]
+  InGovCloud: !Equals ['us-gov-west-1', !Ref "AWS::Region"]
 
 Mappings:
   ParallelClusterUI:
@@ -755,14 +756,17 @@ Resources:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
-          - Action:
+          - !If
+            - InGovCloud
+            - !Ref AWS::NoValue
+            - Action:
               - ce:ListCostAllocationTags
               - ce:UpdateCostAllocationTagsStatus
               - ce:GetCostAndUsage
-            Resource:
-              - !Sub 'arn:aws:ce:us-east-1:${AWS::AccountId}:/*' # CE only available in us-east-1, aws partition, see https://docs.aws.amazon.com/general/latest/gr/billing.html
-            Effect: Allow
-            Sid: CostMonitoringPolicy
+              Resource:
+                - !Sub 'arn:aws:ce:us-east-1:${AWS::AccountId}:/*' # CE only available in us-east-1, aws partition, see https://docs.aws.amazon.com/general/latest/gr/billing.html
+              Effect: Allow
+              Sid: CostMonitoringPolicy
           - Action:
               - pricing:GetProducts
             Resource:


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description
This PR addresses the deployment issue related to a Cost Explorer policy being deployed in GovCloud region.
The fix is not deploy that specific part of the CostMonitoringAndPricingPolicy.
NB: the name of the policy has been left unchanged since changing it right now doesn't provide much value.

This PR doesn't solve any issues since the fix needs to be addressed at code level also.

## How Has This Been Tested?
- manually in my personal account

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [x] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
