### PR TITLE
[Versioning] Bump ParallelCluster UI version to 2023.12.0.

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -6,7 +6,7 @@ Parameters:
   PublicEcrImageUri:
     Description: When specified, the URI of the Docker image for the Lambda of the ParallelCluster UI container
     Type: String
-    Default: public.ecr.aws/pcm/parallelcluster-ui:2023.10.0
+    Default: public.ecr.aws/pcm/parallelcluster-ui:2023.12.0
   VpcEndpointId:
     Description: Enter a VPC endpoint to enable private PCUI implementation. When enabled, the API will only accept requests from within the given VPC.
     Type: String
@@ -146,7 +146,7 @@ Conditions:
 Mappings:
   ParallelClusterUI:
     Constants:
-      Version: 2023.10.0 # format YYYY.MM.REVISION
+      Version: 2023.12.0 # format YYYY.MM.REVISION
 
 Resources:
 


### PR DESCRIPTION
## Description
Bump ParallelCluster UI version to 2023.12.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
