### PR TITLE
[Infrastructure] Add fsx:DescribeFileCaches to ParallelClusterUIUserRole

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -731,9 +731,11 @@ Resources:
           - Action:
               - fsx:DescribeFileSystems
               - fsx:DescribeVolumes
+              - fsx:DescribeFileCaches
             Resource:
               - !Sub arn:${AWS::Partition}:fsx:*:${AWS::AccountId}:volume/*
               - !Sub arn:${AWS::Partition}:fsx:*:${AWS::AccountId}:file-system/*
+              - !Sub arn:${AWS::Partition}:fsx:*:${AWS::AccountId}:file-cache/*
             Effect: Allow
             Sid: FsxPolicy
 


### PR DESCRIPTION
## Description
Add fsx:DescribeFileCaches to ParallelClusterUIUserRole so that the wizard is able to list existing File Caches.
<!-- List of relevant changes introduced -->

## How Has This Been Tested?

Verified in personal environment that adding such policy allows the wizard to list existing File Caches.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
