### PR TITLE
[Dependencies] Bump default ParallelCluster version to 3.8.0b1.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,7 @@ To run AWS ParallelCluster UI locally, start by setting the following environmen
 export AWS_ACCESS_KEY_ID=[...]
 export AWS_SECRET_ACCESS_KEY=[...]
 export AWS_DEFAULT_REGION=us-east-2
-export API_VERSION="3.7.2"
+export API_VERSION="3.8.0b1"
 export API_BASE_URL=https://[API_ID].execute-api.us-east-2.amazonaws.com/prod  # get this from ParallelClusterApi stack outputs
 export ENV=dev
 ```

--- a/infrastructure/environments/demo-cfn-update-args.yaml
+++ b/infrastructure/environments/demo-cfn-update-args.yaml
@@ -1,7 +1,7 @@
 TemplateURL: BUCKET_URL_PLACEHOLDER/parallelcluster-ui.yaml
 Parameters:
   - ParameterKey: Version
-    ParameterValue: 3.7.2
+    ParameterValue: 3.8.0b1
   - ParameterKey: InfrastructureBucket
     ParameterValue: BUCKET_URL_PLACEHOLDER
   - ParameterKey: UserPoolId

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -34,7 +34,7 @@ Parameters:
   Version:
     Description: Version of AWS ParallelCluster to deploy
     Type: String
-    Default: 3.7.2
+    Default: 3.8.0b1
   ImageBuilderVpcId:
     Description: (Optional) Select the VPC to use for building the container images. If not selected, default VPC will be used.
     Type: String


### PR DESCRIPTION
## Changes

Bump default ParallelCluster version to 3.8.0b1, covering both production code and operational scripts.

**Notes**
The goal of this change is not to provide feature parity with ParallelCluster 3.8.0b1.

## How Has This Been Tested?

1. Deployed PCUI with pcluster 3.8.0b1
2. Created and deleted a cluster using a configuration file that triggers all the features introduced in 3.8.0b1: custom munge key, custom slurm db name, alarms, dra for fsx lustre.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
