### PR TITLE
[Infrastructure] Rename APIG and Lambda resources to unblock stack updates to 2023.12.0 and added missing params to demo env

### DIFF
--- a/infrastructure/environments/demo-cfn-update-args.yaml
+++ b/infrastructure/environments/demo-cfn-update-args.yaml
@@ -1,17 +1,37 @@
 TemplateURL: BUCKET_URL_PLACEHOLDER/parallelcluster-ui.yaml
 Parameters:
+  - ParameterKey: AdminUserEmail
+    UsePreviousValue: true
   - ParameterKey: Version
     ParameterValue: 3.8.0
   - ParameterKey: InfrastructureBucket
     ParameterValue: BUCKET_URL_PLACEHOLDER
+  - ParameterKey: PublicEcrImageUri
+    ParameterValue: public.ecr.aws/pcm/parallelcluster-ui:latest
+#   Use the value below if you want to deploy the local image of PCUI.
+#    ParameterValue: DEMO_ACCOUNT_ID.dkr.ecr.DEMO_REGION.amazonaws.com/parallelcluster-ui:latest
   - ParameterKey: UserPoolId
     UsePreviousValue: true
   - ParameterKey: UserPoolAuthDomain
     UsePreviousValue: true
   - ParameterKey: SNSRole
     UsePreviousValue: true
-  - ParameterKey: PublicEcrImageUri
-    ParameterValue: public.ecr.aws/pcm/parallelcluster-ui:latest
+  - ParameterKey: ImageBuilderVpcId
+    UsePreviousValue: true
+  - ParameterKey: ImageBuilderSubnetId
+    UsePreviousValue: true
+  - ParameterKey: VpcEndpointId
+    UsePreviousValue: true
+  - ParameterKey: LambdaSubnetIds
+    UsePreviousValue: true
+  - ParameterKey: LambdaSecurityGroupIds
+    UsePreviousValue: true
+  - ParameterKey: PermissionsBoundaryPolicy
+    UsePreviousValue: true
+  - ParameterKey: PermissionsBoundaryPolicyPCAPI
+    UsePreviousValue: true
+  - ParameterKey: IAMRoleAndPolicyPrefix
+    UsePreviousValue: true
 Capabilities:
   - CAPABILITY_AUTO_EXPAND
   - CAPABILITY_NAMED_IAM

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -195,7 +195,7 @@ Resources:
       TemplateURL: !Sub https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.amazonaws.com/parallelcluster/${Version}/api/parallelcluster-api.yaml
       TimeoutInMinutes: 30
 
-  ParallelClusterUIFunction:
+  ParallelClusterUIFun:
     Type: AWS::Lambda::Function
     Properties:
       Role: !GetAtt ParallelClusterUIUserRole.Arn
@@ -219,13 +219,13 @@ Resources:
           API_VERSION: !Ref Version
           SITE_URL: !Sub
            - https://${Api}.execute-api.${AWS::Region}.${AWS::URLSuffix}/pcui
-           - Api: !Ref ApiGateway
+           - Api: !Ref ApiGatewayRestApi
           AUTH_PATH: !If [ UseExistingCognito, !Ref UserPoolAuthDomain, !GetAtt [ Cognito, Outputs.UserPoolAuthDomain ]]
           SECRET_ID: !GetAtt UserPoolClientSecret.SecretName
           AUDIENCE: !Ref CognitoAppClient
           OIDC_PROVIDER: 'Cognito'
       FunctionName: !Sub
-        - ParallelClusterUIFunction-${StackIdSuffix}
+        - ParallelClusterUIFun-${StackIdSuffix}
         - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
       Code:
         ImageUri: !Sub
@@ -235,7 +235,7 @@ Resources:
               - '-'
               - [!Select [2, !Split ['/', !Ref EcrImage]], !Select [3, !Split ['/', !Ref EcrImage]]]
 
-  ApiGateway:
+  ApiGatewayRestApi:
     Type: AWS::ApiGateway::RestApi
     Properties:
       Name: ParallelClusterUI
@@ -274,14 +274,14 @@ Resources:
   ApiGatewayProxyResource:
     Type: AWS::ApiGateway::Resource
     Properties:
-      RestApiId: !Ref ApiGateway
-      ParentId: !GetAtt ApiGateway.RootResourceId
+      RestApiId: !Ref ApiGatewayRestApi
+      ParentId: !GetAtt ApiGatewayRestApi.RootResourceId
       PathPart: '{proxy+}'
 
   ApiGatewayMethod:
     Type: AWS::ApiGateway::Method
     Properties:
-      RestApiId: !Ref ApiGateway
+      RestApiId: !Ref ApiGatewayRestApi
       ResourceId: !Ref ApiGatewayProxyResource
       HttpMethod: ANY
       AuthorizationType: NONE
@@ -289,21 +289,21 @@ Resources:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
         Uri: !Sub
-          - arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:ParallelClusterUIFunction-${StackIdSuffix}/invocations
+          - arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:ParallelClusterUIFun-${StackIdSuffix}/invocations
           - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
 
   ApiGatewayRootMethod:
     Type: AWS::ApiGateway::Method
     Properties:
-      RestApiId: !Ref ApiGateway
-      ResourceId: !GetAtt ApiGateway.RootResourceId
+      RestApiId: !Ref ApiGatewayRestApi
+      ResourceId: !GetAtt ApiGatewayRestApi.RootResourceId
       HttpMethod: ANY
       AuthorizationType: NONE
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
         Uri: !Sub
-          - arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:ParallelClusterUIFunction-${StackIdSuffix}/invocations
+          - arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:ParallelClusterUIFun-${StackIdSuffix}/invocations
           - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
 
   ApiGatewayLogRole:
@@ -338,16 +338,16 @@ Resources:
     Type: AWS::ApiGateway::Deployment
     DependsOn: ApiGatewayMethod
     Properties:
-      RestApiId: !Ref ApiGateway
+      RestApiId: !Ref ApiGatewayRestApi
 
-  ApiGatewayStage:
+  ApiGatewayRestStage:
     Type: AWS::ApiGateway::Stage
     DependsOn: ApiGatewayAccount
     Properties: 
       AccessLogSetting:
         DestinationArn: !GetAtt ApiGatewayAccessLog.Arn
         Format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","path":"$context.path", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength" }'
-      RestApiId: !Ref ApiGateway
+      RestApiId: !Ref ApiGatewayRestApi
       DeploymentId: !Ref ApiGatewayDeployment
       StageName: pcui
       MethodSettings:
@@ -371,7 +371,7 @@ Resources:
       CallbackURLs:
         - !Sub
           - https://${Api}.execute-api.${AWS::Region}.${AWS::URLSuffix}/pcui/login
-          - Api: !Ref ApiGateway
+          - Api: !Ref ApiGatewayRestApi
       SupportedIdentityProviders:
         - COGNITO
       UserPoolId: !If [ UseExistingCognito, !Ref UserPoolId, !GetAtt [ Cognito, Outputs.UserPoolId ]]
@@ -757,7 +757,7 @@ Resources:
   ParallelClusterUILambdaLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${ParallelClusterUIFunction}
+      LogGroupName: !Sub /aws/lambda/${ParallelClusterUIFun}
       RetentionInDays: 90
 
 
@@ -794,11 +794,11 @@ Resources:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !GetAtt ParallelClusterUIFunction.Arn
+      FunctionName: !GetAtt ParallelClusterUIFun.Arn
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub
         - arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${ApiGateway}/*
-        - { ApiGateway: !Ref ApiGateway }
+        - { ApiGateway: !Ref ApiGatewayRestApi }
 
   ParallelClusterApiGatewayInvoke:
     Type: AWS::IAM::ManagedPolicy
@@ -1004,14 +1004,14 @@ Resources:
 Outputs:
   ParallelClusterUILambdaArn:
     Description: 'ARN of the ParallelCluster UI Lambda function'
-    Value: !GetAtt ParallelClusterUIFunction.Arn
+    Value: !GetAtt ParallelClusterUIFun.Arn
   ParallelClusterUIUrl:
     Description: 'Url to reach the ParallelCluster UI Site.'
     Export:
       Name: !Sub ${AWS::StackName}-ParallelClusterUISite
     Value: !Sub
       - https://${Api}.execute-api.${AWS::Region}.${AWS::URLSuffix}/pcui
-      - Api: !Ref ApiGateway
+      - Api: !Ref ApiGatewayRestApi
   AppClientId:
     Description: The id of the Cognito app client
     Value: !Ref CognitoAppClient


### PR DESCRIPTION
## Changes
1. Renamed APIG and Lambda resources to unblock stack updates to 2023.12.0. The renaming is necessary because as part of PCUI private deployment we are changing the resource.toy e without changing the resource name, which is not supported by CloudFormation updates.
It is also necessary for the Lambda Function, even if we are not changing the resource typ,e because, experimentally, wer observed that changing the vpc configuration is not supported by CloudFormation updates leading the resource to a failed updated (error: Lambda function did not stabilize) 
 In particular we renamed the following resources impacted by the new feature "Private PCUI deployment":
    1. ParallelClusterUIFunction
    2. ApiGateway
    3. ApiGatewayStage
2. Added missing stack parameters to demo env.

## How Has This Been Tested?
1. Updated demo env from 2023.10.0 to 2023.12.0 using `bash scripts/deploy.sh demo`.
2. Verified that the demo env is working properly by logging in and navigating pages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
