### PR TITLE
Add support for Ubuntu2204 and Rhel9 in PCUI, deprecate Ubuntu1804

### DIFF
--- a/frontend/src/__tests__/util.test.tsx
+++ b/frontend/src/__tests__/util.test.tsx
@@ -44,14 +44,6 @@ describe('Given a function to get the default cluster user', () => {
     })
   })
 
-  describe('when the OS is Ubuntu 18.04', () => {
-    const cluster = {config: {Image: {Os: 'ubuntu1804'}}}
-    it('should be ec2-user', () => {
-      const result = clusterDefaultUser(cluster)
-      expect(result).toBe('ubuntu')
-    })
-  })
-
   describe('when the OS is Ubuntu 20.04', () => {
     const cluster = {config: {Image: {Os: 'ubuntu2004'}}}
     it('should be ubuntu', () => {

--- a/frontend/src/__tests__/util.test.tsx
+++ b/frontend/src/__tests__/util.test.tsx
@@ -44,6 +44,14 @@ describe('Given a function to get the default cluster user', () => {
     })
   })
 
+  describe('when the OS is Ubuntu 18.04', () => {
+    const cluster = {config: {Image: {Os: 'ubuntu1804'}}}
+    it('should be ubuntu', () => {
+      const result = clusterDefaultUser(cluster)
+      expect(result).toBe('ubuntu')
+    })
+  })
+
   describe('when the OS is Ubuntu 20.04', () => {
     const cluster = {config: {Image: {Os: 'ubuntu2004'}}}
     it('should be ubuntu', () => {
@@ -65,6 +73,22 @@ describe('Given a function to get the default cluster user', () => {
     it('should be centos', () => {
       const result = clusterDefaultUser(cluster)
       expect(result).toBe('centos')
+    })
+  })
+
+  describe('when the OS is Rhel 8', () => {
+    const cluster = {config: {Image: {Os: 'rhel8'}}}
+    it('should be ec2-user', () => {
+      const result = clusterDefaultUser(cluster)
+      expect(result).toBe('ec2-user')
+    })
+  })
+
+  describe('when the OS is Rhel 9', () => {
+    const cluster = {config: {Image: {Os: 'rhel9'}}}
+    it('should be ec2-user', () => {
+      const result = clusterDefaultUser(cluster)
+      expect(result).toBe('ec2-user')
     })
   })
 })

--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -25,7 +25,10 @@ describe('given a feature flags provider and a list of rules', () => {
   describe('when the version is between 3.1.0 and 3.2.0', () => {
     it('should return the list of available features', async () => {
       const features = await subject('3.1.5', region)
-      expect(features).toEqual<AvailableFeature[]>(['multiuser_cluster'])
+      expect(features).toEqual<AvailableFeature[]>([
+        'ubuntu1804',
+        'multiuser_cluster',
+      ])
     })
   })
 
@@ -33,6 +36,7 @@ describe('given a feature flags provider and a list of rules', () => {
     it('should return the list of available features', async () => {
       const features = await subject('3.2.5', region)
       expect(features).toEqual<AvailableFeature[]>([
+        'ubuntu1804',
         'multiuser_cluster',
         'fsx_ontap',
         'fsx_openzsf',
@@ -49,6 +53,7 @@ describe('given a feature flags provider and a list of rules', () => {
     it('should return the list of available features', async () => {
       const features = await subject('3.3.2', region)
       expect(features).toEqual<AvailableFeature[]>([
+        'ubuntu1804',
         'multiuser_cluster',
         'fsx_ontap',
         'fsx_openzsf',
@@ -71,6 +76,7 @@ describe('given a feature flags provider and a list of rules', () => {
     it('should return the list of available features', async () => {
       const features = await subject('3.4.1', region)
       expect(features).toEqual<AvailableFeature[]>([
+        'ubuntu1804',
         'multiuser_cluster',
         'fsx_ontap',
         'fsx_openzsf',
@@ -95,6 +101,7 @@ describe('given a feature flags provider and a list of rules', () => {
     it('should return the list of available features', async () => {
       const features = await subject('3.6.1', region)
       expect(features).toEqual<AvailableFeature[]>([
+        'ubuntu1804',
         'multiuser_cluster',
         'fsx_ontap',
         'fsx_openzsf',
@@ -139,7 +146,7 @@ describe('given a feature flags provider and a list of rules', () => {
         'on_node_updated',
         'rhel8',
         'new_resources_limits',
-        'ubuntu22',
+        'ubuntu2204',
         'login_nodes',
         'amazon_file_cache',
         'job_exclusive_allocation',
@@ -156,6 +163,7 @@ describe('given a feature flags provider and a list of rules', () => {
     it('should be included in the list of features', async () => {
       const features = await subject('3.1.5', region)
       expect(features).toEqual<AvailableFeature[]>([
+        'ubuntu1804',
         'multiuser_cluster',
         'cost_monitoring',
       ])
@@ -168,7 +176,17 @@ describe('given a feature flags provider and a list of rules', () => {
     })
     it('should not be included in the list of features', async () => {
       const features = await subject('3.1.5', region)
-      expect(features).toEqual<AvailableFeature[]>(['multiuser_cluster'])
+      expect(features).toEqual<AvailableFeature[]>([
+        'ubuntu1804',
+        'multiuser_cluster',
+      ])
+    })
+  })
+
+  describe('when a feature has been deprecated', () => {
+    it('should return the list of available features without the unsupported feature', async () => {
+      const features = await subject('3.7.1', region)
+      expect(features).not.toContain<AvailableFeature[]>(['ubuntu1804'])
     })
   })
 

--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -124,9 +124,9 @@ describe('given a feature flags provider and a list of rules', () => {
     })
   })
 
-  describe('when the version is above and 3.7.0', () => {
+  describe('when the version is between 3.7.0 and 3.9.0', () => {
     it('should return the list of available features', async () => {
-      const features = await subject('3.7.0', region)
+      const features = await subject('3.8.0', region)
       expect(features).toEqual<AvailableFeature[]>([
         'multiuser_cluster',
         'fsx_ontap',
@@ -151,6 +151,38 @@ describe('given a feature flags provider and a list of rules', () => {
         'amazon_file_cache',
         'job_exclusive_allocation',
         'memory_based_scheduling_with_multiple_instance_types',
+      ])
+    })
+  })
+
+  describe('when the version is at or above 3.9.0', () => {
+    it('should return the list of available features', async () => {
+      const features = await subject('3.9.0', region)
+      expect(features).toEqual<AvailableFeature[]>([
+        'multiuser_cluster',
+        'fsx_ontap',
+        'fsx_openzsf',
+        'lustre_persistent2',
+        'memory_based_scheduling',
+        'slurm_queue_update_strategy',
+        'ebs_deletion_policy',
+        'cost_monitoring',
+        'slurm_accounting',
+        'queues_multiple_instance_types',
+        'dynamic_fs_mount',
+        'efs_deletion_policy',
+        'lustre_deletion_policy',
+        'imds_support',
+        'multi_az',
+        'on_node_updated',
+        'rhel8',
+        'new_resources_limits',
+        'ubuntu2204',
+        'login_nodes',
+        'amazon_file_cache',
+        'job_exclusive_allocation',
+        'memory_based_scheduling_with_multiple_instance_types',
+        'rhel9',
       ])
     })
   })

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -41,6 +41,7 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
     'job_exclusive_allocation',
     'memory_based_scheduling_with_multiple_instance_types',
   ],
+  '3.9.0': ['rhel9'],
 }
 
 const featureToDeperecatedVersionMap: Partial<

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -11,6 +11,8 @@
 import {AvailableFeature} from './types'
 
 const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
+  // Placing ubuntu1804 here to be counted as a feature flag, so it can be deprecated
+  '3.0.0': ['ubuntu1804'],
   '3.1.0': ['multiuser_cluster'],
   '3.2.0': [
     'fsx_ontap',
@@ -33,12 +35,30 @@ const versionToFeaturesMap: Record<string, AvailableFeature[]> = {
   '3.4.0': ['multi_az', 'on_node_updated'],
   '3.6.0': ['rhel8', 'new_resources_limits'],
   '3.7.0': [
-    'ubuntu22',
+    'ubuntu2204',
     'login_nodes',
     'amazon_file_cache',
     'job_exclusive_allocation',
     'memory_based_scheduling_with_multiple_instance_types',
   ],
+}
+
+const featureToDeperecatedVersionMap: Partial<
+  Record<AvailableFeature, string>
+> = {
+  ubuntu1804: '3.7.0',
+}
+
+function isNotDeprecated(
+  feature: AvailableFeature,
+  currentVersion: string,
+): boolean {
+  if (feature in featureToDeperecatedVersionMap) {
+    if (currentVersion >= featureToDeperecatedVersionMap[feature]!) {
+      return false
+    }
+  }
+  return true
 }
 
 const featureToUnsupportedRegionsMap: Partial<
@@ -87,4 +107,5 @@ export function featureFlagsProvider(
     .concat(composeFlagsListByVersion(version))
     .concat(additionalFeaturesParsed)
     .filter(feature => isSupportedInRegion(feature, region))
+    .filter(feature => isNotDeprecated(feature, version))
 }

--- a/frontend/src/feature-flags/types.ts
+++ b/frontend/src/feature-flags/types.ts
@@ -34,3 +34,4 @@ export type AvailableFeature =
   | 'amazon_file_cache'
   | 'job_exclusive_allocation'
   | 'memory_based_scheduling_with_multiple_instance_types'
+  | 'rhel9'

--- a/frontend/src/feature-flags/types.ts
+++ b/frontend/src/feature-flags/types.ts
@@ -10,6 +10,7 @@
 
 // We must track here the features that may be under feature flagging in the wizard.
 export type AvailableFeature =
+  | 'ubuntu1804'
   | 'fsx_ontap'
   | 'fsx_openzsf'
   | 'lustre_persistent2'
@@ -28,7 +29,7 @@ export type AvailableFeature =
   | 'rhel8'
   | 'cost_monitoring'
   | 'new_resources_limits'
-  | 'ubuntu22'
+  | 'ubuntu2204'
   | 'login_nodes'
   | 'amazon_file_cache'
   | 'job_exclusive_allocation'

--- a/frontend/src/old-pages/Configure/Cluster/OsFormField.tsx
+++ b/frontend/src/old-pages/Configure/Cluster/OsFormField.tsx
@@ -26,6 +26,7 @@ const SUPPORTED_OSES_LIST: TilesProps.TilesDefinition[] = [
 const UBUNTU18_OS = {value: 'ubuntu1804', label: 'Ubuntu 18.04'}
 const RHEL8_OS = {value: 'rhel8', label: 'Red Hat Enterprise Linux 8'}
 const UBUNTU22_OS = {value: 'ubuntu2204', label: 'Ubuntu 22.04'}
+const RHEL9_OS = {value: 'rhel9', label: 'Red Hat Enterprise Linux 9'}
 
 export function OsFormField() {
   const {t} = useTranslation()
@@ -35,12 +36,13 @@ export function OsFormField() {
   let osesList = useFeatureFlag('rhel8')
     ? SUPPORTED_OSES_LIST.concat(RHEL8_OS)
     : SUPPORTED_OSES_LIST
-  osesList = useFeatureFlag('ubuntu2204')
-    ? osesList.concat(UBUNTU22_OS)
-    : osesList
   osesList = useFeatureFlag('ubuntu1804')
     ? osesList.concat(UBUNTU18_OS)
     : osesList
+  osesList = useFeatureFlag('ubuntu2204')
+    ? osesList.concat(UBUNTU22_OS)
+    : osesList
+  osesList = useFeatureFlag('rhel9') ? osesList.concat(RHEL9_OS) : osesList
   osesList = editing ? osesList.map(os => ({...os, disabled: true})) : osesList
 
   const handleChange: NonCancelableEventHandler<TilesProps.ChangeDetail> =

--- a/frontend/src/old-pages/Configure/Cluster/OsFormField.tsx
+++ b/frontend/src/old-pages/Configure/Cluster/OsFormField.tsx
@@ -21,10 +21,11 @@ const osPath = ['app', 'wizard', 'config', 'Image', 'Os']
 const SUPPORTED_OSES_LIST: TilesProps.TilesDefinition[] = [
   {value: 'alinux2', label: 'Amazon Linux 2'},
   {value: 'centos7', label: 'CentOS 7'},
-  {value: 'ubuntu1804', label: 'Ubuntu 18.04'},
   {value: 'ubuntu2004', label: 'Ubuntu 20.04'},
 ]
+const UBUNTU18_OS = {value: 'ubuntu1804', label: 'Ubuntu 18.04'}
 const RHEL8_OS = {value: 'rhel8', label: 'Red Hat Enterprise Linux 8'}
+const UBUNTU22_OS = {value: 'ubuntu2204', label: 'Ubuntu 22.04'}
 
 export function OsFormField() {
   const {t} = useTranslation()
@@ -34,6 +35,12 @@ export function OsFormField() {
   let osesList = useFeatureFlag('rhel8')
     ? SUPPORTED_OSES_LIST.concat(RHEL8_OS)
     : SUPPORTED_OSES_LIST
+  osesList = useFeatureFlag('ubuntu2204')
+    ? osesList.concat(UBUNTU22_OS)
+    : osesList
+  osesList = useFeatureFlag('ubuntu1804')
+    ? osesList.concat(UBUNTU18_OS)
+    : osesList
   osesList = editing ? osesList.map(os => ({...os, disabled: true})) : osesList
 
   const handleChange: NonCancelableEventHandler<TilesProps.ChangeDetail> =

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -68,7 +68,6 @@ function clusterDefaultUser(cluster: any) {
     alinux2: 'ec2-user',
     ubuntu2204: 'ubuntu',
     ubuntu2004: 'ubuntu',
-    ubuntu1804: 'ubuntu',
     centos7: 'centos',
   }[os]
 }

--- a/frontend/src/util.ts
+++ b/frontend/src/util.ts
@@ -68,7 +68,10 @@ function clusterDefaultUser(cluster: any) {
     alinux2: 'ec2-user',
     ubuntu2204: 'ubuntu',
     ubuntu2004: 'ubuntu',
+    ubuntu1804: 'ubuntu',
     centos7: 'centos',
+    rhel8: 'ec2-user',
+    rhel9: 'ec2-user',
   }[os]
 }
 


### PR DESCRIPTION
## Changes
- Added ubuntu2204 to the UI (the feature flag was already there)
- Aded Rhel9 to the UI and as a feature flag
- Added function to check for deprecation and added ubuntu 1804 as deprecated with 3.7

## How Has This Been Tested?
Deployed in personal account and created clusters with ubuntu2204 and rhe9
![Screenshot 2024-02-22 at 1 41 19 PM](https://github.com/aws/aws-parallelcluster-ui/assets/23422148/852c05cd-d2f5-427e-b7a3-1d620df5a2cd)

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->
- Addresses this issue: https://github.com/aws/aws-parallelcluster-ui/issues/318

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
