### PR TITLE
[Instance Type] Add support for instance family p5.

### DIFF
--- a/api/PclusterApiHandler.py
+++ b/api/PclusterApiHandler.py
@@ -556,7 +556,9 @@ def get_instance_types():
     filters = [
         {"Name": "current-generation", "Values": ["true"]},
         {"Name": "instance-type",
-         "Values": ["c5*", "c6*", "c7*", "g4*", "g5*", "g6*", "hpc*", "p3*", "p4*", "t2*", "t3*", "m6*", "m7*", "r*"]},
+         "Values": [
+             "c5*", "c6*", "c7*", "g4*", "g5*", "g6*", "hpc*", "p3*", "p4*", "p5*", "t2*", "t3*", "m6*", "m7*", "r*"
+         ]},
     ]
     instance_paginator = ec2.get_paginator("describe_instance_types")
     instances_paginator = instance_paginator.paginate(Filters=filters)


### PR DESCRIPTION
## Changes
Add support for instance family p5.
This change is required because in PC 3.10.0 we introduced the support for p5 and with PC 3.11.0 we introduced the support for p5e.


## How Has This Been Tested?

Deployed in personal account and verified that p5 instance types are shown in the dropdown both for head node and compute nodes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
