### PR TITLE
[Ops] Fix scripts used to deploy and update PCUI by adding provenance flag to docker build commands.

### DIFF
--- a/scripts/build_and_release_image.sh
+++ b/scripts/build_and_release_image.sh
@@ -63,9 +63,9 @@ if [ ! -d node_modules ]; then
 fi
 
 echo "[INFO] Building image"
-docker build --build-arg PUBLIC_URL=/ -t frontend-awslambda .
+docker build --provenance false --build-arg PUBLIC_URL=/ -t frontend-awslambda .
 popd
-docker build -f Dockerfile.awslambda -t ${ECR_REPO} .
+docker build --provenance false -f Dockerfile.awslambda -t ${ECR_REPO} .
 
 ECR_IMAGE_VERSION_TAGGED=${ECR_ENDPOINT}/${ECR_REPO}:${TAG}
 ECR_IMAGE_LATEST_TAGGED=${ECR_ENDPOINT}/${ECR_REPO}:latest

--- a/scripts/build_and_update_lambda.sh
+++ b/scripts/build_and_update_lambda.sh
@@ -65,9 +65,9 @@ pushd frontend
 if [ ! -d node_modules ]; then
   npm install
 fi
-docker build --build-arg PUBLIC_URL=/ -t frontend-awslambda .
+docker build --provenance false --build-arg PUBLIC_URL=/ -t frontend-awslambda .
 popd
-docker build -f Dockerfile.awslambda -t ${IMAGE} .
+docker build --provenance false -f Dockerfile.awslambda -t ${IMAGE} .
 
 echo "Logging in to private repo..."
 aws ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin "${ECR_ENDPOINT}"


### PR DESCRIPTION
## Changes
Fix scripts used to deploy and update PCUI by adding provenance flag to docker build commands.
Such flag is required to make the deployment succeed with the newer version of docker CLI on M1/M2/M3 laptops.
The option is used to relax some checks in the manifest.
This change is safe as it is impacting only the way we deploy PCUI for local testing purposes.

See https://www.reddit.com/r/aws/comments/1hf3rrq/struggling_to_deploy_docker_image_to_aws_lambda/

## How Has This Been Tested?

Before this change the deployment script was failing both on creating and updating the PCUI deployment due to a manifest error. With this option they both succeed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
