### PR TITLE
[Ops] Build and Release Image: use ecr-public command when targeting ECR public endpoint and standard ecr otherwise.

### DIFF
--- a/scripts/build_and_release_image.sh
+++ b/scripts/build_and_release_image.sh
@@ -52,7 +52,8 @@ elif ! [[ $TAG =~ [0-9]{4}\.(0[1-9]|1[0-2])\.[0-9]+ ]]; then
 fi
 
 echo "[INFO] Logging in ${ECR_ENDPOINT}"
-aws ecr-public get-login-password --region "$ECR_REGION" | docker login --username AWS --password-stdin "${ECR_ENDPOINT}"
+[[ $ECR_ENDPOINT =~ ^public.ecr.aws/.*$ ]] && ECR_COMMAND=ecr-public || ECR_COMMAND=ecr
+aws $ECR_COMMAND get-login-password --region "$ECR_REGION" | docker login --username AWS --password-stdin "${ECR_ENDPOINT}"
 
 echo "[INFO] Building frontend"
 


### PR DESCRIPTION
## Changes

Build and Release Image: use ecr-public command when targeting ECR public endpoint and standard ecr otherwise.
With this change we can reuse the same script used to deploy PCUI official image to deploy a test image in our personal account.

## How Has This Been Tested?

1. Used to deploy PCUI image in personal account
2. Verified that the variable ECR_COMMAND is populated as expected when targeting public ECR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
