### PR TITLE
[Tools] Add scripts to facilitate 1-click deployment of PCUI in personal environment

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,8 +21,24 @@ bash ./rollforward_awslambda_image.sh
 
 **NOTE:** The rollforward script should be used only if the rollback script is launched by mistake, the normal procedure to publish a new release after a rollback is by launching the `build_and_release_image.sh --tag YYYY.MM.REVISION` after fixing the code
 
-# How to deploy PCUI image in personal account
+# How to deploy PCUI in personal account
+Create configurations files for your personal environment (una tantum):
 
+```
+bash scripts/setup-env.sh [ENVIRONMENT_NAME]
+```
+
+where *ENVIRONMENT_NAME* could be your login.
+
+Adapt the configurations files `[ENVIRONMENT_NAME]-*` created in `infrastructure/environments` with your data.
+
+Deploy the local PCUI to your environment:
+
+```
+bash scripts/deploy.sh [ENVIRONMENT_NAME]
+```
+
+# How to deploy the PCUI image to a private ECR repository
 Create an ECR *private* repository in your personal account, where PCUI Docker images will be stored for testing:
 
 ```

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+function info() {
+  echo "[INFO] $1"
+}
+
+function warn() {
+  echo "[WARN] $1"
+}
+
+function fail() {
+  echo "[ERROR] $1" && exit 1
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+set -e
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to update the infrastructure of a given PCM environment.
+# An environment is composed of a list of variables with the entrypoints of the environment
+# and a CloudFormation request file where the stack update can be customized,
+# for example by changing the parameters provided to the previous version of the stack
+#
+# Usage: ./scripts/deploy.sh [ENVIRONMENT]
+# Example: ./scripts/deploy.sh demo
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+
+INFRASTRUCTURE_DIR="$CURRENT_DIR/../infrastructure"
+
+source "$CURRENT_DIR/common.sh"
+
+ENVIRONMENT=$1
+
+[[ -z $ENVIRONMENT ]] && fail "Missing required argument: ENVIRONMENT"
+
+info "Selected environment: $ENVIRONMENT"
+
+source "$INFRASTRUCTURE_DIR/environments/$ENVIRONMENT-variables.sh"
+
+# STEP: Upload templates
+info "Retrieving infrastructure bucket"
+if [[ -n $INFRA_BUCKET_NAME ]]; then
+  BUCKET=$INFRA_BUCKET_NAME
+else
+  BUCKET=$(aws cloudformation describe-stack-resources \
+    --region "$REGION" \
+    --stack-name "$INFRA_BUCKET_STACK_NAME" \
+    --logical-resource-id InfrastructureBucket \
+    --output text \
+    --query 'StackResources[0].PhysicalResourceId')
+fi
+info "Using infrastructure bucket $BUCKET"
+
+info "Uploading templates to infrastructure bucket $BUCKET"
+FILES=(parallelcluster-ui-cognito.yaml parallelcluster-ui.yaml)
+for FILE in "${FILES[@]}"; do
+  aws s3 cp --region "$REGION" "$INFRASTRUCTURE_DIR/$FILE" "s3://$BUCKET/$FILE"
+done
+# -----------------------------
+
+# STEP: Setup private ECR repository
+ECR_REPOSITORY_NAME="parallelcluster-ui"
+info "Settings up private ECR repository $ECR_REPOSITORY_NAME"
+if [[ ! $(aws ecr describe-repositories --repository-name $ECR_REPOSITORY_NAME --region "$REGION" 2>/dev/null) ]]; then
+  info "The private ECR repository $ECR_REPOSITORY_NAME does not exist, creating ..."
+  aws ecr create-repository \
+    --region "$REGION" \
+    --repository-name $ECR_REPOSITORY_NAME \
+    --image-tag-mutability MUTABLE
+
+else
+  info "The private ECR repository $ECR_REPOSITORY_NAME already exists"
+fi
+REPOSITORY_INFO=$(aws ecr describe-repositories \
+--region "$REGION" \
+--repository-name $ECR_REPOSITORY_NAME \
+--query "repositories[0].{arn:repositoryArn,uri:repositoryUri}" \
+--output json)
+REPOSITORY_ARN=$(echo "$REPOSITORY_INFO" | jq -cr '.arn')
+REPOSITORY_ENDPOINT=$(echo "$REPOSITORY_INFO" | jq -cr '.uri' | cut -d '/' -f 1)
+info "Using private ECR repository $REPOSITORY_ARN at ECR endpoint $REPOSITORY_ENDPOINT"
+# -----------------------------
+
+# STEP: Build image locally and publish to private ECR repository
+info "Building image locally and publishing it to private ECR repository"
+ECR_IMAGE_TAG=$(date +%Y.%m.%d)
+bash "$CURRENT_DIR/build_and_release_image.sh" --ecr-region "$REGION" --ecr-endpoint "$REPOSITORY_ENDPOINT" --tag "$ECR_IMAGE_TAG"
+info "Image built with tag '$ECR_IMAGE_TAG' and 'latest'"
+# -----------------------------
+
+# STEP: Deploy stack
+info "Deploying stack $STACK_NAME"
+BUCKET_URL="https://$BUCKET.s3.$REGION.amazonaws.com"
+
+if [[ ! $(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" 2>/dev/null) ]]; then
+  info "The stack $STACK_NAME does not exist, creating ..."
+  CFN_DEPLOY_COMMAND="create-stack"
+  CFN_WAIT_COMMAND="stack-create-complete"
+  CFN_CLI_INPUT_YAML_FILE="$INFRASTRUCTURE_DIR/environments/$ENVIRONMENT-cfn-create-args.yaml"
+
+else
+  info "The stack $STACK_NAME exists, updating ..."
+  CFN_DEPLOY_COMMAND="update-stack"
+  CFN_WAIT_COMMAND="stack-update-complete"
+  CFN_CLI_INPUT_YAML_FILE="$INFRASTRUCTURE_DIR/environments/$ENVIRONMENT-cfn-update-args.yaml"
+fi
+
+CLI_INPUT_YAML=$(sed "s#BUCKET_URL_PLACEHOLDER#$BUCKET_URL#g" "$CFN_CLI_INPUT_YAML_FILE")
+
+AWS_PAGER="cat" aws cloudformation $CFN_DEPLOY_COMMAND \
+  --cli-input-yaml "$CLI_INPUT_YAML" \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION"
+
+aws cloudformation wait $CFN_WAIT_COMMAND \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION"
+
+info "Deployment completed!"
+#  -----------------------------
+
+# STEP: Retrieve stack details
+PCUI_ENDPOINT=$(aws cloudformation describe-stacks \
+                  --stack-name "$STACK_NAME" \
+                  --region "$REGION" \
+                  --query "Stacks[0].Outputs[?OutputKey == 'ParallelClusterUIUrl'].OutputValue" \
+                  --output text)
+
+info "PCUI endpoint is $PCUI_ENDPOINT"

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to update the infrastructure of a given PCM environment.
+# An environment is composed of a list of variables with the entrypoints of the environment
+# and a CloudFormation request file where the stack update can be customized,
+# for example by changing the parameters provided to the previous version of the stack
+#
+# Usage: ./scripts/setup-env.sh [ENVIRONMENT]
+# Example: ./scripts/setup-env.sh demo
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+ENVIRONMENTS_DIR=$(realpath "$CURRENT_DIR/../infrastructure/environments")
+
+source "$CURRENT_DIR/common.sh"
+
+ENVIRONMENT=$1
+
+[[ -z $ENVIRONMENT ]] && fail "Missing required argument: ENVIRONMENT"
+
+info "Selected environment: $ENVIRONMENT"
+
+if [[ $(ls $ENVIRONMENTS_DIR/$ENVIRONMENT-*) ]]; then
+  warn "Configuration files for the environment $ENVIRONMENT already exist. Nothing to do."
+  exit 0
+fi
+
+info "Creating environment files"
+cp "$ENVIRONMENTS_DIR/demo-variables.sh" "$ENVIRONMENTS_DIR/$ENVIRONMENT-variables.sh"
+chmod +x "$ENVIRONMENTS_DIR/$ENVIRONMENT-variables.sh"
+cp "$ENVIRONMENTS_DIR/demo-cfn-update-args.yaml" "$ENVIRONMENTS_DIR/$ENVIRONMENT-cfn-create-args.sh"
+cp "$ENVIRONMENTS_DIR/demo-cfn-update-args.yaml" "$ENVIRONMENTS_DIR/$ENVIRONMENT-cfn-update-args.sh"
+
+info "Environment files created! Check out $ENVIRONMENTS_DIR"


### PR DESCRIPTION
## Changes
1. Add script 'deploy.sh' to deploy (created or update) the local PCUI to a personal environment.
2. Add script 'setup-env.sh' to create the configuration files to deploy PCUI to personal environments
3. Documented how to use the above scripts.

Command to create files for the personal environment (this must be done just the first time):

```
bash scripts/setup-env.sh giacomo-env
```

Command to deploy (create or update) PCUI into the environment:

```
bash scripts/deploy.sh giacomo-env
```

Example of execution:

```
(pcluster-ui) ➜  aws-parallelcluster-ui git:(wip/mgiacomo/2023120/fix-urlib-cve) ✗ bash scripts/deploy.sh mgiacomo                            
[INFO] Selected environment: mgiacomo
[INFO] Retrieving infrastructure bucket
[INFO] Using infrastructure bucket mgiacomo-aws-parallelcluster-ui
[INFO] Uploading templates to infrastructure bucket mgiacomo-aws-parallelcluster-ui
upload: infrastructure/parallelcluster-ui-cognito.yaml to s3://mgiacomo-aws-parallelcluster-ui/parallelcluster-ui-cognito.yaml
upload: infrastructure/parallelcluster-ui.yaml to s3://mgiacomo-aws-parallelcluster-ui/parallelcluster-ui.yaml
[INFO] Settings up private ECR repository parallelcluster-ui
[INFO] The private ECR repository parallelcluster-ui already exists
[INFO] Using private ECR repository arn:aws:ecr:us-east-1:REDACTED:repository/parallelcluster-ui at ECR endpoint REDACTED.dkr.ecr.us-east-1.amazonaws.com
[INFO] Building image locally and publishing it to private ECR repository
[INFO] Logging in REDACTED.dkr.ecr.us-east-1.amazonaws.com
Login Succeeded
[INFO] Building frontend
~/workplace/aws-parallelcluster-ui/frontend ~/workplace/aws-parallelcluster-ui
[INFO] Building image
...DOCKER LOGS...
[INFO] Pushing image REDACTED.dkr.ecr.us-east-1.amazonaws.com/parallelcluster-ui:2023.11.21 in repository parallelcluster-ui
...DOCKER LOGS...
[INFO] Uploaded: REDACTED.dkr.ecr.us-east-1.amazonaws.com/parallelcluster-ui:2023.11.21, REDACTED.dkr.ecr.us-east-1.amazonaws.com/parallelcluster-ui:latest
[INFO] Image built with tag '2023.11.21' and 'latest'
[INFO] Deploying stack pcui-test
[INFO] The stack pcui-test does not exist, creating ...
{
    "StackId": "arn:aws:cloudformation:us-east-1:REDACTED:stack/pcui-test/REDACTED"
}
[INFO] Deployment completed!
[INFO] PCUI endpoint is https://REDACTED.execute-api.us-east-1.amazonaws.com/pcui
```

## How Has This Been Tested?

Used both script to deploy PCUI in personal account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
