### PR TITLE
Return RegionalHostedZoneId from the cloudformation UI stack

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -1109,8 +1109,15 @@ Outputs:
     Condition: UseCustomDomain
     Description: |
       The endpoint associated with the custom domain name. 
-      Add an A record in your DNS for the PCUI custom domain name pointing to this endpoint.
+      Add an A alias record in your DNS for the PCUI custom domain name pointing to this endpoint.
+      https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-api-gateway.html#routing-to-api-gateway-config
     Value: !GetAtt ApiGatewayCustomDomain.RegionalDomainName
+  CustomDomainRegionalHostedZoneId:
+    Condition: UseCustomDomain
+    Description: |
+      The region-specific Amazon Route 53 Hosted Zone ID of the regional endpoint.
+      You need this while creating Route53 alias
+    Value: !GetAtt ApiGatewayCustomDomain.RegionalHostedZoneId
   AppClientId:
     Description: The id of the Cognito app client
     Value: !Ref CognitoAppClient


### PR DESCRIPTION
## Description
Return RegionalHostedZoneId in outputs of the UI stack as long as this value is needed by Route53 alias
https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-api-gateway.html#routing-to-api-gateway-config

## Changes
A new output variable

## How Has This Been Tested?
Deployed the UI stack and checked that value exists

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [x] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [x] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [x] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [x] I checked that infrastructure/update_infrastructure.sh runs without any error
- [x] I checked that `npm run build` builds without any error
- [x] I checked that clusters are listed correctly
- [x] I checked that a new cluster can be created (config is produced and dry run passes)
- [x] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
