### PR TITLE
[Accounting] Fix issues that were breaking the rendering of accounting info

### DIFF
--- a/frontend/src/model.tsx
+++ b/frontend/src/model.tsx
@@ -879,7 +879,7 @@ function SlurmAccounting(
   request('post', url, args)
     .then((response: any) => {
       if (response.status === 200) {
-        console.log(response.data)
+        console.log("Accounting data retrieved", response.data)
         successCallback && successCallback(response.data)
       }
     })

--- a/frontend/src/old-pages/Clusters/Accounting.tsx
+++ b/frontend/src/old-pages/Clusters/Accounting.tsx
@@ -294,7 +294,7 @@ function JobProperties({job}: any) {
           <SpaceBetween direction="vertical" size="l">
             <ValueWithLabel label="Queue">{job.partition}</ValueWithLabel>
             <ValueWithLabel label="Return Code">
-              {getIn(job, ['exit_code', 'return_code'])}
+              {getIn(job, ['exit_code', 'return_code', 'number'])}
             </ValueWithLabel>
             <ValueWithLabel label="Exit Status">
               {
@@ -384,7 +384,7 @@ export default function ClusterAccounting() {
     clusterName,
     'accounting',
     'jobs',
-  ])
+  ]) || []
 
   React.useEffect(() => {
     refreshAccounting({}, null, true)

--- a/frontend/src/old-pages/Clusters/Accounting.tsx
+++ b/frontend/src/old-pages/Clusters/Accounting.tsx
@@ -266,7 +266,7 @@ function CostEstimate({job}: any) {
 }
 
 function JobProperties({job}: any) {
-  console.log(job)
+  console.log("Processing job properties for job", job)
   return (
     <Container>
       <SpaceBetween direction="vertical" size="l">


### PR DESCRIPTION
## Description

<!-- Summary of what this PR introduces and possibly why -->

## Changes

Fix issues that were breaking the rendering of accounting info
 In particular:
 1. fix the retrieval of compute nodes instance type to determine price estimate;
 2. fix the generation of job properties rendered in the job accounting modal.

Also minor improvements to log lines related to accounting.


![Screenshot 2024-07-15 at 16 01 42](https://github.com/user-attachments/assets/ae6d6c19-94a8-4fe4-8f23-881f665829ea)

## How Has This Been Tested?

Manually deployed and verified that the modal showed the accounting info per job is displayed.


In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
