### PR TITLE
[Infrastructure] Add EC2 permissions required by PCUI private deployment only when private deployment is enabled.

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -859,11 +859,6 @@ Resources:
             - ec2:DescribeInstanceTypes
             - ec2:DescribeSubnets
             - ec2:DescribeKeyPairs
-            - ec2:DescribeNetworkInterfaces
-            - ec2:CreateNetworkInterface
-            - ec2:DeleteNetworkInterface
-            - ec2:DescribeInstances
-            - ec2:AttachNetworkInterface
             Resource:
               - '*'
             Effect: Allow
@@ -878,6 +873,27 @@ Resources:
                 ec2:ResourceTag/parallelcluster:version: "*"
             Effect: Allow
             Sid: EC2ManagePolicy
+          - Fn::If:
+            - IsPrivate
+            - Action:
+                - ec2:CreateNetworkInterface
+                - ec2:DeleteNetworkInterface
+                - ec2:AttachNetworkInterface
+              Resource:
+                - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:*
+              Effect: Allow
+              Sid: PrivateDeploymentWritePolicy
+            - !Ref AWS::NoValue
+          - Fn::If:
+            - IsPrivate
+            - Action:
+                - ec2:DescribeNetworkInterfaces
+                - ec2:DescribeInstances
+              Resource:
+                - '*'
+              Effect: Allow
+              Sid: PrivateDeploymentReadPolicy
+            - !Ref AWS::NoValue
 
   DescribeFsxPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
## Description
Add EC2 permissions required by PCUI private deployment only when private deployment is enabled.
In particular, the following permissions are required by the PCUI Lambda execution role when private deployment is enabled:
1. ec2:CreateNetworkInterface
1. ec2:DeleteNetworkInterface
1. ec2:AttachNetworkInterface
1. ec2:DescribeNetworkInterfaces
1. ec2:DescribeInstances

## How Has This Been Tested?

1. Deployed in personal environment with private deployment *disabled*: deployment succeeded, extra permissions not deployed, cluster creation succeeded.
2. Deployed in personal environment with private deployment *enable*: deployment succeeded, extra permissions are deployed, cluster creation succeeded. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
