### PR TITLE
[Dependencies] Add cryptography backend for python-jose

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ Werkzeug==2.3.8
 boto3==1.24.30
 requests==2.31.0
 urllib3==1.26.18
-python-jose==3.3.0
+python-jose[cryptography]==3.3.0
 PyYAML==6.0
 pytest==7.2.2
 pytest-mock==3.8.2

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ Werkzeug==2.3.8
 boto3==1.24.30
 requests==2.31.0
 urllib3==1.26.18
+# Installing cryptography backend since it is the recommended one: https://pypi.org/project/python-jose/
 python-jose[cryptography]==3.3.0
 PyYAML==6.0
 pytest==7.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,10 +16,14 @@ certifi==2023.7.22
     # via
     #   -r requirements.in
     #   requests
+cffi==1.16.0
+    # via cryptography
 charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via flask
+cryptography==42.0.2
+    # via python-jose
 ecdsa==0.18.0
     # via python-jose
 exceptiongroup==1.1.1
@@ -62,6 +66,8 @@ pyasn1==0.5.0
     # via
     #   python-jose
     #   rsa
+pycparser==2.21
+    # via cffi
 pytest==7.2.2
     # via
     #   -r requirements.in
@@ -70,7 +76,7 @@ pytest-mock==3.8.2
     # via -r requirements.in
 python-dateutil==2.8.2
     # via botocore
-python-jose==3.3.0
+python-jose[cryptography]==3.3.0
     # via -r requirements.in
 pyyaml==6.0
     # via -r requirements.in


### PR DESCRIPTION
## Changes
* Use `python-jose[cryptography]` instead of just `python-jose` to use the cryptography backend instead of `ecdsa` backend
  * Doing this because of this CVE for edcsa that they don't intend to fix: https://github.com/aws/aws-parallelcluster-ui/security/dependabot/29
  * ecdsa will still be installed, but will be unused, since cryptography will be used instead: https://pypi.org/project/python-jose/

## How Has This Been Tested?

Ran pytest, deployed, created/deleted cluster

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
