### PR TITLE
[Ops] Add possibility to specify the infrastructure bucket name

### DIFF
--- a/infrastructure/environments/demo-variables.sh
+++ b/infrastructure/environments/demo-variables.sh
@@ -1,3 +1,6 @@
 REGION=eu-west-1
 STACK_NAME=parallelcluster-ui-demo
 INFRA_BUCKET_STACK_NAME=pcluster-manager-github
+# If the bucket used by the environment is not managed by a dedicated CloudFormation stack,
+# specify the bucket name as follows and comment out 'INFRA_BUCKET_STACK_NAME'.
+# INFRA_BUCKET_NAME=pcluster-ui-bucket

--- a/infrastructure/update-environment-infra.sh
+++ b/infrastructure/update-environment-infra.sh
@@ -23,13 +23,16 @@ FILES=(parallelcluster-ui-cognito.yaml parallelcluster-ui.yaml)
 ENVIRONMENT=$1
 . "${SCRIPT_DIR}/environments/${ENVIRONMENT}-variables.sh"
 
-BUCKET=$(aws cloudformation describe-stack-resources \
-  --stack-name "${INFRA_BUCKET_STACK_NAME}" \
-  --logical-resource-id InfrastructureBucket \
-  --region "${REGION}" \
-  --output json \
-  --query 'StackResources[0].PhysicalResourceId'\
-  | tr -d '"' )
+if [[ -n $INFRA_BUCKET_NAME ]]; then
+  BUCKET=$INFRA_BUCKET_NAME
+else
+  BUCKET=$(aws cloudformation describe-stack-resources \
+    --stack-name "${INFRA_BUCKET_STACK_NAME}" \
+    --logical-resource-id InfrastructureBucket \
+    --output json \
+    --query 'StackResources[0].PhysicalResourceId'\
+    | tr -d '"' )
+fi
 
 # The yaml files describing the infrastructure are uploaded to a private S3 bucket
 # and then used to update the CloudFormation stack, where the same bucket is passed as parameters.


### PR DESCRIPTION
## Description
Add possibility to specify the infrastructure bucket name directly, rather than referencing the CloudFormation stack that deploys it.

## How Has This Been Tested?

Used to update personal environment, where the infra bucket stack does not exists, but only the bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
