### PR TITLE
[Dependencies] Upgrade Axios to version 1.7.8 (from 1.6.7).

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "@cloudscape-design/design-tokens": "^3.0.11",
         "@cloudscape-design/global-styles": "^1.0.8",
         "@reduxjs/toolkit": "^1.6.1",
-        "axios": "^1.6.7",
+        "axios": "1.7.8",
         "i18next": "^21.8.13",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
@@ -2762,11 +2762,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.8.tgz",
+      "integrity": "sha512-Uu0wb7KNqK2t5K+YQyVCLM76prD5sRFjKHbJYCP1J7JFGEQ6nN7HWn9+04LAeiJ3ji54lgS/gZCH1oxyrf1SPw==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -4630,15 +4631,16 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "@cloudscape-design/design-tokens": "^3.0.11",
     "@cloudscape-design/global-styles": "^1.0.8",
     "@reduxjs/toolkit": "^1.6.1",
-    "axios": "^1.6.7",
+    "axios": "1.7.8",
     "i18next": "^21.8.13",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
## Description
Upgrade Axios to version 1.7.8 (from 1.6.7) to address vuln https://github.com/aws/aws-parallelcluster-ui/security/dependabot/45

## How Has This Been Tested?

Deployed PCUI, navigated pages and submitted cluster creation through wizard.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
