### PR TITLE
[Feature Flag] Fix a bug in versions comparison that was disabling all PC 3.2.0+ features on PC 3.10.0+.

### DIFF
--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -155,37 +155,40 @@ describe('given a feature flags provider and a list of rules', () => {
     })
   })
 
-  describe('when the version is at or above 3.9.0', () => {
-    it('should return the list of available features', async () => {
-      const features = await subject('3.9.0', region)
-      expect(features).toEqual<AvailableFeature[]>([
-        'multiuser_cluster',
-        'fsx_ontap',
-        'fsx_openzsf',
-        'lustre_persistent2',
-        'memory_based_scheduling',
-        'slurm_queue_update_strategy',
-        'ebs_deletion_policy',
-        'cost_monitoring',
-        'slurm_accounting',
-        'queues_multiple_instance_types',
-        'dynamic_fs_mount',
-        'efs_deletion_policy',
-        'lustre_deletion_policy',
-        'imds_support',
-        'multi_az',
-        'on_node_updated',
-        'rhel8',
-        'new_resources_limits',
-        'ubuntu2204',
-        'login_nodes',
-        'amazon_file_cache',
-        'job_exclusive_allocation',
-        'memory_based_scheduling_with_multiple_instance_types',
-        'rhel9',
-      ])
+  for (const version of ["3.9.0", "3.10.0"]) {
+    describe(`when the version is ${version}`, () => {
+      it('should return the list of available features', async () => {
+        const features = await subject(version, region)
+        expect(features).toEqual<AvailableFeature[]>([
+          'multiuser_cluster',
+          'fsx_ontap',
+          'fsx_openzsf',
+          'lustre_persistent2',
+          'memory_based_scheduling',
+          'slurm_queue_update_strategy',
+          'ebs_deletion_policy',
+          'cost_monitoring',
+          'slurm_accounting',
+          'queues_multiple_instance_types',
+          'dynamic_fs_mount',
+          'efs_deletion_policy',
+          'lustre_deletion_policy',
+          'imds_support',
+          'multi_az',
+          'on_node_updated',
+          'rhel8',
+          'new_resources_limits',
+          'ubuntu2204',
+          'login_nodes',
+          'amazon_file_cache',
+          'job_exclusive_allocation',
+          'memory_based_scheduling_with_multiple_instance_types',
+          'rhel9',
+        ])
+      })
     })
-  })
+  }
+
 
   describe('when an additional feature has been enabled through the browser session storage', () => {
     beforeEach(() => {

--- a/frontend/src/feature-flags/featureFlagsProvider.ts
+++ b/frontend/src/feature-flags/featureFlagsProvider.ts
@@ -50,12 +50,16 @@ const featureToDeperecatedVersionMap: Partial<
   ubuntu1804: '3.7.0',
 }
 
+function isVersionGreaterOrEqualThan(version: string, other: string): boolean {
+  return version != null && version.localeCompare(other, undefined, { numeric: true, sensitivity: 'base' }) >= 0
+}
+
 function isNotDeprecated(
   feature: AvailableFeature,
   currentVersion: string,
 ): boolean {
   if (feature in featureToDeperecatedVersionMap) {
-    if (currentVersion >= featureToDeperecatedVersionMap[feature]!) {
+    if (isVersionGreaterOrEqualThan(currentVersion, featureToDeperecatedVersionMap[feature]!)) {
       return false
     }
   }
@@ -86,7 +90,7 @@ function composeFlagsListByVersion(currentVersion: string): AvailableFeature[] {
   let features: Set<AvailableFeature> = new Set([])
 
   for (let version in versionToFeaturesMap) {
-    if (currentVersion >= version) {
+    if (isVersionGreaterOrEqualThan(currentVersion, version)) {
       features = new Set([...features, ...versionToFeaturesMap[version]])
     }
   }

--- a/frontend/src/feature-flags/useFeatureFlag.ts
+++ b/frontend/src/feature-flags/useFeatureFlag.ts
@@ -24,6 +24,9 @@ export function isFeatureEnabled(
   feature: AvailableFeature,
 ): boolean {
   const features = new Set(featureFlagsProvider(version, region))
-
-  return features.has(feature)
+  const enabled = features.has(feature)
+  if (!enabled) {
+    console.log(`FEATURE FLAG: Feature ${feature} is disabled`)
+  }
+  return enabled
 }


### PR DESCRIPTION
## Description
Fix a bug in feature flagging that was disabling of all PC 3.2.0+ features on PC 3.10.0+.
In particular, we needed to fix the logic that compares semantic versions.

Before this change 3.10.0 and 3.10.1 were considered lower than 3.2.0 and greater than 3.1.0, so every feature between 3.2.0 and 3.9.0 was disabled.
With this fix, feature flags are correct.

Example: the feature flexible instance type was disablòed for 3.10.0 because of the bug.
With the fix it is now enabled (see screenshot)

![Screenshot 2024-07-19 at 17 05 45](https://github.com/user-attachments/assets/8300793b-8922-4306-bd3a-f9c07b988665)

*Note*
There is a package dedicated to semver comparison ([semver](https://www.npmjs.com/package/semver)), but it's not worth it to add an extra dependency for such an easy logic.

## How Has This Been Tested?

1. Unit tests (full suite + one new test covering the buggy case)
2. Deployed in personal account and verified that feature flagging is working for 3.10.1

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
