### PR TITLE
Bump PCUI to 2024.10.0 and PC version to 3.11.0

### DIFF
--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -155,7 +155,7 @@ describe('given a feature flags provider and a list of rules', () => {
     })
   })
 
-  for (const version of ["3.9.0", "3.10.0"]) {
+  for (const version of ["3.9.0", "3.11.0"]) {
     describe(`when the version is ${version}`, () => {
       it('should return the list of available features', async () => {
         const features = await subject(version, region)

--- a/infrastructure/environments/demo-cfn-create-args.yaml
+++ b/infrastructure/environments/demo-cfn-create-args.yaml
@@ -3,7 +3,7 @@ Parameters:
   - ParameterKey: AdminUserEmail
     ParameterValue: my@email.com
   - ParameterKey: Version
-    ParameterValue: 3.10.1
+    ParameterValue: 3.11.0
   - ParameterKey: InfrastructureBucket
     ParameterValue: BUCKET_URL_PLACEHOLDER
   - ParameterKey: PublicEcrImageUri

--- a/infrastructure/environments/demo-cfn-update-args.yaml
+++ b/infrastructure/environments/demo-cfn-update-args.yaml
@@ -3,7 +3,7 @@ Parameters:
   - ParameterKey: AdminUserEmail
     UsePreviousValue: true
   - ParameterKey: Version
-    ParameterValue: 3.10.1
+    ParameterValue: 3.11.0
   - ParameterKey: InfrastructureBucket
     ParameterValue: BUCKET_URL_PLACEHOLDER
   - ParameterKey: PublicEcrImageUri

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -34,7 +34,7 @@ Parameters:
   Version:
     Description: Version of AWS ParallelCluster to deploy
     Type: String
-    Default: 3.10.1
+    Default: 3.11.0
   ImageBuilderVpcId:
     Description: (Optional) Select the VPC to use for building the container images. If not selected, default VPC will be used.
     Type: String

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -6,7 +6,7 @@ Parameters:
   PublicEcrImageUri:
     Description: When specified, the URI of the Docker image for the Lambda of the ParallelCluster UI container
     Type: String
-    Default: public.ecr.aws/pcm/parallelcluster-ui:2024.07.1
+    Default: public.ecr.aws/pcm/parallelcluster-ui:2024.10.0
   VpcEndpointId:
     Description: Enter a VPC endpoint with type interface for the execute-api service to enable private PCUI implementation. When enabled, the API will only accept requests from within the given VPC.
     Type: String
@@ -173,7 +173,7 @@ Conditions:
 Mappings:
   ParallelClusterUI:
     Constants:
-      Version: 2024.07.1 # format YYYY.MM.REVISION
+      Version: 2024.10.0 # format YYYY.MM.REVISION
       CustomDomainBasePath: pcui
 
 Resources:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -65,5 +65,5 @@ Build and push the image:
 ./scripts/build_and_release_image.sh \
 --ecr-region us-east-1 \
 --ecr-endpoint $ECR_ENDPOINT \
---tag 2023.10.16
+--tag YYYY.MM.NN
 ```


### PR DESCRIPTION
## Changes
1. Bump PCUI version to 2024.10.0
2. PC version to 3.11.0
3. Removed misleading version number from README instructions

## How Has This Been Tested?

PCUI deployed in personal account and able to create a cluster using PC 3.11.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
