### PR TITLE
[Dependencies] Upgrade dependencies to address vulnerabilities.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,14 +2,15 @@ Flask-Cors==4.0.2
 Flask==2.3.3
 Werkzeug==2.3.8
 boto3==1.24.30
-requests==2.31.0
-urllib3==1.26.18
+requests==2.32.0
+urllib3==1.26.19
 # Installing cryptography backend since it is the recommended one: https://pypi.org/project/python-jose/
 python-jose[cryptography]==3.3.0
-cryptography==42.0.4
+cryptography==43.0.1
 PyYAML==6.0
 pytest==7.2.2
 pytest-mock==3.8.2
 itsdangerous==2.1.2
 marshmallow==3.19.0
-certifi==2023.7.22
+certifi==2024.7.4
+jinja2==3.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ botocore==1.27.96
     # via
     #   boto3
     #   s3transfer
-certifi==2023.7.22
+certifi==2024.7.4
     # via
     #   -r requirements.in
     #   requests
@@ -24,7 +24,7 @@ charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via flask
-cryptography==42.0.4
+cryptography==43.0.1
     # via
     #   -r requirements.in
     #   python-jose
@@ -48,8 +48,10 @@ itsdangerous==2.1.2
     # via
     #   -r requirements.in
     #   flask
-jinja2==3.1.3
-    # via flask
+jinja2==3.1.5
+    # via
+    #   -r requirements.in
+    #   flask
 jmespath==1.0.1
     # via
     #   boto3
@@ -84,7 +86,7 @@ python-jose[cryptography]==3.3.0
     # via -r requirements.in
 pyyaml==6.0
     # via -r requirements.in
-requests==2.31.0
+requests==2.32.0
     # via -r requirements.in
 rsa==4.9
     # via python-jose
@@ -96,7 +98,7 @@ six==1.16.0
     #   python-dateutil
 tomli==2.0.1
     # via pytest
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -r requirements.in
     #   botocore


### PR DESCRIPTION
## Description

Upgrade dependencies to address vulnerabilities. In particular:
* requests to 2.32.0 (from 2.31.0) to address https://nvd.nist.gov/vuln/detail/cve-2024-35195

* urllib3 to 1.26.19 (from 1.26.18) to address https://nvd.nist.gov/vuln/detail/cve-2024-37891

* cryptography to 43.0.1 (from 42.0.4) to address https://cwe.mitre.org/data/definitions/1395.html

* certifi to 2024.7.4 (from 2023.7.22) to address https://nvd.nist.gov/vuln/detail/cve-2024-39689

* jinja2 to 3.1.5 (from 3.1.3) to address https://nvd.nist.gov/vuln/detail/CVE-2024-56201 and https://nvd.nist.gov/vuln/detail/CVE-2024-56326

## How Has This Been Tested?
PCUI deployed from scratch on personal account. 
Used the deployment to login/logout create/update/delete cluster

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
