### PR TITLE
[Frontend] Fix label/placeholder used by the Wizard for existing EBS volumes

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -891,7 +891,10 @@
         }
       },
       "Ebs": {
-        "existing": "EBS ID",
+        "existing": {
+          "label": "EBS ID",
+          "placeholder": "i.e., vol-1234"
+        },
         "volumeType": {
           "label": "Volume type",
           "placeholder": "Default ({{defaultVolumeType}})"

--- a/frontend/src/old-pages/Configure/Storage.tsx
+++ b/frontend/src/old-pages/Configure/Storage.tsx
@@ -1048,12 +1048,12 @@ function StorageInstance({index}: any) {
               {
                 Ebs: (
                   <FormField
-                    label={t('wizard.storage.Ebs.existing')}
+                    label={t('wizard.storage.Ebs.existing.label')}
                     errorText={existingPathError}
                   >
                     <Input
                       placeholder={t(
-                        'wizard.storage.instance.useExisting.placeholder',
+                        'wizard.storage.Ebs.existing.placeholder',
                       )}
                       value={existingId}
                       onChange={({detail}) => {


### PR DESCRIPTION
## Description
Fix label/placeholder used by the Wizard for existing EBS volumes.

Before this change the wizard showed the placeholder "i.e., fsx-1234 or efs-1234" as hint for existing EBS volumes, whereas it should rather be "i.e., vol-1234".

## How Has This Been Tested?

1. Tested in personal environment that the wizard shows the expected label and placeholder
2. Verified with git-grep that there is no occurrence of the local string `wizard.storage.Ebs.existing`., which has been removed in this change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
