### PR TITLE
[Frontend] Add support for Memory Based Scheduling with Multiple Instance Types in ParallelCluster 3.7.0+.

### DIFF
--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -143,6 +143,7 @@ describe('given a feature flags provider and a list of rules', () => {
         'login_nodes',
         'amazon_file_cache',
         'job_exclusive_allocation',
+        'memory_based_scheduling_with_multiple_instance_types',
       ])
     })
   })

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -37,6 +37,7 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
     'login_nodes',
     'amazon_file_cache',
     'job_exclusive_allocation',
+    'memory_based_scheduling_with_multiple_instance_types',
   ],
 }
 

--- a/frontend/src/feature-flags/types.ts
+++ b/frontend/src/feature-flags/types.ts
@@ -32,3 +32,4 @@ export type AvailableFeature =
   | 'login_nodes'
   | 'amazon_file_cache'
   | 'job_exclusive_allocation'
+  | 'memory_based_scheduling_with_multiple_instance_types'

--- a/frontend/src/old-pages/Configure/Queues/__tests__/hasMultipleInstanceTypes.test.tsx
+++ b/frontend/src/old-pages/Configure/Queues/__tests__/hasMultipleInstanceTypes.test.tsx
@@ -13,7 +13,7 @@
 import {Queue} from '../queues.types'
 import {hasMultipleInstanceTypes} from '../SlurmMemorySettings'
 
-describe('Given a function to validate if mutiple instance types have been selected', () => {
+describe('Given a function to validate if multiple instance types have been selected', () => {
   describe('if at least a resource of a queue has multiple instance types selected', () => {
     const queues: Queue[] = [
       {


### PR DESCRIPTION
## Changes

Add support for Memory Based Scheduling with Multiple Instance Types in ParallelCluster 3.7.0+.

**Known Limitations**
The wizard does not remove the schedulable memory property in the resulting cluster config when mem based scheduling is enabled and then disabled. This is not a blocking bug because the resulting cluster config is valid, but simply an unexpected behaviour that we may decide to address in another iteration.

## How Has This Been Tested?

1. Unit tests
2. Manual verification with Pcluster 3.7.0: mem based scheduling can be toggled and preserved with input cluster config when using multiple instance types in 3.7.0. Verified with dryrun creation.
3. Manual verification with Pcluster 3.6.0: feature flagging is working as expected prohibiting the use of mem based scheduling with multiple instance types. Verified with dryrun creation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
