### PR TITLE
Add default cluster user for Ubuntu22.

### DIFF
--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -66,6 +66,7 @@ function clusterDefaultUser(cluster: any) {
   // @ts-expect-error TS(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   return {
     alinux2: 'ec2-user',
+    ubuntu2204: 'ubuntu',
     ubuntu2004: 'ubuntu',
     ubuntu1804: 'ubuntu',
     centos7: 'centos',


### PR DESCRIPTION
## Changes

Add default cluster user for Ubuntu22.
Without this change, the default cluster user for Ubuntu22 falls back to 'ec2-user' making part of the UI to fail (Job Status panel).

## How Has This Been Tested?

Verified that with the proposed fix, the job status panle does not return any error and the subvmitted request to the backend has the expected cluster user.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
