### PR TITLE
[PCUI]Add PermissionBoundary for every role and IAM prefix for every …

### DIFF
--- a/infrastructure/parallelcluster-ui-cognito.yaml
+++ b/infrastructure/parallelcluster-ui-cognito.yaml
@@ -11,11 +11,11 @@ Parameters:
     Type: String
     Description: 'ARN of the IAM PermissionBoundary policy'
     Default: ''
-    ConstraintDescription: "The value must be a valid ARN in the format: arn:.*:iam:.*:policy/PolicyNameParameter"
+    ConstraintDescription: "The value must be a valid IAM policy ARN in the format: arn:.*:iam:.*:policy/PolicyNameParameter"
     AllowedPattern: "^(arn:.*:iam::.*:policy\\/([a-zA-Z0-9_-]+))|()$"
   IAMRoleAndPolicyPrefix:
     Type: String
-    Description: 'Prefix for IAM roles and policies'
+    Description: 'Prefix for IAM roles and policies name'
     Default: ''
     MaxLength: 10
 
@@ -49,7 +49,9 @@ Resources:
             Action:
               - sts:AssumeRole
       PermissionsBoundary: !If [ HasPermissionBoundary, !Ref PermissionBoundaryARN, !Ref 'AWS::NoValue' ]
-      RoleName: !Sub ${IAMRoleAndPolicyPrefix}SNSRole
+      RoleName: !Sub
+        - ${IAMRoleAndPolicyPrefix}SNSRole-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId']]]] }
       Policies:
         - PolicyName: !Sub ${IAMRoleAndPolicyPrefix}CognitoSNSPolicy
           PolicyDocument:

--- a/infrastructure/parallelcluster-ui-cognito.yaml
+++ b/infrastructure/parallelcluster-ui-cognito.yaml
@@ -7,9 +7,21 @@ Parameters:
     Description: Email address of administrative user setup by default.
     Type: String
     MinLength: 1
+  PermissionBoundaryARN:
+    Type: String
+    Description: 'ARN of the IAM PermissionBoundary policy'
+    Default: ''
+    ConstraintDescription: "The value must be a valid ARN in the format: arn:.*:iam:.*:policy/PolicyNameParameter"
+    AllowedPattern: "^(arn:.*:iam::.*:policy\\/([a-zA-Z0-9_-]+))|()$"
+  IAMRoleAndPolicyPrefix:
+    Type: String
+    Description: 'Prefix for IAM roles and policies'
+    Default: ''
+    MaxLength: 10
 
 Conditions:
   GovCloud: !Equals [!Ref AWS::Region, 'us-gov-west-1']
+  HasPermissionBoundary: !Not [ !Equals [ !Ref PermissionBoundaryARN, '' ] ]
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -36,8 +48,10 @@ Resources:
                 - cognito-idp.amazonaws.com
             Action:
               - sts:AssumeRole
+      PermissionsBoundary: !If [ HasPermissionBoundary, !Ref PermissionBoundaryARN, !Ref 'AWS::NoValue' ]
+      RoleName: !Sub ${IAMRoleAndPolicyPrefix}SNSRole
       Policies:
-        - PolicyName: CognitoSNSPolicy
+        - PolicyName: !Sub ${IAMRoleAndPolicyPrefix}CognitoSNSPolicy
           PolicyDocument:
             Version: 2012-10-17
             Statement:

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -131,7 +131,7 @@ Resources:
         PermissionBoundaryARN: !Ref PermissionBoundaryARN
         IAMRoleAndPolicyPrefix: !Ref IAMRoleAndPolicyPrefix
       TemplateURL: !Sub
-        - 'https://${Bucket}.s3.amazonaws.com/parallelcluster-ui-cognito.yaml'
+        - '${Bucket}/parallelcluster-ui-cognito.yaml'
         - Bucket: !If 
           - HasDefaultInfrastructure
           - PLACEHOLDER

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -39,11 +39,11 @@ Parameters:
     Type: String
     Description: 'ARN of the IAM PermissionBoundary policy'
     Default: ''
-    ConstraintDescription: "The value must be a valid ARN in the format: arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/PolicyNameParameter"
+    ConstraintDescription: "The value must be a valid IAM policy ARN in the format: arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/PolicyNameParameter"
     AllowedPattern: "^(arn:.*:iam::.*:policy\\/([a-zA-Z0-9_-]+))|()$"
   IAMRoleAndPolicyPrefix:
     Type: String
-    Description: 'Prefix for IAM roles and policies'
+    Description: 'Prefix for IAM roles and policies name'
     Default: ''
     MaxLength: 10
 Metadata:
@@ -145,11 +145,8 @@ Resources:
       Parameters:
         PermissionsBoundaryPolicy: !Ref PermissionBoundaryARN
         IAMRoleAndPolicyPrefix: !Ref IAMRoleAndPolicyPrefix
-        ApiDefinitionS3Uri: s3://kkolur-pcapi/ParallelCluster.openapi.yaml
-        #!Sub s3://${AWS::Region}-aws-parallelcluster/parallelcluster/${Version}/api/ParallelCluster.openapi.yaml
-        PoliciesTemplateUri: https://kkolur-pcapi.s3.amazonaws.com/parallelcluster-policies.yaml
-        CreateApiUserRole: True
-        CustomBucket: kkolur-pcapi
+        ApiDefinitionS3Uri: !Sub s3://${AWS::Region}-aws-parallelcluster/parallelcluster/${Version}/api/ParallelCluster.openapi.yaml
+        CreateApiUserRole: False
         EnableIamAdminAccess: True
         ImageBuilderSubnetId: !If
           - UseNonDockerizedPCAPI
@@ -165,8 +162,7 @@ Resources:
             - NonDefaultVpc
             - !Ref ImageBuilderVpcId
             - !Ref AWS::NoValue
-      TemplateURL: https://kkolur-pcapi.s3.amazonaws.com/parallelcluster-api.yaml
-      # !Sub https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.amazonaws.com/parallelcluster/${Version}/api/parallelcluster-api.yaml
+      TemplateURL: !Sub https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.amazonaws.com/parallelcluster/${Version}/api/parallelcluster-api.yaml
       TimeoutInMinutes: 30
 
   ParallelClusterUIFunction:
@@ -378,7 +374,9 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       PermissionsBoundary: !If [HasPermissionBoundary, !Ref PermissionBoundaryARN, !Ref 'AWS::NoValue']
-      RoleName: !Sub ${IAMRoleAndPolicyPrefix}UserPoolClientSecretRole
+      RoleName: !Sub
+        - ${IAMRoleAndPolicyPrefix}UserPoolClientSecretRole-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId']]]] }
       Policies:
         - PolicyName: !Sub ${IAMRoleAndPolicyPrefix}CognitoPermissions
           PolicyDocument:
@@ -419,7 +417,9 @@ Resources:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
         - !Sub arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds
       PermissionsBoundary: !If [HasPermissionBoundary, !Ref PermissionBoundaryARN, !Ref 'AWS::NoValue']
-      RoleName: !Sub ${IAMRoleAndPolicyPrefix}ImageBuilderInstanceRole
+      RoleName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ImageBuilderInstanceRole-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId']]]] }
       AssumeRolePolicyDocument:
         Statement:
           - Action:
@@ -599,7 +599,9 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       PermissionsBoundary: !If [HasPermissionBoundary, !Ref PermissionBoundaryARN, !Ref 'AWS::NoValue']
-      RoleName: !Sub ${IAMRoleAndPolicyPrefix}EcrImageDeletionLambdaRole
+      RoleName: !Sub
+        - ${IAMRoleAndPolicyPrefix}EcrImageDeletionLambdaRole-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId']]]] }
       Policies:
         - PolicyName: !Sub ${IAMRoleAndPolicyPrefix}LoggingPolicy
           PolicyDocument:
@@ -657,7 +659,9 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
       PermissionsBoundary: !If [HasPermissionBoundary, !Ref PermissionBoundaryARN, !Ref 'AWS::NoValue']
-      RoleName: !Sub ${IAMRoleAndPolicyPrefix}ParallelClusterUIUserRole
+      RoleName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterUIUserRole-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId']]]] }
       ManagedPolicyArns:
         # Required for Lambda logging and XRay
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSXRayDaemonWriteAccess

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -35,7 +35,17 @@ Parameters:
     Description: (Optional) S3 bucket where CloudFormation files are stored. Change this parameter only when testing changes made to the infrastructure itself.
     Type: String
     Default: ''
-
+  PermissionBoundaryARN:
+    Type: String
+    Description: 'ARN of the IAM PermissionBoundary policy'
+    Default: ''
+    ConstraintDescription: "The value must be a valid ARN in the format: arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/PolicyNameParameter"
+    AllowedPattern: "^(arn:.*:iam::.*:policy\\/([a-zA-Z0-9_-]+))|()$"
+  IAMRoleAndPolicyPrefix:
+    Type: String
+    Description: 'Prefix for IAM roles and policies'
+    Default: ''
+    MaxLength: 10
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -102,6 +112,7 @@ Conditions:
       - !Equals ['4', !Select [ 1, !Split ['.', !Ref Version] ] ]
       - !Equals ['5', !Select [ 1, !Split ['.', !Ref Version] ] ]
   InGovCloud: !Equals ['us-gov-west-1', !Ref "AWS::Region"]
+  HasPermissionBoundary: !Not [!Equals [!Ref PermissionBoundaryARN, '']]
 
 Mappings:
   ParallelClusterUI:
@@ -117,8 +128,10 @@ Resources:
     Properties:
       Parameters:
         AdminUserEmail: !Ref AdminUserEmail
-      TemplateURL: !Sub 
-        - '${Bucket}/parallelcluster-ui-cognito.yaml'
+        PermissionBoundaryARN: !Ref PermissionBoundaryARN
+        IAMRoleAndPolicyPrefix: !Ref IAMRoleAndPolicyPrefix
+      TemplateURL: !Sub
+        - 'https://${Bucket}.s3.amazonaws.com/parallelcluster-ui-cognito.yaml'
         - Bucket: !If 
           - HasDefaultInfrastructure
           - PLACEHOLDER
@@ -130,8 +143,13 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       Parameters:
-        ApiDefinitionS3Uri: !Sub s3://${AWS::Region}-aws-parallelcluster/parallelcluster/${Version}/api/ParallelCluster.openapi.yaml
-        CreateApiUserRole: False
+        PermissionsBoundaryPolicy: !Ref PermissionBoundaryARN
+        IAMRoleAndPolicyPrefix: !Ref IAMRoleAndPolicyPrefix
+        ApiDefinitionS3Uri: s3://kkolur-pcapi/ParallelCluster.openapi.yaml
+        #!Sub s3://${AWS::Region}-aws-parallelcluster/parallelcluster/${Version}/api/ParallelCluster.openapi.yaml
+        PoliciesTemplateUri: https://kkolur-pcapi.s3.amazonaws.com/parallelcluster-policies.yaml
+        CreateApiUserRole: True
+        CustomBucket: kkolur-pcapi
         EnableIamAdminAccess: True
         ImageBuilderSubnetId: !If
           - UseNonDockerizedPCAPI
@@ -147,7 +165,8 @@ Resources:
             - NonDefaultVpc
             - !Ref ImageBuilderVpcId
             - !Ref AWS::NoValue
-      TemplateURL: !Sub https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.amazonaws.com/parallelcluster/${Version}/api/parallelcluster-api.yaml
+      TemplateURL: https://kkolur-pcapi.s3.amazonaws.com/parallelcluster-api.yaml
+      # !Sub https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.amazonaws.com/parallelcluster/${Version}/api/parallelcluster-api.yaml
       TimeoutInMinutes: 30
 
   ParallelClusterUIFunction:
@@ -358,8 +377,10 @@ Resources:
               Service: lambda.amazonaws.com
             Action:
               - 'sts:AssumeRole'
+      PermissionsBoundary: !If [HasPermissionBoundary, !Ref PermissionBoundaryARN, !Ref 'AWS::NoValue']
+      RoleName: !Sub ${IAMRoleAndPolicyPrefix}UserPoolClientSecretRole
       Policies:
-        - PolicyName: CognitoPermissions
+        - PolicyName: !Sub ${IAMRoleAndPolicyPrefix}CognitoPermissions
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -370,7 +391,7 @@ Resources:
                   - !Sub
                     - arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${UserPoolId}
                     - { UserPoolId: !If [UseExistingCognito, !Ref UserPoolId, !GetAtt [ Cognito, Outputs.UserPoolId ]]}
-        - PolicyName: SecretsManagerPermissions
+        - PolicyName: !Sub ${IAMRoleAndPolicyPrefix}SecretsManagerPermissions
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -397,6 +418,8 @@ Resources:
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
         - !Sub arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds
+      PermissionsBoundary: !If [HasPermissionBoundary, !Ref PermissionBoundaryARN, !Ref 'AWS::NoValue']
+      RoleName: !Sub ${IAMRoleAndPolicyPrefix}ImageBuilderInstanceRole
       AssumeRolePolicyDocument:
         Statement:
           - Action:
@@ -575,8 +598,10 @@ Resources:
               Service: lambda.amazonaws.com
             Action:
               - 'sts:AssumeRole'
+      PermissionsBoundary: !If [HasPermissionBoundary, !Ref PermissionBoundaryARN, !Ref 'AWS::NoValue']
+      RoleName: !Sub ${IAMRoleAndPolicyPrefix}EcrImageDeletionLambdaRole
       Policies:
-        - PolicyName: LoggingPolicy
+        - PolicyName: !Sub ${IAMRoleAndPolicyPrefix}LoggingPolicy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -585,7 +610,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub arn:${AWS::Partition}:logs:*:*:*
-        - PolicyName: BatchDeletePolicy
+        - PolicyName: !Sub ${IAMRoleAndPolicyPrefix}BatchDeletePolicy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -631,6 +656,8 @@ Resources:
             Action: sts:AssumeRole
             Principal:
               Service: lambda.amazonaws.com
+      PermissionsBoundary: !If [HasPermissionBoundary, !Ref PermissionBoundaryARN, !Ref 'AWS::NoValue']
+      RoleName: !Sub ${IAMRoleAndPolicyPrefix}ParallelClusterUIUserRole
       ManagedPolicyArns:
         # Required for Lambda logging and XRay
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSXRayDaemonWriteAccess


### PR DESCRIPTION
…role and policy.

<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

<!-- Summary of what this PR introduces and possibly why -->
[PCUI]Add PermissionBoundary for every role and IAM prefix for every role and policy.

## Changes

<!-- List of relevant changes introduced -->

## How Has This Been Tested?

<!-- The tests you ran to verify your changes -->

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
