### PR TITLE
[Custom Domain] Improve user experience to configure custom domain

### DIFF
--- a/infrastructure/environments/demo-cfn-create-args.yaml
+++ b/infrastructure/environments/demo-cfn-create-args.yaml
@@ -33,7 +33,13 @@ Parameters:
 #  - ParameterKey: IAMRoleAndPolicyPrefix
 #    ParameterValue: xxxxxxxxxx
 #  - ParameterKey: CustomDomain
-#    ParameterValue: xxxxxxxxxx
+#    ParameterValue: pcui.example.com
+#  - ParameterKey: CustomDomainCertificateArn
+#    ParameterValue: arn:<PARTITION>:acm:<REGION>:<ACCOUNT>:certificate/<CERTIFICATE_ID>
+#  - ParameterKey: CognitoCustomDomain
+#    ParameterValue: auth-pcui.example.com
+#  - ParameterKey: CognitoCustomDomainCertificateArn
+#    ParameterValue: arn:<PARTITION>:acm:<REGION>:<ACCOUNT>:certificate/<CERTIFICATE_ID>
 Capabilities:
   - CAPABILITY_AUTO_EXPAND
   - CAPABILITY_NAMED_IAM

--- a/infrastructure/environments/demo-cfn-update-args.yaml
+++ b/infrastructure/environments/demo-cfn-update-args.yaml
@@ -34,6 +34,12 @@ Parameters:
     UsePreviousValue: true
   - ParameterKey: CustomDomain
     UsePreviousValue: true
+  - ParameterKey: CustomDomainCertificateArn
+    UsePreviousValue: true
+  - ParameterKey: CognitoCustomDomain
+    UsePreviousValue: true
+  - ParameterKey: CognitoCustomDomainCertificateArn
+    UsePreviousValue: true
 Capabilities:
   - CAPABILITY_AUTO_EXPAND
   - CAPABILITY_NAMED_IAM

--- a/infrastructure/parallelcluster-ui-cognito.yaml
+++ b/infrastructure/parallelcluster-ui-cognito.yaml
@@ -17,10 +17,19 @@ Parameters:
     Description: 'Prefix applied to the name of every IAM role and policy (max length: 10)'
     Default: ''
     MaxLength: 10
+  CustomDomain:
+    Type: String
+    Description: (Optional) Custom domain name. If omitted, the default domain name will be used.
+    Default: ''
+  CustomDomainCertificateArn:
+    Type: String
+    Description: '(Optional) ARN of the ACM Certificate issued for the custom domain. This is required only if `CustomDomain` is specified.'
+    Default: ''
 
 Conditions:
   GovCloud: !Equals [!Ref AWS::Region, 'us-gov-west-1']
   UsePermissionBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryPolicy, '' ] ]
+  UseCustomDomain: !Not [!Equals [!Ref CustomDomain, '']]
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -34,6 +43,11 @@ Metadata:
         Parameters:
           - IAMRoleAndPolicyPrefix
           - PermissionsBoundaryPolicy
+      - Label:
+          default: (Optional) Custom Domain
+        Parameters:
+          - CustomDomain
+          - CustomDomainCertificateArn
     ParameterLabels:
       AdminUserEmail:
         default: Initial Admin's Email
@@ -73,7 +87,14 @@ Resources:
     Type: AWS::Cognito::UserPoolDomain
     Properties:
       UserPoolId: !Ref CognitoUserPool
-      Domain: !Join [ "-", ["pcui-auth", !Select [2, !Split [ "/", !Ref 'AWS::StackId']]]]
+      Domain: !If
+        - UseCustomDomain
+        - !Ref CustomDomain
+        - !Join [ "-", ["pcui-auth", !Select [2, !Split [ "/", !Ref 'AWS::StackId']]]]
+      CustomDomainConfig: !If
+        - UseCustomDomain
+        - { CertificateArn: !Ref CustomDomainCertificateArn }
+        - !Ref AWS::NoValue
 
   CognitoUserPool:
     Type: AWS::Cognito::UserPool
@@ -125,9 +146,19 @@ Outputs:
 
   UserPoolAuthDomain:
     Description: The domain of the authorization server.
-    Value: !Sub
-      - https://${Domain}.${Auth}.${AWS::Region}.amazoncognito.com
-      - {Domain: !Ref UserPoolDomain, Auth: !If [GovCloud, 'auth-fips', 'auth']}
+    Value: !If
+      - UseCustomDomain
+      - !Sub https://${UserPoolDomain}
+      - !Sub
+        - https://${Domain}.${Auth}.${AWS::Region}.amazoncognito.com
+        - {Domain: !Ref UserPoolDomain, Auth: !If [GovCloud, 'auth-fips', 'auth']}
+
+  CustomDomainEndpoint:
+    Condition: UseCustomDomain
+    Description: |
+      The endpoint associated with the custom domain name. 
+      Add an A record in your DNS for the custom domain name pointing to this endpoint.
+    Value: !GetAtt UserPoolDomain.CloudFrontDistribution
 
   UserPoolId:
     Description: Cognito UserPool Id

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -66,6 +66,18 @@ Parameters:
     Type: String
     Description: (Optional) Custom domain name. If omitted, the default domain name will be used.
     Default: ''
+  CustomDomainCertificateArn:
+    Type: String
+    Description: '(Optional) ARN of the ACM Certificate issued for the custom domain. This is required only if `CustomDomain` is specified.'
+    Default: ''
+  CognitoCustomDomain:
+    Type: String
+    Description: '(Optional) Custom domain name for Cognito. If omitted, the default Cognito domain name will be used.'
+    Default: ''
+  CognitoCustomDomainCertificateArn:
+    Type: String
+    Description: '(Optional) ARN of the ACM Certificate issued for the Cognito custom domain. This is required only if `CognitoCustomDomain` is specified.'
+    Default: ''
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -108,6 +120,9 @@ Metadata:
           default: (Optional) Custom Domain
         Parameters:
           - CustomDomain
+          - CustomDomainCertificateArn
+          - CognitoCustomDomain
+          - CognitoCustomDomainCertificateArn
       - Label:
           default: (Debugging only) Infrastructure S3 Bucket
         Parameters:
@@ -153,6 +168,7 @@ Conditions:
   UsePermissionBoundaryPCAPI: !Not [!Equals [!Ref PermissionsBoundaryPolicyPCAPI, '']]
   UseIAMRoleAndPolicyPrefix: !Not [!Equals [!Ref IAMRoleAndPolicyPrefix, '']]
   UseCustomDomain: !Not [!Equals [!Ref CustomDomain, '']]
+  UseCognitoCustomDomain: !Not [!Equals [!Ref CognitoCustomDomain, '']]
 
 Mappings:
   ParallelClusterUI:
@@ -171,6 +187,8 @@ Resources:
         AdminUserEmail: !Ref AdminUserEmail
         PermissionsBoundaryPolicy: !Ref PermissionsBoundaryPolicy
         IAMRoleAndPolicyPrefix: !Ref IAMRoleAndPolicyPrefix
+        CustomDomain: !Ref CognitoCustomDomain
+        CustomDomainCertificateArn: !Ref CognitoCustomDomainCertificateArn
       TemplateURL: !Sub
         - '${Bucket}/parallelcluster-ui-cognito.yaml'
         - Bucket: !If 
@@ -1026,6 +1044,26 @@ Resources:
             Effect: Allow
             Sid: SsmGetCommandInvocationPolicy
 
+  ApiGatewayCustomDomain:
+    Condition: UseCustomDomain
+    Type: AWS::ApiGateway::DomainName
+    Properties:
+#      CertificateArn: !Ref CustomDomainCertificateArn
+      DomainName: !Ref CustomDomain
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
+      RegionalCertificateArn: !Ref CustomDomainCertificateArn
+      SecurityPolicy: TLS_1_2
+
+  ApiGatewayCustomDomainMapping:
+    Condition: UseCustomDomain
+    Type: AWS::ApiGateway::BasePathMapping
+    Properties:
+      BasePath: !FindInMap [ ParallelClusterUI, Constants, CustomDomainBasePath ]
+      DomainName: !Ref ApiGatewayCustomDomain
+      RestApiId: !Ref ApiGatewayRestApi
+      Stage: !Ref ApiGatewayRestStage
 
 Outputs:
   ParallelClusterUILambdaArn:
@@ -1043,6 +1081,12 @@ Outputs:
       - !Sub
         - https://${Api}.execute-api.${AWS::Region}.${AWS::URLSuffix}/${Stage}
         - { Api: !Ref ApiGatewayRestApi, Stage: !Ref ApiGatewayRestStage }
+  CustomDomainEndpoint:
+    Condition: UseCustomDomain
+    Description: |
+      The endpoint associated with the custom domain name. 
+      Add an A record in your DNS for the PCUI custom domain name pointing to this endpoint.
+    Value: !GetAtt ApiGatewayCustomDomain.RegionalDomainName
   AppClientId:
     Description: The id of the Cognito app client
     Value: !Ref CognitoAppClient
@@ -1052,3 +1096,9 @@ Outputs:
   UserPoolClientSecretName:
     Description: The app client secret name for ParallelCluster UI.
     Value: !GetAtt UserPoolClientSecret.SecretName
+  CognitoCustomDomainEndpoint:
+    Condition: UseCognitoCustomDomain
+    Description: |
+      The endpoint associated with the Cognito custom domain name. 
+      Add an A record in your DNS for the Cognito custom domain name pointing to this endpoint.
+    Value: !GetAtt Cognito.Outputs.CustomDomainEndpoint


### PR DESCRIPTION
## Changes

Improve user experience to configure custom domain
In particular, we added the following new optional parameters to the PCUI stack:

  1. `CustomDomain`
  2. `CustomDomainCertificateArn`
  3. `CognitoCustomDomain`
  4. `CognitoCustomDomainCertificateArn`

and the following new outputs when a custom domain is set:

  1. `CustomDomainEndpoint`
  2. `CognitoCustomDomainEndpoint`

## How Has This Been Tested?
Tested that the following deployments succeed:
1. Cognito Stack with default domain
2. Cognito Stack with custom domain
3. PCUI stack with default domain using an existing Cognito stack with default domain
4. PCUI stack with default domain using an existing Cognito stack with custom domain
5. PCUI stack with custom domain using an existing Cognito stack with default domain
6. PCUI stack with custom domain using an existing Cognito stack with custom domain
7. PCUI stack with default domain using a new Cognito stack with default domain
8. PCUI stack with default domain using a new Cognito stack with custom domain
9. PCUI stack with custom domain using a new Cognito stack with default domain
10. PCUI stack with custom domain using a new Cognito stack with custom domain

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
