### PR TITLE
Upgrade python version to 3.9

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -693,7 +693,7 @@ Resources:
               cfnresponse.send(event, context, response_status, response_data, physical_resource_id, reason)
 
       Handler: index.handler
-      Runtime: python3.7
+      Runtime: python3.9
       Role: !GetAtt EcrImageDeletionLambdaRole.Arn
 
   EcrImageDeletionLambdaLogGroup:


### PR DESCRIPTION
## Changes

Upgrade Lambda runtime from Python3.7 to Python3.9

## References

Lambda Python 3.7 runtime was deprecated earlier today https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
