### PR TITLE
[Dependencies] Remove unused python-jose dependencies from requirements.txt

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ boto3==1.24.30
 requests==2.31.0
 urllib3==1.26.18
 # Installing cryptography backend since it is the recommended one: https://pypi.org/project/python-jose/
+# This will install unused dependencies ecdsa, rsa, and pyasn1. Please remove from requirements.txt if it is there
 python-jose[cryptography]==3.3.0
 PyYAML==6.0
 pytest==7.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,8 +26,6 @@ click==8.1.3
     # via flask
 cryptography==42.0.2
     # via python-jose
-ecdsa==0.18.0
-    # via python-jose
 exceptiongroup==1.1.1
     # via pytest
 flask==2.3.3
@@ -64,10 +62,6 @@ packaging==23.1
     #   pytest
 pluggy==1.0.0
     # via pytest
-pyasn1==0.5.0
-    # via
-    #   python-jose
-    #   rsa
 pycparser==2.21
     # via cffi
 pytest==7.2.2
@@ -84,8 +78,6 @@ pyyaml==6.0
     # via -r requirements.in
 requests==2.31.0
     # via -r requirements.in
-rsa==4.9
-    # via python-jose
 s3transfer==0.6.1
     # via boto3
 six==1.16.0


### PR DESCRIPTION
## Changes
- Removed ecdsa, rsa, and pyasn1 from requirements.txt
  - After this [PR to change backend](https://github.com/aws/aws-parallelcluster-ui/pull/311) of python-jose, ecdsa, rsa, and pyasn1 are installed but unused. https://pypi.org/project/python-jose/
- Added comment to remove those dependencies for if in the future people run `pip-compile` and those dependencies appear in requirements.txt again
<!-- List of relevant changes introduced -->

## How Has This Been Tested?
Deployed in personal acc, created/deleted cluster
<!-- The tests you ran to verify your changes -->

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
