### PR TITLE
[PCUI] Support On-Demand Capacity Reservations and Capacity Blocks for PCUI

### DIFF
--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -1094,6 +1094,19 @@
         },
         "rootVolume": {
           "title": "Root volume"
+        },
+        "capacityType":{
+          "label": "CapacityType"
+        },
+        "capacityReservationTarget": {
+          "title": "Capacity reservations",
+          "label": "CapacityReservationTarget"
+        },
+        "capacityReservationResourceGroupArn": {
+          "label": "CapacityReservationResourceGroupArn"
+        },
+        "capacityReservationId": {
+          "label": "CapacityReservationId"
         }
       },
       "addQueueButton": {

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -1082,7 +1082,24 @@
             "description": "Prevent multiple threads from running on an EC2 instance core."
           }
         },
-        "enableEfa": "Use EFA"
+        "enableEfa": "Use EFA",
+        "capacityReservationTarget": {
+          "title": "Capacity reservations",
+          "label": "CapacityReservationTarget",
+          "help": {
+            "title": "Capacity Reservations and Capacity Blocks",
+            "description": "Learn how to configure Capacity Reservations and Capacity Blocks in ParallelCluster.",
+            "odcrLink": "Launch instances using On-Demand Capacity Reservations (ODCR)",
+            "capacityBlocksLink": "Launch instances using Capacity Blocks",
+            "note": "When selecting CapacityReservationId, the specified instance type will automatically apply."
+          }
+        },
+        "capacityReservationResourceGroupArn": {
+          "label": "CapacityReservationResourceGroupArn"
+        },
+        "capacityReservationId": {
+          "label": "CapacityReservationId"
+        }
       },
       "advancedOptions": {
         "label": "Advanced options",
@@ -1094,19 +1111,6 @@
         },
         "rootVolume": {
           "title": "Root volume"
-        },
-        "capacityType":{
-          "label": "CapacityType"
-        },
-        "capacityReservationTarget": {
-          "title": "Capacity reservations",
-          "label": "CapacityReservationTarget"
-        },
-        "capacityReservationResourceGroupArn": {
-          "label": "CapacityReservationResourceGroupArn"
-        },
-        "capacityReservationId": {
-          "label": "CapacityReservationId"
         }
       },
       "addQueueButton": {

--- a/frontend/locales/en/strings.json
+++ b/frontend/locales/en/strings.json
@@ -1088,7 +1088,7 @@
           "label": "CapacityReservationTarget",
           "help": {
             "title": "Capacity Reservations and Capacity Blocks",
-            "description": "Learn how to configure Capacity Reservations and Capacity Blocks in ParallelCluster.",
+            "description": "Configure your cluster to use Capacity Reservations or Capacity Blocks for better resource management and availability.",
             "odcrLink": "Launch instances using On-Demand Capacity Reservations (ODCR)",
             "capacityBlocksLink": "Launch instances using Capacity Blocks",
             "note": "When selecting CapacityReservationId, the specified instance type will automatically apply."

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -10,7 +10,7 @@
 // OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Fameworks
+// Frameworks
 import React, {
   ReactElement,
   useCallback,
@@ -677,6 +677,62 @@ function IamPoliciesEditor({basePath}: any) {
   )
 }
 
+function OdcrCbSelect({
+  selectedOption,
+  onChange,
+  inputValue,
+  onInputChange,
+}: {
+  selectedOption: string
+  onChange: (event: any) => void
+  inputValue: string
+  onInputChange: (event: any) => void
+}) {
+  const { t } = useTranslation()
+
+  const options = [
+    { label: 'none', value: 'none' },
+    { label: t('wizard.queues.advancedOptions.capacityReservationId.label'), value: 'capacityReservationId' },
+    { label: t('wizard.queues.advancedOptions.capacityReservationResourceGroupArn.label'), value: 'capacityReservationResourceGroupArn' },
+  ]
+
+  const getPlaceholder = () => {
+    if (selectedOption === 'capacityReservationId') {
+      return "cr-<reservation-id>"
+    }
+    if (selectedOption === 'capacityReservationResourceGroupArn') {
+      return "arn:aws:resource-groups:<region>:<account-id>:group/<resource-group-name>"
+    }
+    return ""
+  }
+
+  return (
+    <SpaceBetween direction="vertical" size="xs">
+      <FormField label={t('wizard.queues.advancedOptions.capacityReservationTarget.label')}>
+        <Select
+          selectedOption={
+            options.find(option => option.value === selectedOption) || {
+              label: 'none',
+              value: 'none',
+            }
+          }
+          onChange={onChange}
+          options={options}
+        />
+      </FormField>
+      {(selectedOption === 'capacityReservationId' || selectedOption === 'capacityReservationResourceGroupArn') && (
+        <FormField label={`${t(`wizard.queues.advancedOptions.${selectedOption}.label`)}`}>
+          <Input
+            placeholder={getPlaceholder()}
+            value={inputValue}
+            onChange={onInputChange}
+          />
+        </FormField>
+      )}
+    </SpaceBetween>
+  )
+}
+
 type HelpTextInputProps = {
   name: string
   path: string[]
@@ -788,4 +844,5 @@ export {
   IamPoliciesEditor,
   HelpTextInput,
   CheckboxWithHelpPanel,
+  OdcrCbSelect,
 }

--- a/frontend/src/old-pages/Configure/Components.tsx
+++ b/frontend/src/old-pages/Configure/Components.tsx
@@ -692,8 +692,8 @@ function OdcrCbSelect({
 
   const options = [
     { label: 'none', value: 'none' },
-    { label: t('wizard.queues.advancedOptions.capacityReservationId.label'), value: 'capacityReservationId' },
-    { label: t('wizard.queues.advancedOptions.capacityReservationResourceGroupArn.label'), value: 'capacityReservationResourceGroupArn' },
+    { label: t('wizard.queues.computeResource.capacityReservationId.label'), value: 'capacityReservationId' },
+    { label: t('wizard.queues.computeResource.capacityReservationResourceGroupArn.label'), value: 'capacityReservationResourceGroupArn' },
   ]
 
   const getPlaceholder = () => {
@@ -708,7 +708,36 @@ function OdcrCbSelect({
 
   return (
     <SpaceBetween direction="vertical" size="xs">
-      <FormField label={t('wizard.queues.advancedOptions.capacityReservationTarget.label')}>
+      <FormField
+        label={t('wizard.queues.computeResource.capacityReservationTarget.label')}
+        info={
+          <InfoLink
+            helpPanel={
+              <TitleDescriptionHelpPanel
+                title={t('wizard.queues.computeResource.capacityReservationTarget.help.title')}
+                description={
+                  <>
+                    <p>{t('wizard.queues.computeResource.capacityReservationTarget.help.description')}</p>
+                    <ul>
+                      <li>
+                        <a href="https://docs.aws.amazon.com/parallelcluster/latest/ug/launch-instances-odcr-v3.html" target="_blank" rel="noopener noreferrer">
+                          {t('wizard.queues.computeResource.capacityReservationTarget.help.odcrLink')}
+                        </a>
+                      </li>
+                      <li>
+                        <a href="https://docs.aws.amazon.com/parallelcluster/latest/ug/launch-instances-capacity-blocks.html" target="_blank" rel="noopener noreferrer">
+                          {t('wizard.queues.computeResource.capacityReservationTarget.help.capacityBlocksLink')}
+                        </a>
+                      </li>
+                    </ul>
+                    <p>{t('wizard.queues.computeResource.capacityReservationTarget.help.note')}</p>
+                  </>
+                }
+              />
+            }
+          />
+        }
+      >
         <Select
           selectedOption={
             options.find(option => option.value === selectedOption) || {
@@ -721,7 +750,7 @@ function OdcrCbSelect({
         />
       </FormField>
       {(selectedOption === 'capacityReservationId' || selectedOption === 'capacityReservationResourceGroupArn') && (
-        <FormField label={`${t(`wizard.queues.advancedOptions.${selectedOption}.label`)}`}>
+        <FormField label={`${t(`wizard.queues.computeResource.${selectedOption}.label`)}`}>
           <Input
             placeholder={getPlaceholder()}
             value={inputValue}

--- a/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {
   ColumnLayout,
   FormField,
@@ -17,6 +18,7 @@ import {clearState, setState, useState} from '../../../store'
 import {
   CheckboxWithHelpPanel,
   HelpTextInput,
+  OdcrCbSelect,
   useInstanceGroups,
 } from '../Components'
 import {
@@ -207,6 +209,26 @@ export function ComputeResource({
       [efaInstances, instanceTypePath, setEnableEFA],
     )
 
+  const [odcrCbOption, setOdcrCbOption] = React.useState('none')
+  const [odcrCbInput, setOdcrCbInput] = React.useState('')
+
+  const capacityReservationTargetPath = useMemo(
+    () => [...path, 'CapacityReservationTarget'],
+    [path],
+  )
+
+  React.useEffect(() => {
+    if (odcrCbOption === 'none') {
+      clearState(capacityReservationTargetPath)
+    } else {
+      const updateData = {
+        CapacityReservationId: odcrCbOption === 'capacityReservationId' ? odcrCbInput : undefined,
+        CapacityReservationResourceGroupArn: odcrCbOption === 'capacityReservationResourceGroupArn' ? odcrCbInput : undefined,
+      }
+      setState(capacityReservationTargetPath, updateData)
+    }
+  }, [odcrCbOption, odcrCbInput])
+
   return (
     <SpaceBetween direction="vertical" size="s">
       <div className={componentsStyle['space-between-wrap']}>
@@ -282,6 +304,17 @@ export function ComputeResource({
         )}
       </ColumnLayout>
       <SpaceBetween direction="vertical" size="s">
+        <OdcrCbSelect
+          selectedOption={odcrCbOption}
+          onChange={({detail}) => {
+            setOdcrCbOption(detail.selectedOption.value)
+            if (detail.selectedOption.value === 'none') {
+              setOdcrCbInput('')
+            }
+          }}
+          inputValue={odcrCbInput}
+          onInputChange={({detail}) => setOdcrCbInput(detail.value)}
+        />
         <CheckboxWithHelpPanel
           checked={multithreadingDisabled}
           disabled={hpcInstanceSelected}

--- a/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
@@ -273,6 +273,7 @@ export function ComputeResource({
             />
           </FormField>
         </SpaceBetween>
+        {/* Render the instance type selection field only when 'capacityReservationId' is not selected */}
         {odcrCbOption !== 'capacityReservationId' && (
           <FormField
             label={t('wizard.queues.computeResource.instanceType.label')}

--- a/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
@@ -226,6 +226,10 @@ export function ComputeResource({
         CapacityReservationResourceGroupArn: odcrCbOption === 'capacityReservationResourceGroupArn' ? odcrCbInput : undefined,
       }
       setState(capacityReservationTargetPath, updateData)
+
+      if (odcrCbOption === 'capacityReservationId') {
+        clearState(instanceTypePath)
+      }
     }
   }, [odcrCbOption, odcrCbInput])
 
@@ -269,24 +273,26 @@ export function ComputeResource({
             />
           </FormField>
         </SpaceBetween>
-        <FormField
-          label={t('wizard.queues.computeResource.instanceType.label')}
-          errorText={typeError}
-        >
-          <Multiselect
-            selectedOptions={instances.map(instance => ({
-              value: instance.InstanceType,
-              label: instance.InstanceType,
-            }))}
-            placeholder={t(
-              'wizard.queues.computeResource.instanceType.placeholder.multiple',
-            )}
-            tokenLimit={3}
-            onChange={setInstances}
-            options={instanceOptions}
-            filteringType="auto"
-          />
-        </FormField>
+        {odcrCbOption !== 'capacityReservationId' && (
+          <FormField
+            label={t('wizard.queues.computeResource.instanceType.label')}
+            errorText={typeError}
+          >
+            <Multiselect
+              selectedOptions={instances.map(instance => ({
+                value: instance.InstanceType,
+                label: instance.InstanceType,
+              }))}
+              placeholder={t(
+                'wizard.queues.computeResource.instanceType.placeholder.multiple',
+              )}
+              tokenLimit={3}
+              onChange={setInstances}
+              options={instanceOptions}
+              filteringType="auto"
+            />
+          </FormField>
+        )}
         {enableMemoryBasedScheduling && (
           <HelpTextInput
             name={t('wizard.queues.schedulableMemory.name')}

--- a/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
+++ b/frontend/src/old-pages/Configure/Queues/MultiInstanceComputeResource.tsx
@@ -386,7 +386,10 @@ export function validateComputeResources(
   computeResources: MultiInstanceComputeResource[],
 ): [boolean, QueueValidationErrors] {
   let errors = computeResources.reduce<QueueValidationErrors>((acc, cr, i) => {
-    if (!cr.Instances || !cr.Instances.length) {
+    const hasCapacityReservationId = cr.CapacityReservationTarget?.CapacityReservationId
+
+    // Skip instance type validation if CapacityReservationId is set
+    if (!hasCapacityReservationId && (!cr.Instances || !cr.Instances.length)) {
       acc[i] = 'instance_types_empty'
     }
     return acc

--- a/frontend/src/old-pages/Configure/Queues/Queues.tsx
+++ b/frontend/src/old-pages/Configure/Queues/Queues.tsx
@@ -39,7 +39,6 @@ import {
   SecurityGroups,
   IamPoliciesEditor,
   SubnetSelect,
-  OdcrCbSelect,
 } from '../Components'
 import {Trans, useTranslation} from 'react-i18next'
 import {SlurmMemorySettings, validateSlurmSettings} from './SlurmMemorySettings'
@@ -406,23 +405,6 @@ function Queue({index}: any) {
   const subnetsList = useState(subnetPath) || []
   const isMultiAZActive = useFeatureFlag('multi_az')
 
-  const [odcrCbOption, setOdcrCbOption] = React.useState('none')
-  const [odcrCbInput, setOdcrCbInput] = React.useState('')
-
-  const capacityReservationTargetPath = [...queuesPath, index, 'CapacityReservationTarget']
-
-  React.useEffect(() => {
-    if (odcrCbOption === 'none') {
-      clearState(capacityReservationTargetPath)
-    } else {
-      const updateData = {
-        CapacityReservationId: odcrCbOption === 'capacityReservationId' ? odcrCbInput : undefined,
-        CapacityReservationResourceGroupArn: odcrCbOption === 'capacityReservationResourceGroupArn' ? odcrCbInput : undefined,
-      }
-      setState(capacityReservationTargetPath, updateData)
-    }
-  }, [odcrCbOption, odcrCbInput])
-
   React.useEffect(() => {
     if (capacityType === 'CAPACITY_BLOCK') {
       clearState(allocationStrategyPath)
@@ -600,20 +582,6 @@ function Queue({index}: any) {
               {t('wizard.queues.advancedOptions.iamPolicies.label')}
             </Header>
             <IamPoliciesEditor basePath={[...queuesPath, index]} />
-            <Header variant="h3">
-              {t('wizard.queues.advancedOptions.capacityReservationTarget.title')}
-            </Header>
-            <OdcrCbSelect
-                selectedOption={odcrCbOption}
-                onChange={({ detail }) => {
-                  setOdcrCbOption(detail.selectedOption.value)
-                  if (detail.selectedOption.value === 'none') {
-                    setOdcrCbInput('')
-                  }
-                }}
-                inputValue={odcrCbInput}
-                onInputChange={({ detail }) => setOdcrCbInput(detail.value)}
-            />
           </SpaceBetween>
         </ExpandableSection>
       }

--- a/frontend/src/old-pages/Configure/Queues/SlurmMemorySettings.tsx
+++ b/frontend/src/old-pages/Configure/Queues/SlurmMemorySettings.tsx
@@ -60,7 +60,7 @@ const hasMultipleInstanceTypes = (queues: Queue[]): boolean => {
         computeResources.map(computeResource => computeResource.Instances),
       )
       .flat()
-      .filter(instances => instances.length > 1).length > 0
+      .filter(instances => instances && instances.length > 1).length > 0
   )
 }
 

--- a/frontend/src/old-pages/Configure/Queues/queues.mapper.ts
+++ b/frontend/src/old-pages/Configure/Queues/queues.mapper.ts
@@ -15,7 +15,7 @@ import {
 } from './queues.types'
 
 function mapComputeResource(
-    computeResource: SingleInstanceComputeResource | MultiInstanceComputeResource,
+  computeResource: SingleInstanceComputeResource | MultiInstanceComputeResource,
 ): MultiInstanceComputeResource {
   // If it's already a MultiInstanceComputeResource and Instances exist, return it directly
   if ('Instances' in computeResource && computeResource.Instances?.length) {

--- a/frontend/src/old-pages/Configure/Queues/queues.mapper.ts
+++ b/frontend/src/old-pages/Configure/Queues/queues.mapper.ts
@@ -15,21 +15,31 @@ import {
 } from './queues.types'
 
 function mapComputeResource(
-  computeResource: SingleInstanceComputeResource | MultiInstanceComputeResource,
+    computeResource: SingleInstanceComputeResource | MultiInstanceComputeResource,
 ): MultiInstanceComputeResource {
-  if ('Instances' in computeResource) {
+  // If it's already a MultiInstanceComputeResource and Instances exist, return it directly
+  if ('Instances' in computeResource && computeResource.Instances?.length) {
     return computeResource
   }
 
-  const {InstanceType, ...otherComputeResourceConfig} = computeResource
+  // If it's of SingleInstanceComputeResource type, convert it to MultiInstanceComputeResource
+  if ('InstanceType' in computeResource) {
+    const {InstanceType, ...otherComputeResourceConfig} = computeResource
 
+    return {
+      ...otherComputeResourceConfig,
+      Instances: [
+        {
+          InstanceType,
+        },
+      ],
+    }
+  }
+
+  // If Instances are cleared or do not exist, return the other configurations
+  const {Instances, ...otherComputeResourceConfig} = computeResource
   return {
     ...otherComputeResourceConfig,
-    Instances: [
-      {
-        InstanceType,
-      },
-    ],
   }
 }
 

--- a/frontend/src/old-pages/Configure/Queues/queues.types.ts
+++ b/frontend/src/old-pages/Configure/Queues/queues.types.ts
@@ -27,7 +27,7 @@ export type AllocationStrategy = 'lowest-price' | 'capacity-optimized'
 export type ComputeResourceInstance = {InstanceType: string}
 
 export type MultiInstanceComputeResource = ComputeResource & {
-  Instances: ComputeResourceInstance[]
+  Instances?: ComputeResourceInstance[]
 }
 
 export type Tag = {

--- a/frontend/src/old-pages/Configure/Queues/queues.types.ts
+++ b/frontend/src/old-pages/Configure/Queues/queues.types.ts
@@ -26,8 +26,14 @@ export type AllocationStrategy = 'lowest-price' | 'capacity-optimized'
 
 export type ComputeResourceInstance = {InstanceType: string}
 
+export type CapacityReservationTarget = {
+  CapacityReservationId?: string
+  CapacityReservationResourceGroupArn?: string
+}
+
 export type MultiInstanceComputeResource = ComputeResource & {
   Instances?: ComputeResourceInstance[]
+  CapacityReservationTarget?: CapacityReservationTarget
 }
 
 export type Tag = {


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description
feat: Support ODCR(On-Demand Capacity Reservations) and CB(Capacity Blocks) for PCUI

<!-- Summary of what this PR introduces and possibly why -->

## Changes
- Added `CapacityReservationTarget` select component at the compute resource level, allowing users to choose between `CapacityReservationId`, `CapacityReservationResourceGroupArn`, or none.
- Implemented dynamic placeholders to guide users on the required inputs for `CapacityReservationId` and `CapacityReservationResourceGroupArn`.
- Introduced `CAPACITY_BLOCK` as a new purchase type option in the UI.
- Automatically hide the Allocation Strategy selection when `CAPACITY_BLOCK` is selected, following the expected behavior in ParallelCluster.
- Implemented logic to automatically hide the instance type selection and exclude the `Instances` section in the YAML when `CapacityReservationId` is selected.
- Made the `Instances` property of `MultiInstanceComputeResource` optional.
- Updated the mechanism in `queues.mapper.ts` to resolve the conversion conflict.
- Added `CapacityReservationTarget` in queue types.
- Updated `validateComputeResources` to adapt to the new changes, allowing `Instances` to be empty if `CapacityReservationId` is selected. 
- Added info panel for Capacity Reservation and Capacity Block, included documentation links and note on instance type usage.

#### Note:

ParallelCluster supports `CapacityReservationTarget` at both the queue and compute resource levels. However, the official documentation ([Launch Instances into On-Demand Capacity Reservations (ODCR) - ParallelCluster](https://docs.aws.amazon.com/parallelcluster/latest/ug/launch-instances-odcr-v3.html), [Launch Instances Using Capacity Blocks - ParallelCluster](https://docs.aws.amazon.com/parallelcluster/latest/ug/launch-instances-capacity-blocks.html)) recommends managing `CapacityReservationTarget` at the compute resource level. If `CapacityReservationTarget` is specified at both the queue and compute resource levels, the compute resource level option overrides the queue level option. 

Implementing `CapacityReservationTarget` at the queue level is unnecessary, as it adds complexity and requires significant refactoring due to internal PCUI mechanisms that conflict with this implementation. The decision not to implement `CapacityReservationTarget` at the queue level does not impact customers, given that control at the compute resource level aligns with best practices and recommendations.


<!-- List of relevant changes introduced -->

## How Has This Been Tested?

Manually test passed, and worked as expected.

<!-- The tests you ran to verify your changes -->

## References
[Launch Instances into On-Demand Capacity Reservations (ODCR) - ParallelCluster](https://docs.aws.amazon.com/parallelcluster/latest/ug/launch-instances-odcr-v3.html)
[Launch Instances Using Capacity Blocks - ParallelCluster](https://docs.aws.amazon.com/parallelcluster/latest/ug/launch-instances-capacity-blocks.html)
[aws parallelcluster Scheduling section](https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html)
<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
