### PR TITLE
[Infrastructure] Specify PermissionsBoundaryPolicy and IAMRoleAndPolicyPrefix in PCAPI only if not empty.

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -142,6 +142,8 @@ Conditions:
       - !Equals ['5', !Select [ 1, !Split ['.', !Ref Version] ] ]
   InGovCloud: !Equals ['us-gov-west-1', !Ref "AWS::Region"]
   UsePermissionBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicy, '']]
+  UsePermissionBoundaryPCAPI: !Not [!Equals [!Ref PermissionsBoundaryPolicyPCAPI, '']]
+  UseIAMRoleAndPolicyPrefix: !Not [!Equals [!Ref IAMRoleAndPolicyPrefix, '']]
 
 Mappings:
   ParallelClusterUI:
@@ -172,8 +174,8 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       Parameters:
-        PermissionsBoundaryPolicy: !Ref PermissionsBoundaryPolicy
-        IAMRoleAndPolicyPrefix: !Ref IAMRoleAndPolicyPrefix
+        PermissionsBoundaryPolicy: !If [ UsePermissionBoundaryPCAPI, !Ref PermissionsBoundaryPolicyPCAPI, !Ref AWS::NoValue ]
+        IAMRoleAndPolicyPrefix: !If [ UseIAMRoleAndPolicyPrefix, !Ref IAMRoleAndPolicyPrefix, !Ref AWS::NoValue ]
         ApiDefinitionS3Uri: !Sub s3://${AWS::Region}-aws-parallelcluster/parallelcluster/${Version}/api/ParallelCluster.openapi.yaml
         CreateApiUserRole: False
         EnableIamAdminAccess: True


### PR DESCRIPTION
## Description
1. Specify PermissionsBoundaryPolicy and IAMRoleAndPolicyPrefix in PCAPI only if not empty. In this way the PCUI 2023.12.0 deployment can succeed even with PC >= 3.8.0.
2. Fix the parameter used in PCAPI: PermissionsBoundaryPolicyPCAPI rather than PermissionsBoundaryPolicy. This was a bug we did not notice before becausde during manual tests we have always used the same permissions boundary both for PCUI and PCAPI.


## How Has This Been Tested?
1. Deployed PCUI with PC 3.5.0
2. 1. Deployed PCUI with PC 3.8.0b1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
