### PR TITLE
[Dependencies] Bump pcluster version to 3.9.0 in cfn create args

### DIFF
--- a/infrastructure/environments/demo-cfn-create-args.yaml
+++ b/infrastructure/environments/demo-cfn-create-args.yaml
@@ -3,7 +3,7 @@ Parameters:
   - ParameterKey: AdminUserEmail
     ParameterValue: my@email.com
   - ParameterKey: Version
-    ParameterValue: 3.8.0
+    ParameterValue: 3.9.0
   - ParameterKey: InfrastructureBucket
     ParameterValue: BUCKET_URL_PLACEHOLDER
   - ParameterKey: PublicEcrImageUri


### PR DESCRIPTION
## Changes
- Bumps pcluster version in cfn create args, missed to bump the pcluster version here from this PR https://github.com/aws/aws-parallelcluster-ui/pull/316
<!-- List of relevant changes introduced -->
In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
