### PR TITLE
[Dependencies] Delete unused python-jose dependency

### DIFF
--- a/frontend/resources/attributions/npm-python-attributions.txt
+++ b/frontend/resources/attributions/npm-python-attributions.txt
@@ -5868,35 +5868,6 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-ecdsa
-0.18.0
-MIT
-"python-ecdsa" Copyright (c) 2010 Brian Warner
-
-Portions written in 2005 by Peter Pearson and placed in the public domain.
-
-Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation
-files (the "Software"), to deal in the Software without
-restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-
 idna
 3.4
 BSD License
@@ -6301,36 +6272,6 @@ MIT License
   SOFTWARE.
 
 
-
-pyasn1
-0.5.0
-BSD License
-Copyright (c) 2005-2020, Ilya Etingof <etingof@gmail.com>
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-  * Redistributions of source code must retain the above copyright notice, 
-    this list of conditions and the following disclaimer.
-
-  * Redistributions in binary form must reproduce the above copyright notice,
-    this list of conditions and the following disclaimer in the documentation
-    and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE. 
-
-
 pyproject_hooks
 1.0.0
 MIT License
@@ -6466,32 +6407,6 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The above BSD License Applies to all code, even that also covered by Apache 2.0.
-
-python-jose
-3.3.0
-MIT License
-The MIT License (MIT)
-
-Copyright (c) 2015 Michael Davis
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 
 
 requests
@@ -6672,24 +6587,6 @@ Apache Software License
       defend, and hold each Contributor harmless for any liability
       incurred by, or claims asserted against, such Contributor by reason
       of your accepting any such warranty or additional liability.
-
-
-rsa
-4.9
-Apache Software License
-Copyright 2011 Sybren A. Stüvel <sybren@stuvel.eu>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 
 
 s3transfer

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,6 @@ Werkzeug==2.3.8
 boto3==1.24.30
 requests==2.31.0
 urllib3==1.26.18
-python-jose==3.3.0
 PyYAML==6.0
 pytest==7.2.2
 pytest-mock==3.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,6 @@ charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via flask
-ecdsa==0.18.0
-    # via python-jose
 exceptiongroup==1.1.1
     # via pytest
 flask==2.1.2
@@ -58,10 +56,6 @@ packaging==23.1
     #   pytest
 pluggy==1.0.0
     # via pytest
-pyasn1==0.5.0
-    # via
-    #   python-jose
-    #   rsa
 pytest==7.2.2
     # via
     #   -r requirements.in
@@ -70,19 +64,14 @@ pytest-mock==3.8.2
     # via -r requirements.in
 python-dateutil==2.8.2
     # via botocore
-python-jose==3.3.0
-    # via -r requirements.in
 pyyaml==6.0
     # via -r requirements.in
 requests==2.31.0
     # via -r requirements.in
-rsa==4.9
-    # via python-jose
 s3transfer==0.6.1
     # via boto3
 six==1.16.0
     # via
-    #   ecdsa
     #   flask-cors
     #   python-dateutil
 tomli==2.0.1


### PR DESCRIPTION
## Changes

<!-- List of relevant changes introduced -->
* Delete `python-jose` dependency. Looked through codebase and didn't find any usages of `python-jose` or any of its dependencies (ecdsa, pyasn1, rsa)
* Deleted in order to delete dependency on ecdsa, which has a CVE that they don't intend to fix: https://github.com/aws/aws-parallelcluster-ui/security/dependabot/29
* Deleted the relevant sections in attribution doc

## How Has This Been Tested?

Ran pytest, deployed, created and deleted cluster

<!-- The tests you ran to verify your changes -->

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
