### PR TITLE
[Dependencies] Bump flask version for jinja2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 Flask-Cors==3.0.10
-Flask==2.1.2
+Flask==2.3.3
 Werkzeug==2.3.8
 boto3==1.24.30
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@
 #
 attrs==23.1.0
     # via pytest
+blinker==1.7.0
+    # via flask
 boto3==1.24.30
     # via -r requirements.in
 botocore==1.27.96
@@ -24,7 +26,7 @@ ecdsa==0.18.0
     # via python-jose
 exceptiongroup==1.1.1
     # via pytest
-flask==2.1.2
+flask==2.3.3
     # via
     #   -r requirements.in
     #   flask-cors
@@ -40,7 +42,7 @@ itsdangerous==2.1.2
     # via
     #   -r requirements.in
     #   flask
-jinja2==3.1.2
+jinja2==3.1.3
     # via flask
 jmespath==1.0.1
     # via


### PR DESCRIPTION
## Changes
* Updated to [flask v2.3.3](https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-3-3) because it requires jinja2>3.1.2, which will close [CVE-2024-22195](https://github.com/aws/aws-parallelcluster-ui/security/dependabot/28)
* Had to update `app.py` because `JSONEncoder` became deprecated as part of flaskv2.3.0, so used `DefaultJSONProvider`: https://github.com/pallets/flask/pull/4692

<!-- List of relevant changes introduced -->

## How Has This Been Tested?
Deployed stack on personal acc, and created a cluster

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
