### PR TITLE
Paginate list clusters

### DIFF
--- a/frontend/src/__tests__/ListClusters.test.ts
+++ b/frontend/src/__tests__/ListClusters.test.ts
@@ -1,0 +1,109 @@
+import {ListClusters} from '../model'
+import {ClusterInfoSummary, ClusterStatus} from '../types/clusters'
+import {CloudFormationStackStatus} from '../types/base'
+
+const mockCluster1: ClusterInfoSummary = {
+  clusterName: 'test-cluster-1',
+  clusterStatus: ClusterStatus.CreateComplete,
+  version: '3.8.0',
+  cloudformationStackArn: 'arn',
+  region: 'region',
+  cloudformationStackStatus: CloudFormationStackStatus.CreateComplete,
+}
+
+const mockCluster2: ClusterInfoSummary = {
+  clusterName: 'test-cluster-2',
+  clusterStatus: ClusterStatus.CreateComplete,
+  version: '3.8.0',
+  cloudformationStackArn: 'arn',
+  region: 'region',
+  cloudformationStackStatus: CloudFormationStackStatus.CreateComplete,
+}
+
+const mockGet = jest.fn()
+
+jest.mock('axios', () => ({
+  create: () => ({
+    get: (...args: unknown[]) => mockGet(...args),
+  }),
+}))
+
+describe('given a ListClusters command', () => {
+  describe('when the clusters use pagination to be listed', () => {
+    beforeEach(() => {
+      const mockResponse1 = {
+        nextToken: 'asdfghjkl',
+        clusters: [mockCluster1],
+      }
+
+      const mockResponse2 = {
+        clusters: [mockCluster2],
+      }
+      mockGet
+        .mockResolvedValueOnce({data: mockResponse1})
+        .mockResolvedValueOnce({data: mockResponse2})
+    })
+
+    it('should return the list of all clusters', async () => {
+      const data = await ListClusters()
+      expect(data).toEqual([mockCluster1, mockCluster2])
+    })
+  })
+
+  describe('when the clusters are listed in one API call', () => {
+    beforeEach(() => {
+      const mockResponse1 = {
+        clusters: [mockCluster1, mockCluster2],
+      }
+      mockGet.mockResolvedValueOnce({data: mockResponse1})
+    })
+
+    it('should return the list of all clusters', async () => {
+      const data = await ListClusters()
+      expect(data).toEqual([mockCluster1, mockCluster2])
+    })
+  })
+
+  describe('when there are no clusters', () => {
+    beforeEach(() => {
+      const mockResponse1 = {
+        clusters: [],
+      }
+      mockGet.mockResolvedValueOnce({data: mockResponse1})
+    })
+
+    it('should return empty list', async () => {
+      const data = await ListClusters()
+      expect(data).toEqual([])
+    })
+  })
+
+  describe('when the list cluster fails', () => {
+    let mockError: any
+
+    beforeEach(() => {
+      mockError = {
+        response: {
+          data: {
+            message: 'some-error-messasge',
+          },
+        },
+      }
+      mockGet.mockRejectedValueOnce(mockError)
+    })
+
+    it('should throw the error', async () => {
+      try {
+        await ListClusters()
+      } catch (e) {
+        expect(e).toEqual({
+          response: {
+            data: {
+              message: 'some-error-messasge',
+            },
+          },
+        })
+      }
+    })
+  })
+})

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -226,9 +226,17 @@ function DeleteCluster(clusterName: any, callback?: Callback) {
 async function ListClusters(): Promise<ClusterInfoSummary[]> {
   var url = 'api?path=/v3/clusters'
   try {
-    const {data} = await request('get', url)
-    setState(['clusters', 'list'], data?.clusters)
-    return data?.clusters || []
+    var response = await request('get', url)
+    var clusters = response.data.clusters
+    while ('nextToken' in response.data) {
+      const body = {
+        nextToken: response.data.nextToken,
+      }
+      response = await request('get', url, body)
+      clusters = clusters.concat(response.data.clusters)
+    }
+    setState(['clusters', 'list'], clusters)
+    return clusters || []
   } catch (error) {
     if ((error as any).response) {
       notify(`Error: ${(error as any).response.data.message}`, 'error')

--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -229,10 +229,8 @@ async function ListClusters(): Promise<ClusterInfoSummary[]> {
     var response = await request('get', url)
     var clusters = response.data.clusters
     while ('nextToken' in response.data) {
-      const body = {
-        nextToken: response.data.nextToken,
-      }
-      response = await request('get', url, body)
+      const urlToken = `${url}&nextToken=${response.data.nextToken}`
+      response = await request('get', urlToken)
       clusters = clusters.concat(response.data.clusters)
     }
     setState(['clusters', 'list'], clusters)


### PR DESCRIPTION
## Changes
* Paginate list clusters since it's possible that some of the clusters don't show up since previously did not paginate
* Added unit tests for testing listing clusters
* We want to use a URL instead of a body in the GET request because: https://stackoverflow.com/questions/978061/http-get-with-request-body
<!-- List of relevant changes introduced -->

## How Has This Been Tested?

Deployed in personal account, created and deleted clusters
Wrote and ran unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
