### PR TITLE
[Tools] Fix and improve tools used to deploy PCUI for local testing

### DIFF
--- a/scripts/build_and_update_lambda.sh
+++ b/scripts/build_and_update_lambda.sh
@@ -75,3 +75,4 @@ echo "Pushing private docker container..."
 docker push ${IMAGE}
 echo "Updating lambda..."
 aws lambda --region ${REGION} update-function-code --function-name ${LAMBDA_ARN} --image-uri ${IMAGE} --publish >/dev/null
+echo "Lambda updated"

--- a/scripts/build_and_update_lambda.sh
+++ b/scripts/build_and_update_lambda.sh
@@ -50,10 +50,10 @@ function resource_id_from_cf_output {
   echo "$1" | grep "$2" | cut -d " " -f 2
 }
 
-CF_QUERY="StackResources[?LogicalResourceId == 'PrivateEcrRepository' || LogicalResourceId == 'ParallelClusterUIFunction'].{ LogicalResourceId: LogicalResourceId, PhysicalResourceId: PhysicalResourceId }"
+CF_QUERY="StackResources[?LogicalResourceId == 'PrivateEcrRepository' || LogicalResourceId == 'ParallelClusterUIFun'].{ LogicalResourceId: LogicalResourceId, PhysicalResourceId: PhysicalResourceId }"
 CF_OUTPUT=`aws cloudformation describe-stack-resources --stack-name "$STACKNAME" --region "$REGION" --query "$CF_QUERY" --output text | tr '\t' ' '`
 
-LAMBDA_NAME="$(resource_id_from_cf_output "$CF_OUTPUT" "ParallelClusterUIFunction")"
+LAMBDA_NAME="$(resource_id_from_cf_output "$CF_OUTPUT" "ParallelClusterUIFun")"
 LAMBDA_ARN=$(aws lambda --region ${REGION} list-functions --query "Functions[?contains(FunctionName, '$LAMBDA_NAME')] | [0].FunctionArn" | xargs echo)
 
 ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)


### PR DESCRIPTION
## Description
Fix and improve tools used to deploy PCUI for local testing. In particular:
1. Fixed the script used to update the lambda function with local code. It was broken because it was looking for the lambda function using a wrong name.
2. Made deploy.sh able to update the lambda, so that the developer can now deploy local code with a single script. 
3. Added a success log line at the end of the above script to let the user kwno it succeeded.


## How Has This Been Tested?
1. Used both scripts to deploy PCUI for local testing.


## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
