### PR TITLE
[Bug] Fix get call with special characters in nextToken in listclusters

### DIFF
--- a/frontend/src/__tests__/ListClusters.test.ts
+++ b/frontend/src/__tests__/ListClusters.test.ts
@@ -23,9 +23,8 @@ const mockCluster2: ClusterInfoSummary = {
 const mockGet = jest.fn()
 
 jest.mock('axios', () => ({
-  create: () => ({
-    get: (...args: unknown[]) => mockGet(...args),
-  }),
+  get: (...args: unknown[]) => mockGet(...args),
+  create: (...args: unknown[]) => jest.fn(),
 }))
 
 describe('given a ListClusters command', () => {


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description
- Found that when paginating the nextToken has special characters that aren't getting sent properly (found there was a problem when I had ~10 clusters spun up from testing)
- The token needs to be encoded properly so I added `encodeURIComponent`
- [Axios has a special parameter `params`](https://github.com/axios/axios?tab=readme-ov-file#request-config) that can handle the special characters
<!-- Summary of what this PR introduces and possibly why -->

<!-- List of relevant changes introduced -->

## How Has This Been Tested?
- Having ~10 clusters up, without this change PCUI breaks. Before adding paginating, it only shows a couple clusters. With this fix, we can see all the clusters without any breaks
- Checked in the logs that PCUI is sending the correct API calls, they send the api calls with the proper nextToken and receive a successful response with the paginated clusters
- Unit tests pass

<!-- The tests you ran to verify your changes -->

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
