### PR TITLE
[Dependency] Upgrade python-jose to 3.4.0.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ boto3==1.24.30
 requests==2.32.0
 urllib3==1.26.19
 # Installing cryptography backend since it is the recommended one: https://pypi.org/project/python-jose/
-python-jose[cryptography]==3.3.0
+python-jose[cryptography]==3.4.0
 cryptography==43.0.1
 PyYAML==6.0.2
 pytest==7.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ packaging==23.1
     #   pytest
 pluggy==1.0.0
     # via pytest
-pyasn1==0.5.0
+pyasn1==0.4.8
     # via
     #   python-jose
     #   rsa
@@ -78,7 +78,7 @@ pytest-mock==3.8.2
     # via -r requirements.in
 python-dateutil==2.8.2
     # via botocore
-python-jose[cryptography]==3.3.0
+python-jose[cryptography]==3.4.0
     # via -r requirements.in
 pyyaml==6.0.2
     # via -r requirements.in


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

Upgrade python-jose to 3.4.0 to address Vulnerabilities https://github.com/aws/aws-parallelcluster-ui/security/dependabot/64


*  python-jose 3.4.0 depends on pyasn1<0.5.0 and >=0.4.1




## How Has This Been Tested?

`bash scripts/deploy.sh my-env` and created a basic 3.11.1 cluster



## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
