### PR TITLE
[Dependencies] Bump Pcluster version to 3.8.0.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,7 @@ To run AWS ParallelCluster UI locally, start by setting the following environmen
 export AWS_ACCESS_KEY_ID=[...]
 export AWS_SECRET_ACCESS_KEY=[...]
 export AWS_DEFAULT_REGION=us-east-2
-export API_VERSION="3.8.0b1"
+export API_VERSION="3.8.0"
 export API_BASE_URL=https://[API_ID].execute-api.us-east-2.amazonaws.com/prod  # get this from ParallelClusterApi stack outputs
 export ENV=dev
 ```

--- a/infrastructure/environments/demo-cfn-update-args.yaml
+++ b/infrastructure/environments/demo-cfn-update-args.yaml
@@ -1,7 +1,7 @@
 TemplateURL: BUCKET_URL_PLACEHOLDER/parallelcluster-ui.yaml
 Parameters:
   - ParameterKey: Version
-    ParameterValue: 3.8.0b1
+    ParameterValue: 3.8.0
   - ParameterKey: InfrastructureBucket
     ParameterValue: BUCKET_URL_PLACEHOLDER
   - ParameterKey: UserPoolId

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -34,7 +34,7 @@ Parameters:
   Version:
     Description: Version of AWS ParallelCluster to deploy
     Type: String
-    Default: 3.8.0b1
+    Default: 3.8.0
   ImageBuilderVpcId:
     Description: (Optional) Select the VPC to use for building the container images. If not selected, default VPC will be used.
     Type: String


### PR DESCRIPTION
## Changes

Bump Pcluster version to 3.8.0.

## How Has This Been Tested?

1. Deployed in personal account
2. Navigated pages
3. Verified that the wizard does not introduce any block to the submission of a cluster configuration for 3.8.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
