### PR TITLE
[Dependencies] Bump ParallelCluster version to 3.11.1.

### DIFF
--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -155,7 +155,7 @@ describe('given a feature flags provider and a list of rules', () => {
     })
   })
 
-  for (const version of ["3.9.0", "3.11.0"]) {
+  for (const version of ["3.9.0", "3.11.1"]) {
     describe(`when the version is ${version}`, () => {
       it('should return the list of available features', async () => {
         const features = await subject(version, region)

--- a/infrastructure/environments/demo-cfn-create-args.yaml
+++ b/infrastructure/environments/demo-cfn-create-args.yaml
@@ -3,7 +3,7 @@ Parameters:
   - ParameterKey: AdminUserEmail
     ParameterValue: my@email.com
   - ParameterKey: Version
-    ParameterValue: 3.11.0
+    ParameterValue: 3.11.1
   - ParameterKey: InfrastructureBucket
     ParameterValue: BUCKET_URL_PLACEHOLDER
   - ParameterKey: PublicEcrImageUri

--- a/infrastructure/environments/demo-cfn-update-args.yaml
+++ b/infrastructure/environments/demo-cfn-update-args.yaml
@@ -3,7 +3,7 @@ Parameters:
   - ParameterKey: AdminUserEmail
     UsePreviousValue: true
   - ParameterKey: Version
-    ParameterValue: 3.11.0
+    ParameterValue: 3.11.1
   - ParameterKey: InfrastructureBucket
     ParameterValue: BUCKET_URL_PLACEHOLDER
   - ParameterKey: PublicEcrImageUri

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -34,7 +34,7 @@ Parameters:
   Version:
     Description: Version of AWS ParallelCluster to deploy
     Type: String
-    Default: 3.11.0
+    Default: 3.11.1
   ImageBuilderVpcId:
     Description: (Optional) Select the VPC to use for building the container images. If not selected, default VPC will be used.
     Type: String


### PR DESCRIPTION
**DO NOT MERGE UNTIL PC 3.11.1 IS OUT**

## Changes

Bump ParallelCluster version to 3.11.1.

## How Has This Been Tested?

From PCUI perspective, there is no change between 3.11.0 and 3.11.1 and we already extensively tested the support for 3.11.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
