### PR TITLE
Add support for g6 and m7 family instances.

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -556,7 +556,7 @@ def get_instance_types():
     filters = [
         {"Name": "current-generation", "Values": ["true"]},
         {"Name": "instance-type",
-         "Values": ["c5*", "c6*", "c7*", "g4*", "g5*", "hpc*", "p3*", "p4*", "t2*", "t3*", "m6*", "r*"]},
+         "Values": ["c5*", "c6*", "c7*", "g4*", "g5*", "g6*", "hpc*", "p3*", "p4*", "t2*", "t3*", "m6*", "m7*", "r*"]},
     ]
     instance_paginator = ec2.get_paginator("describe_instance_types")
     instances_paginator = instance_paginator.paginate(Filters=filters)


### PR DESCRIPTION
## Description

Some AWS Regions have G6 and M7 instances deployed. This change adds support for those.

## Changes

Add G6 and M7 instances to drop down menu.

## How Has This Been Tested?

My colleagues have been using the m7i instance type for their head nodes for a few months without any issues. 

## References

https://aws.amazon.com/ec2/instance-types/g6/
https://aws.amazon.com/ec2/instance-types/m7a/
https://aws.amazon.com/ec2/instance-types/m7i/

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
