### PR TITLE
[Frontend] Avoid surfacing errors in the UI that are caused by failures in interacting with Cost Explorer, regardless the failure root cause.

### DIFF
--- a/frontend/src/__tests__/GetCostMonitoringStatus.test.ts
+++ b/frontend/src/__tests__/GetCostMonitoringStatus.test.ts
@@ -9,13 +9,14 @@
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {GetCostMonitoringStatus} from '../model'
+import {GetCostMonitoringStatus, notify} from '../model'
 import {
   CostMonitoringStatus,
   CostMonitoringStatusResponse,
 } from '../old-pages/Clusters/Costs/costs.types'
 
 const mockGet = jest.fn()
+const mockNotify = jest.fn()
 
 jest.mock('axios', () => ({
   create: () => ({
@@ -63,6 +64,19 @@ describe('given a GetCostMonitoringStatus command', () => {
       }
 
       mockGet.mockRejectedValueOnce(mockError)
+    })
+
+    it('does not surface the error', async () => {
+      jest.mock('../model', () => {
+        return {
+          notify: (...args: unknown[]) => mockNotify(...args),
+        }
+      })
+      try {
+        await GetCostMonitoringStatus()
+      } catch (e) {
+        expect(mockNotify).toHaveBeenCalledTimes(0)
+      }
     })
 
     it('should re-throw the error', async () => {

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -912,7 +912,7 @@ async function GetCostMonitoringStatus(): Promise<CostMonitoringStatus> {
     return data?.active || false
   } catch (error) {
     if ((error as AxiosError).response) {
-      notify(`Error: ${(error as any).response.data.message}`, 'error')
+      console.log(`Error: ${(error as any).response.data.message}`)
     }
     throw error
   }


### PR DESCRIPTION
Avoid surfacing errors in the UI that are caused by failures in interacting with Cost Explorer, regardless the failure root cause.

## Changes

1. Replaced the error notification at the UI level with a console log
2. Added unit tests to cover the scenario

## How Has This Been Tested?

1. Unit tests
2. Manual test verifying that errors are not displayed in the UI when access to Cost Explorer is forbidden by a permissions boundary
3. Manual test verifying that the cost monitoring feature behaves as expected in the UI when the permission boundary is removed and the access to Cost Explorer has recovered.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
