### PR TITLE
[Dependencies] Upgrade Werkzeug to version 3.0.6 (from 2.3.8).

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 Flask-Cors==4.0.2
 Flask==2.3.3
-Werkzeug==2.3.8
+Werkzeug==3.0.6
 boto3==1.24.30
 requests==2.32.0
 urllib3==1.26.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -97,7 +97,7 @@ urllib3==1.26.19
     #   -r requirements.in
     #   botocore
     #   requests
-werkzeug==2.3.8
+werkzeug==3.0.6
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
## Description
Upgrade Werkzeug to version 3.0.6 (from 2.3.8).

## How Has This Been Tested?
Deployed PCUI and verified it works by navigating pages and creating a cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
