### PR TITLE
[Infrastructure] Reduce ID and Access Token validity from 10 to 5 minutes.

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -253,8 +253,8 @@ Resources:
       UserPoolId: !If [ UseExistingCognito, !Ref UserPoolId, !GetAtt [ Cognito, Outputs.UserPoolId ]]
       PreventUserExistenceErrors: ENABLED
       RefreshTokenValidity: 7
-      AccessTokenValidity: 10
-      IdTokenValidity: 10
+      AccessTokenValidity: 5
+      IdTokenValidity: 5
       TokenValidityUnits:
         AccessToken: "minutes"
         IdToken: "minutes"


### PR DESCRIPTION
## Changes

Reduce ID and Access Token validity from 10 to 5 minutes.
This is a best practice to improve the security posture of the product as it reduces the operability time of a potential malicious token.

## How Has This Been Tested?

[ONGOING] Deployed in test environment and verified that a user session works as expected for more than 5 minutes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
