### PR TITLE
[Infrastructure] Add support for permissions boundary and IAM prefixes

### DIFF
--- a/infrastructure/parallelcluster-ui-cognito.yaml
+++ b/infrastructure/parallelcluster-ui-cognito.yaml
@@ -7,9 +7,15 @@ Parameters:
     Description: Email address of administrative user setup by default.
     Type: String
     MinLength: 1
+  PermissionsBoundaryPolicy:
+    Type: String
+    Description: 'ARN of the IAM policy to use as permissions boundary for every IAM role'
+    Default: ''
+    AllowedPattern: "^(arn:.*:iam::.*:policy\\/([a-zA-Z0-9_-]+))|()$"
 
 Conditions:
   GovCloud: !Equals [!Ref AWS::Region, 'us-gov-west-1']
+  UsePermissionBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryPolicy, '' ] ]
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -18,9 +24,15 @@ Metadata:
           default: Admin info
         Parameters:
           - AdminUserEmail
+      - Label:
+          default: (Optional) Permissions
+        Parameters:
+          - PermissionsBoundaryPolicy
     ParameterLabels:
       AdminUserEmail:
         default: Initial Admin's Email
+      PermissionsBoundaryPolicy:
+        default: Permissions Boundary
 
 
 Resources:
@@ -44,7 +56,7 @@ Resources:
               - Effect: Allow
                 Action: sns:publish
                 Resource: '*'
-
+      PermissionsBoundary: !If [ UsePermissionBoundary, !Ref PermissionsBoundaryPolicy, !Ref 'AWS::NoValue' ]
 
   UserPoolDomain:
     Type: AWS::Cognito::UserPoolDomain

--- a/infrastructure/parallelcluster-ui-cognito.yaml
+++ b/infrastructure/parallelcluster-ui-cognito.yaml
@@ -12,6 +12,11 @@ Parameters:
     Description: 'ARN of the IAM policy to use as permissions boundary for every IAM role'
     Default: ''
     AllowedPattern: "^(arn:.*:iam::.*:policy\\/([a-zA-Z0-9_-]+))|()$"
+  IAMRoleAndPolicyPrefix:
+    Type: String
+    Description: 'Prefix applied to the name of every IAM role and policy (max length: 10)'
+    Default: ''
+    MaxLength: 10
 
 Conditions:
   GovCloud: !Equals [!Ref AWS::Region, 'us-gov-west-1']
@@ -27,10 +32,13 @@ Metadata:
       - Label:
           default: (Optional) Permissions
         Parameters:
+          - IAMRoleAndPolicyPrefix
           - PermissionsBoundaryPolicy
     ParameterLabels:
       AdminUserEmail:
         default: Initial Admin's Email
+      IAMRoleAndPolicyPrefix:
+        default: Prefix for IAM Roles and Policies
       PermissionsBoundaryPolicy:
         default: Permissions Boundary
 
@@ -39,6 +47,9 @@ Resources:
   SNSRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub
+        - ${IAMRoleAndPolicyPrefix}SNSRole-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -49,7 +60,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: CognitoSNSPolicy
+        - PolicyName: !Sub ${IAMRoleAndPolicyPrefix}SNSPermissions
           PolicyDocument:
             Version: 2012-10-17
             Statement:

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -47,7 +47,16 @@ Parameters:
     Description: (Optional) S3 bucket where CloudFormation files are stored. Change this parameter only when testing changes made to the infrastructure itself.
     Type: String
     Default: ''
-
+  PermissionsBoundaryPolicy:
+    Type: String
+    Description: 'ARN of the IAM policy to use as permissions boundary for every IAM role created by ParallelCluster UI infrastructure'
+    Default: ''
+    AllowedPattern: "^(arn:.*:iam::.*:policy\\/([a-zA-Z0-9_-]+))|()$"
+  PermissionsBoundaryPolicyPCAPI:
+    Type: String
+    Description: 'ARN of the IAM policy to use as permissions boundary for every IAM role created by ParallelCluster API infrastructure'
+    Default: ''
+    AllowedPattern: "^(arn:.*:iam::.*:policy\\/([a-zA-Z0-9_-]+))|()$"
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -80,6 +89,11 @@ Metadata:
         Parameters:
           - ImageBuilderVpcId
           - ImageBuilderSubnetId
+      - Label:
+          default: (Optional) Permissions Boundaries
+        Parameters:
+          - PermissionsBoundaryPolicy
+          - PermissionsBoundaryPolicyPCAPI
       - Label:
           default: (Debugging only) Infrastructure S3 Bucket
         Parameters:
@@ -121,6 +135,7 @@ Conditions:
       - !Equals ['4', !Select [ 1, !Split ['.', !Ref Version] ] ]
       - !Equals ['5', !Select [ 1, !Split ['.', !Ref Version] ] ]
   InGovCloud: !Equals ['us-gov-west-1', !Ref "AWS::Region"]
+  UsePermissionBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicy, '']]
 
 Mappings:
   ParallelClusterUI:
@@ -136,6 +151,7 @@ Resources:
     Properties:
       Parameters:
         AdminUserEmail: !Ref AdminUserEmail
+        PermissionsBoundaryPolicy: !Ref PermissionsBoundaryPolicy
       TemplateURL: !Sub 
         - '${Bucket}/parallelcluster-ui-cognito.yaml'
         - Bucket: !If 
@@ -149,6 +165,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       Parameters:
+        PermissionsBoundaryPolicy: !Ref PermissionsBoundaryPolicy
         ApiDefinitionS3Uri: !Sub s3://${AWS::Region}-aws-parallelcluster/parallelcluster/${Version}/api/ParallelCluster.openapi.yaml
         CreateApiUserRole: False
         EnableIamAdminAccess: True
@@ -294,6 +311,7 @@ Resources:
               - 'sts:AssumeRole'
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs'
+      PermissionsBoundary: !If [UsePermissionBoundary, !Ref PermissionsBoundaryPolicy, !Ref 'AWS::NoValue']
 
   ApiGatewayAccessLog:
     Type: AWS::Logs::LogGroup
@@ -477,6 +495,7 @@ Resources:
                   - secretsmanager:DeleteSecret
                 Resource:
                   - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${AWS::StackName}*
+      PermissionsBoundary: !If [UsePermissionBoundary, !Ref PermissionsBoundaryPolicy, !Ref 'AWS::NoValue']
 
   PrivateEcrRepository:
     DependsOn: ParallelClusterApi
@@ -502,6 +521,7 @@ Resources:
                 - !Sub ec2.${AWS::URLSuffix}
         Version: '2012-10-17'
       Path: /executionServiceEC2Role/
+      PermissionsBoundary: !If [UsePermissionBoundary, !Ref PermissionsBoundaryPolicy, !Ref 'AWS::NoValue']
 
   ImageBuilderInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -701,6 +721,7 @@ Resources:
                 Resource: !Sub
                   - arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/*${StackIdSuffix}*
                   - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
+      PermissionsBoundary: !If [UsePermissionBoundary, !Ref PermissionsBoundaryPolicy, !Ref 'AWS::NoValue']
 
   EcrImagesRemover:
     Type: Custom::EcrImagesRemover
@@ -740,6 +761,7 @@ Resources:
         - !Ref CostMonitoringAndPricingPolicy
         - !Ref SsmSendPolicy
         - !Ref SsmGetCommandInvocationPolicy
+      PermissionsBoundary: !If [UsePermissionBoundary, !Ref PermissionsBoundaryPolicy, !Ref 'AWS::NoValue']
 
 
   ParallelClusterUIApiGatewayInvoke:

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -57,6 +57,11 @@ Parameters:
     Description: 'ARN of the IAM policy to use as permissions boundary for every IAM role created by ParallelCluster API infrastructure'
     Default: ''
     AllowedPattern: "^(arn:.*:iam::.*:policy\\/([a-zA-Z0-9_-]+))|()$"
+  IAMRoleAndPolicyPrefix:
+    Type: String
+    Description: 'Prefix applied to the name of every IAM role and policy (max length: 10)'
+    Default: ''
+    MaxLength: 10
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -90,8 +95,9 @@ Metadata:
           - ImageBuilderVpcId
           - ImageBuilderSubnetId
       - Label:
-          default: (Optional) Permissions Boundaries
+          default: (Optional) Permissions
         Parameters:
+          - IAMRoleAndPolicyPrefix
           - PermissionsBoundaryPolicy
           - PermissionsBoundaryPolicyPCAPI
       - Label:
@@ -152,7 +158,8 @@ Resources:
       Parameters:
         AdminUserEmail: !Ref AdminUserEmail
         PermissionsBoundaryPolicy: !Ref PermissionsBoundaryPolicy
-      TemplateURL: !Sub 
+        IAMRoleAndPolicyPrefix: !Ref IAMRoleAndPolicyPrefix
+      TemplateURL: !Sub
         - '${Bucket}/parallelcluster-ui-cognito.yaml'
         - Bucket: !If 
           - HasDefaultInfrastructure
@@ -166,6 +173,7 @@ Resources:
     Properties:
       Parameters:
         PermissionsBoundaryPolicy: !Ref PermissionsBoundaryPolicy
+        IAMRoleAndPolicyPrefix: !Ref IAMRoleAndPolicyPrefix
         ApiDefinitionS3Uri: !Sub s3://${AWS::Region}-aws-parallelcluster/parallelcluster/${Version}/api/ParallelCluster.openapi.yaml
         CreateApiUserRole: False
         EnableIamAdminAccess: True
@@ -301,6 +309,9 @@ Resources:
   ApiGatewayLogRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ApiGatewayLogRole-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -463,6 +474,9 @@ Resources:
   UserPoolClientSecretRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub
+        - ${IAMRoleAndPolicyPrefix}UserPoolClientSecretRole-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -472,7 +486,7 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       Policies:
-        - PolicyName: CognitoPermissions
+        - PolicyName: !Sub ${IAMRoleAndPolicyPrefix}UserPoolPermissions
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -483,7 +497,7 @@ Resources:
                   - !Sub
                     - arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${UserPoolId}
                     - { UserPoolId: !If [UseExistingCognito, !Ref UserPoolId, !GetAtt [ Cognito, Outputs.UserPoolId ]]}
-        - PolicyName: SecretsManagerPermissions
+        - PolicyName: !Sub ${IAMRoleAndPolicyPrefix}SecretsManagerPermissions
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -508,6 +522,9 @@ Resources:
   ImageBuilderInstanceRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ImageBuilderInstanceRole-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
         - !Sub arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds
@@ -526,6 +543,9 @@ Resources:
   ImageBuilderInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
+      InstanceProfileName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ImageBuilderInstanceProfile-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       Path: /executionServiceEC2Role/
       Roles:
         - !Ref ImageBuilderInstanceRole
@@ -682,6 +702,9 @@ Resources:
   EcrImageDeletionLambdaRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub
+        - ${IAMRoleAndPolicyPrefix}EcrImageDeletionLambdaRole-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -691,7 +714,7 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       Policies:
-        - PolicyName: LoggingPolicy
+        - PolicyName: !Sub ${IAMRoleAndPolicyPrefix}LogsPermissions
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -700,7 +723,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub arn:${AWS::Partition}:logs:*:*:*
-        - PolicyName: BatchDeletePolicy
+        - PolicyName: !Sub ${IAMRoleAndPolicyPrefix}EcrPermissions
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -741,6 +764,9 @@ Resources:
   ParallelClusterUIUserRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterUIUserRole-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow
@@ -777,6 +803,9 @@ Resources:
   ParallelClusterApiGatewayInvoke:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}ParallelClusterApiGatewayInvoke-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -790,6 +819,9 @@ Resources:
   CognitoPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}CognitoPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId']]]] }
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -815,6 +847,9 @@ Resources:
   EC2Policy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}EC2Policy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -847,6 +882,9 @@ Resources:
   DescribeFsxPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}DescribeFsxPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -864,6 +902,9 @@ Resources:
   DescribeEfsPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}DescribeEfsPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -877,6 +918,9 @@ Resources:
   CostMonitoringAndPricingPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}CostMonitoringAndPricingPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -902,6 +946,9 @@ Resources:
   SsmSendPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}SsmSendPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -924,6 +971,9 @@ Resources:
   SsmGetCommandInvocationPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}SsmGetCommandInvocationPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
       PolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
## Changes

1. Add support for permissions boundary: now the user can optionally specify the IAM policies to be used as permissions boundaries for the PCUI infrastructure and the PCAPI infrastructure, separately.
2. Add support for IAM roles and policies prefix: now the user can optionally specify a prefix to be added to every IAM role and policy name created as part of both PCUI and PCAPI infrastructure.

**Note about Customer Experience**
When a permissions boundary is specified for the PCAPI infrastructure, such boundary is also set as condition for _iam:CreateRole/PutRolePolicy/DeleteRolePolicy/AttachRolePolicyDetachRolePolicy_ (this behaviour is part of the product since Jan 2023 see [commit](https://github.com/aws/aws-parallelcluster/pull/4840)).  This implies that when such boundary is specified, only clusters with the configuration Iam/PermissionsBoundary equal to that boundary can succeed.

## How Has This Been Tested?

1. PCUI deployed as default without prefix and boundary.
    1. verified that resources do not have prefix and boundaries. 
    2. Created and deleted a cluster.
4. PCUI deployed with prefix and boundary: 
    1. Verified that resources have the expected prefix and boundary. 
    2. Creation of a cluster without Iam/Permissions boundary fails as expected because of the [condition on iam:CreateRole](https://github.com/aws/aws-parallelcluster/blob/release-3.8/cloudformation/policies/parallelcluster-policies.yaml#L134-L145)
    3. Created and deleted a cluster with Iam/PermissionsBoundary equal to the one set for PCAPI
    5. Created and deleted a cluster with Iam/PermissionsBoundary and prefix equal to the ones set for PCAPI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
