### PR TITLE
Add support for ParallelCluster 3.7.0

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,7 +52,9 @@ export AUDIENCE=<the value of the Client ID noted in the previous step>
 export AUTH_PATH=<the UserPoolAuthDomain output of the ParallelClusterCognito nested stack>
 ```
 
-Set `DISABLE_AUTH=False` in `api/utils.py` to facilitate live reloading.
+Set `DISABLE_AUTH=True` in `api/utils.py` to facilitate live reloading.
+Notice that cluster creation (both concrete and dryrun) is expected to fail
+when authentication is disabled.
 
 Start the API backend by running:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,6 +6,7 @@ To run AWS ParallelCluster UI locally, start by setting the following environmen
 export AWS_ACCESS_KEY_ID=[...]
 export AWS_SECRET_ACCESS_KEY=[...]
 export AWS_DEFAULT_REGION=us-east-2
+export API_VERSION="3.7.0"
 export API_BASE_URL=https://[API_ID].execute-api.us-east-2.amazonaws.com/prod  # get this from ParallelClusterApi stack outputs
 export ENV=dev
 ```

--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -498,6 +498,13 @@ def get_aws_config():
     except:
         pass
 
+    file_caches = []
+    try:
+        file_caches = list(filter(lambda file_cache: (file_cache["Lifecycle"] == "AVAILABLE"),
+                                  fsx.describe_file_caches()["FileCaches"]))
+    except:
+        pass
+
     efs_filesystems = []
     try:
         efs_filesystems = efs.describe_file_systems()["FileSystems"]
@@ -518,6 +525,7 @@ def get_aws_config():
         "region": region,
         "fsx_filesystems": fsx_filesystems,
         "fsx_volumes": fsx_volumes,
+        "file_caches": file_caches,
         "efs_filesystems": efs_filesystems,
         "efa_instance_types": efa_instance_types,
     }

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -780,6 +780,7 @@
         "storageTypes": "Storage types",
         "storageTypesPlaceholder": "Select file system types",
         "volumePlaceholder": "Select a volume",
+        "cachePlaceholder": "Select a cache",
         "addStorage": "Add storage",
         "removeStorage": "Remove storage",
         "sourceTitle": "Source {{index}} - {{name}}"
@@ -820,7 +821,8 @@
         "existing": {
           "fsxLustre": "FSx Lustre Filesystem",
           "fsxOpenZfs": "FSx OpenZFS volume",
-          "fsxOnTap": "FSx NetApp ONTAP volume"
+          "fsxOnTap": "FSx NetApp ONTAP volume",
+          "fileCache": "Amazon File Cache"
         },
         "capacity": {
           "label": "Storage capacity (GB)",

--- a/frontend/src/__tests__/storageCreationValidation.test.tsx
+++ b/frontend/src/__tests__/storageCreationValidation.test.tsx
@@ -10,8 +10,11 @@ describe('Given a function to determine whether we can create a storage of a giv
     })
   })
   describe('when the storage type does not support creation', () => {
-    it('should not allow the creation of a new storage', () => {
+    it('should not allow the creation of a new storage with type FsxOntap', () => {
       expect(canCreateStorage('FsxOntap', [], [])).toBeFalsy()
+    })
+    it('should not allow the creation of a new storage with type FileCache', () => {
+      expect(canCreateStorage('FileCache', [], [])).toBeFalsy()
     })
   })
   describe('when the attached storages are not available', () => {
@@ -60,8 +63,13 @@ describe('Given a function to determine whether we can attach an existing storag
     })
   })
   describe('when the attached storages are not available', () => {
-    it('should allow the attachment of an existing storage', () => {
+    it('should allow the attachment of an existing storage with type Efs', () => {
       expect(canAttachExistingStorage('Efs', null as any, [])).toBeTruthy()
+    })
+    it('should allow the attachment of an existing storage with type FileCache', () => {
+      expect(
+        canAttachExistingStorage('FileCache', null as any, []),
+      ).toBeTruthy()
     })
   })
   describe('when the ui storages details are not available', () => {

--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -91,9 +91,9 @@ describe('given a feature flags provider and a list of rules', () => {
     })
   })
 
-  describe('when the version is above and 3.6.0', () => {
+  describe('when the version is between 3.6.0 and 3.7.0', () => {
     it('should return the list of available features', async () => {
-      const features = await subject('3.6.0', region)
+      const features = await subject('3.6.1', region)
       expect(features).toEqual<AvailableFeature[]>([
         'multiuser_cluster',
         'fsx_ontap',
@@ -113,6 +113,36 @@ describe('given a feature flags provider and a list of rules', () => {
         'on_node_updated',
         'rhel8',
         'new_resources_limits',
+      ])
+    })
+  })
+
+  describe('when the version is above and 3.7.0', () => {
+    it('should return the list of available features', async () => {
+      const features = await subject('3.7.0', region)
+      expect(features).toEqual<AvailableFeature[]>([
+        'multiuser_cluster',
+        'fsx_ontap',
+        'fsx_openzsf',
+        'lustre_persistent2',
+        'memory_based_scheduling',
+        'slurm_queue_update_strategy',
+        'ebs_deletion_policy',
+        'cost_monitoring',
+        'slurm_accounting',
+        'queues_multiple_instance_types',
+        'dynamic_fs_mount',
+        'efs_deletion_policy',
+        'lustre_deletion_policy',
+        'imds_support',
+        'multi_az',
+        'on_node_updated',
+        'rhel8',
+        'new_resources_limits',
+        'ubuntu22',
+        'login_nodes',
+        'amazon_file_cache',
+        'job_exclusive_allocation',
       ])
     })
   })

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -32,6 +32,12 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
   ],
   '3.4.0': ['multi_az', 'on_node_updated'],
   '3.6.0': ['rhel8', 'new_resources_limits'],
+  '3.7.0': [
+    'ubuntu22',
+    'login_nodes',
+    'amazon_file_cache',
+    'job_exclusive_allocation',
+  ],
 }
 
 const featureToUnsupportedRegionsMap: Partial<

--- a/frontend/src/feature-flags/types.ts
+++ b/frontend/src/feature-flags/types.ts
@@ -8,6 +8,7 @@
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
+// We must track here the features that may be under feature flagging in the wizard.
 export type AvailableFeature =
   | 'fsx_ontap'
   | 'fsx_openzsf'
@@ -27,3 +28,7 @@ export type AvailableFeature =
   | 'rhel8'
   | 'cost_monitoring'
   | 'new_resources_limits'
+  | 'ubuntu22'
+  | 'login_nodes'
+  | 'amazon_file_cache'
+  | 'job_exclusive_allocation'

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -623,10 +623,12 @@ function LoadAwsConfig(region?: string, callback?: Callback) {
     .then((response: any) => {
       if (response.status === 200) {
         console.log('aws', response.data)
-        const {fsx_filesystems, fsx_volumes, ...data} = response.data
+        const {fsx_filesystems, fsx_volumes, file_caches, ...data} =
+          response.data
         setState(['aws'], {
           fsxFilesystems: extractFsxFilesystems(fsx_filesystems),
           fsxVolumes: extractFsxVolumes(fsx_volumes),
+          fileCaches: extractFileCaches(file_caches),
           ...data,
         })
         GetInstanceTypes(region)
@@ -658,6 +660,23 @@ const extractFsxFilesystems = (filesystems: any) => {
     lustre: mappedFilesystems.filter((fs: any) => fs.type === 'LUSTRE'),
     zfs: mappedFilesystems.filter((fs: any) => fs.type === 'OPENZFS'),
     ontap: mappedFilesystems.filter((fs: any) => fs.type === 'ONTAP'),
+  }
+}
+
+const extractFileCaches = (file_caches: any) => {
+  const mappedFileCaches = file_caches
+    .map((fc: any) => ({
+      id: fc.FileCacheId,
+      name: nameFromFilesystem(fc),
+      type: fc.FileCacheType,
+    }))
+    .map((fc: any) => ({
+      ...fc,
+      displayName: `${fc.id} ${fc.name}`,
+    }))
+
+  return {
+    lustre: mappedFileCaches.filter((fc: any) => fc.type === 'LUSTRE'),
   }
 }
 

--- a/frontend/src/old-pages/Configure/Storage.types.ts
+++ b/frontend/src/old-pages/Configure/Storage.types.ts
@@ -19,6 +19,11 @@ export const STORAGE_TYPE_PROPS = {
     maxToCreate: 0,
     maxExistingToAttach: 20,
   },
+  FileCache: {
+    mountFilesystem: false,
+    maxToCreate: 0,
+    maxExistingToAttach: 20,
+  },
   Efs: {
     mountFilesystem: true,
     maxToCreate: 1,
@@ -105,6 +110,10 @@ export interface FsxOpenZfsSettings {
   VolumeId: string
 }
 
+export interface FileCacheSettings {
+  FileCacheId: string
+}
+
 interface CommonSharedStorageDetails {
   Name: string
   MountDir: string
@@ -135,12 +144,18 @@ export interface FsxOpenZfsStorage extends CommonSharedStorageDetails {
   FsxOpenZfsSettings?: FsxOpenZfsSettings
 }
 
+export interface FileCacheStorage extends CommonSharedStorageDetails {
+  StorageType: 'FileCache'
+  FileCacheSettings?: FileCacheSettings
+}
+
 export type Storage =
   | EbsStorage
   | EfsStorage
   | FsxLustreStorage
   | FsxOnTapStorage
   | FsxOpenZfsStorage
+  | FileCacheStorage
 
 export type Storages = Storage[]
 

--- a/frontend/src/old-pages/Configure/Storage/storage.mapper.ts
+++ b/frontend/src/old-pages/Configure/Storage/storage.mapper.ts
@@ -22,6 +22,8 @@ function mapStorageToUiSetting(storage: Storage): UIStorageSettings[0] {
       return {useExisting: !!storage.FsxOntapSettings?.VolumeId}
     case 'FsxOpenZfs':
       return {useExisting: !!storage.FsxOpenZfsSettings?.VolumeId}
+    case 'FileCache':
+      return {useExisting: !!storage.FileCacheSettings?.FileCacheId}
   }
 }
 
@@ -39,6 +41,8 @@ export function mapStorageToExternalFileSystem(
       return storage.FsxOntapSettings?.VolumeId
     case 'FsxOpenZfs':
       return storage.FsxOpenZfsSettings?.VolumeId
+    case 'FileCache':
+      return storage.FileCacheSettings?.FileCacheId
     default:
       return undefined
   }

--- a/infrastructure/environments/demo-cfn-update-args.yaml
+++ b/infrastructure/environments/demo-cfn-update-args.yaml
@@ -1,7 +1,7 @@
 TemplateURL: BUCKET_URL_PLACEHOLDER/parallelcluster-ui.yaml
 Parameters:
   - ParameterKey: Version
-    ParameterValue: 3.6.0
+    ParameterValue: 3.7.0
   - ParameterKey: InfrastructureBucket
     ParameterValue: BUCKET_URL_PLACEHOLDER
   - ParameterKey: UserPoolId

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -22,7 +22,7 @@ Parameters:
   Version:
     Description: Version of AWS ParallelCluster to deploy
     Type: String
-    Default: 3.6.0
+    Default: 3.7.0
   ImageBuilderVpcId:
     Description: (Optional) Select the VPC to use for building the container images. If not selected, default VPC will be used.
     Type: String


### PR DESCRIPTION
## Description

Add support for ParallelCluster 3.7.0

## Changes
1. pcluster version bumped to 3.7.0 in CloudFormation template and demo env.
2. 3.7.0 features added to feature flags provider + new unit tests covering it.
3. Add Amazon File Cache as a supported shared storage within the Wizard (both frontend and backend changes). This change was considered out of scope at first, but discovered that it was actually easier to introduce it than modifying the inner logic to silently avoid it. Moreover we are providing feature parity for File Cache that is certainly valuable for our users.
4. Documentation: added to DEVELOPMENT.md some valuable information about development process learned during this iteration.

### Known Limitations
1. With this change we are not achieving the full feature parity with ParallelCluster 3.7.0. In fact we are missing in the Wizard: support for Ubuntu 22.04 and support for Memory Based Scheduling with Flexible Instance Types. Nevertheless the lack of this feature parity is not a blocker for the wizard.
2. Unit tests for the backend on API GET:/manager/get_aws_configuration have been considered out of scope because they must be written from the ground up and we will cover in a follow up PR.

## How Has This Been Tested?
1. Unit tests on the backend
3. Unit tests on the frontend
4. Manual test: created a cluster using a cluster config file exercising all the config-impactful features introduced in ParallelCluster 3.7.0: Ubuntu22.04, Login Nodes, Memory Based Scheduling, Amazon File Cache.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
