### PR TITLE
Remove obselete ImageBuilder parameters

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -23,14 +23,6 @@ Parameters:
     Description: Version of AWS ParallelCluster to deploy
     Type: String
     Default: 3.6.0
-  ImageBuilderVpcId:
-    Description: (Optional) Select the VPC to use for building the container images. If not selected, default VPC will be used.
-    Type: String
-    Default: ''
-  ImageBuilderSubnetId:
-    Description: (Optional) Select the subnet to use for building the container images (public subnets only). If not selected, Subnet in the default VPC will be used.
-    Type: String
-    Default: ''
   InfrastructureBucket:
     Description: (Optional) S3 bucket where CloudFormation files are stored. Change this parameter only when testing changes made to the infrastructure itself.
     Type: String
@@ -58,11 +50,6 @@ Metadata:
         Parameters:
           - Version
       - Label:
-          default: (Optional) ImageBuilder Custom VPC
-        Parameters:
-          - ImageBuilderVpcId
-          - ImageBuilderSubnetId
-      - Label:
           default: (Debugging only) Infrastructure S3 Bucket
         Parameters:
           - InfrastructureBucket
@@ -78,10 +65,6 @@ Metadata:
         default: SNSRole ARN from a previously deployed PCUI
 
 Conditions:
-  NonDefaultVpc:
-    Fn::And:
-      - !Not [!Equals [!Ref ImageBuilderVpcId, ""]]
-      - !Not [!Equals [!Ref ImageBuilderSubnetId, ""]]
   HasDefaultInfrastructure: !Equals [!Ref InfrastructureBucket, '']
   UseExistingCognito:
     !And
@@ -90,17 +73,6 @@ Conditions:
       - !Not [!Equals [!Ref SNSRole, ""]]
   UseNewCognito:
     !Not [ Condition: UseExistingCognito]
-  UseNonDockerizedPCAPI:
-    !Not [ Condition: UseDockerizedPCAPI]
-  UseDockerizedPCAPI: !And
-    - !Equals ['3', !Select [ 0, !Split ['.', !Ref Version] ] ] # Check PC version major is 3 and PC version minor is 0-5
-    - !Or
-      - !Equals ['0', !Select [ 1, !Split ['.', !Ref Version] ] ]
-      - !Equals ['1', !Select [ 1, !Split ['.', !Ref Version] ] ]
-      - !Equals ['2', !Select [ 1, !Split ['.', !Ref Version] ] ]
-      - !Equals ['3', !Select [ 1, !Split ['.', !Ref Version] ] ]
-      - !Equals ['4', !Select [ 1, !Split ['.', !Ref Version] ] ]
-      - !Equals ['5', !Select [ 1, !Split ['.', !Ref Version] ] ]
   InGovCloud: !Equals ['us-gov-west-1', !Ref "AWS::Region"]
 
 Mappings:
@@ -133,20 +105,6 @@ Resources:
         ApiDefinitionS3Uri: !Sub s3://${AWS::Region}-aws-parallelcluster/parallelcluster/${Version}/api/ParallelCluster.openapi.yaml
         CreateApiUserRole: False
         EnableIamAdminAccess: True
-        ImageBuilderSubnetId: !If
-          - UseNonDockerizedPCAPI
-          - !Ref AWS::NoValue
-          - Fn::If:
-              - NonDefaultVpc
-              - !Ref ImageBuilderSubnetId
-              - !Ref AWS::NoValue
-        ImageBuilderVpcId: !If
-          - UseNonDockerizedPCAPI
-          - !Ref AWS::NoValue
-          - Fn::If:
-            - NonDefaultVpc
-            - !Ref ImageBuilderVpcId
-            - !Ref AWS::NoValue
       TemplateURL: !Sub https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.amazonaws.com/parallelcluster/${Version}/api/parallelcluster-api.yaml
       TimeoutInMinutes: 30
 
@@ -415,13 +373,6 @@ Resources:
       Roles:
         - !Ref ImageBuilderInstanceRole
 
-  InfrastructureConfigurationSecurityGroup:
-    Condition: NonDefaultVpc
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      VpcId: !Ref ImageBuilderVpcId
-      GroupDescription: Parallel cluster image builder security group
-
   InfrastructureConfiguration:
     Type: AWS::ImageBuilder::InfrastructureConfiguration
     Properties:
@@ -430,16 +381,6 @@ Resources:
         - { Version: !Join ['_', !Split ['.', !FindInMap [ParallelClusterUI, Constants, Version]]], StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
       InstanceProfileName: !Ref ImageBuilderInstanceProfile
       TerminateInstanceOnFailure: true
-      SubnetId:
-        Fn::If:
-          - NonDefaultVpc
-          - !Ref ImageBuilderSubnetId
-          - !Ref AWS::NoValue
-      SecurityGroupIds:
-        Fn::If:
-          - NonDefaultVpc
-          - [!Ref InfrastructureConfigurationSecurityGroup]
-          - !Ref AWS::NoValue
       InstanceMetadataOptions:
         HttpTokens: required
 


### PR DESCRIPTION
## Description

ImageBuilder parameters are no longer valid in the PC API as of this [commit](https://github.com/aws/aws-parallelcluster/commit/716d3f65b7b5b0ea2a4a6394369987696937d333). PCUI stacks would fail to create if a user tried using these parameters for PCUI.

## How Has This Been Tested?

Successfully created a stack using updated config