### PR TITLE
Add boto3 script to fetch environment variables for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ infrastructure/cognitolambda/node_modules
 public/*
 /frontend/tsconfig.tsbuildinfo
 .idea/
+.env

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,6 +10,11 @@ export API_BASE_URL=https://[API_ID].execute-api.us-east-2.amazonaws.com/prod  #
 export ENV=dev
 ```
 
+If you have boto3 installed and have set your AWS credentials, you can run this script to fetch the necessary environment variables:
+```bash
+python3 scripts/generate_env.py -n $PCUI_STACK_NAME -r $PCUI_REGION && source .env
+```
+
 If you don't have a virtual environment setup already, you can run from the base dir of the project:
 ```bash
 python3 -m venv venv

--- a/scripts/generate_env.py
+++ b/scripts/generate_env.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import boto3
+import argparse
+from os import path
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-n', '--stack-name', type=str, required=True, help="Name of PCUI stack")
+parser.add_argument('-r', '--region', type=str, required=False, help="Region of PCUI stack if different from AWS_DEFAULT_REGION")
+args = parser.parse_args()
+
+client = boto3.client('cloudformation', region_name=args.region)
+	
+def get_nested_stack_name(logical_id, stack_name=args.stack_name):
+	nested_stack = client.describe_stack_resource(StackName=stack_name, LogicalResourceId=logical_id)
+	return nested_stack['StackResourceDetail']['PhysicalResourceId']
+
+def get_output(stack_name, output_key):
+	stack = client.describe_stacks(StackName=stack_name)['Stacks'][0]
+	return next((o.get("OutputValue") for o in stack.get('Outputs', []) if o.get("OutputKey") == output_key), None)
+
+pc_api_stack_name = get_nested_stack_name('ParallelClusterApi')
+pcui_cognito_stack_name = get_nested_stack_name('Cognito')
+outpath = f"{path.dirname(path.dirname(__file__))}/.env"
+
+with open(outpath, 'w') as file:
+	file.write(f"export API_BASE_URL={get_output(pc_api_stack_name, 'ParallelClusterApiInvokeUrl')}\n")
+	file.write("export ENV=dev\n")
+	file.write(f"export SECRET_ID={get_output(args.stack_name, 'UserPoolClientSecretName')}\n")
+	file.write("export SITE_URL=http://localhost:5001\n")
+	file.write(f"export AUDIENCE={get_output(args.stack_name, 'AppClientId')}\n")
+	file.write(f"export AUTH_PATH={get_output(pcui_cognito_stack_name, 'UserPoolAuthDomain')}")
+	
+print(f"Wrote to {outpath}")


### PR DESCRIPTION
Simplify PCUI development setup with a boto3 script. The script writes to a `.env` file that needs to be sourced.