### PR TITLE
[Permissions] Add new stack parameter 'AdditionalPoliciesPCAPI' to add custom permissions for the ParallelCluster API Lambda role, on top of the default ones.

### DIFF
--- a/infrastructure/environments/demo-cfn-create-args.yaml
+++ b/infrastructure/environments/demo-cfn-create-args.yaml
@@ -26,6 +26,8 @@ Parameters:
 #    ParameterValue: "subnet-xxxxxxxxxx,subnet-xxxxxxxxxx,subnet-xxxxxxxxxx"
 #  - ParameterKey: LambdaSecurityGroupIds
 #    ParameterValue: sg-xxxxxxxxxx
+#  - ParameterKey: AdditionalPoliciesPCAPI
+#    ParameterValue: arn:aws:iam::xxxxxxxxxx:policy/xxxxxxxxxx
 #  - ParameterKey: PermissionsBoundaryPolicy
 #    ParameterValue: arn:aws:iam::xxxxxxxxxx:policy/xxxxxxxxxx
 #  - ParameterKey: PermissionsBoundaryPolicyPCAPI

--- a/infrastructure/environments/demo-cfn-update-args.yaml
+++ b/infrastructure/environments/demo-cfn-update-args.yaml
@@ -26,6 +26,8 @@ Parameters:
     UsePreviousValue: true
   - ParameterKey: LambdaSecurityGroupIds
     UsePreviousValue: true
+  - ParameterKey: AdditionalPoliciesPCAPI
+    UsePreviousValue: true
   - ParameterKey: PermissionsBoundaryPolicy
     UsePreviousValue: true
   - ParameterKey: PermissionsBoundaryPolicyPCAPI

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -57,6 +57,13 @@ Parameters:
     Description: 'ARN of the IAM policy to use as permissions boundary for every IAM role created by ParallelCluster API infrastructure. [ParallelCluster >= 3.8.0]'
     Default: ''
     AllowedPattern: "^(arn:.*:iam::.*:policy\\/([a-zA-Z0-9_-]+))|()$"
+  AdditionalPoliciesPCAPI:
+    Type: String
+    Description: |
+      (OPTIONAL) ARN of the additional IAM policy to be attached to the default execution role for the ParallelCluster Lambda function. 
+      Only one policy can be specified.
+    Default: ''
+    AllowedPattern: "^(arn:.*:iam::.*:policy\\/([a-zA-Z0-9_-]+))|()$"
   IAMRoleAndPolicyPrefix:
     Type: String
     Description: 'Prefix applied to the name of every IAM role and policy (max length: 10). [ParallelCluster >= 3.8.0]'
@@ -113,6 +120,7 @@ Metadata:
       - Label:
           default: (Optional) Permissions
         Parameters:
+          - AdditionalPoliciesPCAPI
           - IAMRoleAndPolicyPrefix
           - PermissionsBoundaryPolicy
           - PermissionsBoundaryPolicyPCAPI
@@ -169,6 +177,7 @@ Conditions:
   UseIAMRoleAndPolicyPrefix: !Not [!Equals [!Ref IAMRoleAndPolicyPrefix, '']]
   UseCustomDomain: !Not [!Equals [!Ref CustomDomain, '']]
   UseCognitoCustomDomain: !Not [!Equals [!Ref CognitoCustomDomain, '']]
+  UseAdditionalPoliciesPCAPI: !Not [!Equals [!Ref AdditionalPoliciesPCAPI, '']]
 
 Mappings:
   ParallelClusterUI:
@@ -204,6 +213,7 @@ Resources:
       Parameters:
         PermissionsBoundaryPolicy: !If [ UsePermissionBoundaryPCAPI, !Ref PermissionsBoundaryPolicyPCAPI, !Ref AWS::NoValue ]
         IAMRoleAndPolicyPrefix: !If [ UseIAMRoleAndPolicyPrefix, !Ref IAMRoleAndPolicyPrefix, !Ref AWS::NoValue ]
+        ParallelClusterFunctionAdditionalPolicies: !If [ UseAdditionalPoliciesPCAPI, !Ref AdditionalPoliciesPCAPI, !Ref AWS::NoValue ]
         ApiDefinitionS3Uri: !Sub s3://${AWS::Region}-aws-parallelcluster/parallelcluster/${Version}/api/ParallelCluster.openapi.yaml
         CreateApiUserRole: False
         EnableIamAdminAccess: True


### PR DESCRIPTION
## Changes

Add new stack parameter 'AdditionalPoliciesPCAPI' to add custom permissions for the ParallelCluster API Lambda role, on top of the default ones.

This change depends on PCAPI change in https://github.com/aws/aws-parallelcluster/pull/6670

This change addresses https://github.com/aws/aws-parallelcluster-ui/issues/246

## How Has This Been Tested?

* Deployed PCUI w/o specifying 'AdditionalPoliciesPCAPI' -> the PCAPI Lambda has the default permissions 
* Deployed PCUI w/ 'AdditionalPoliciesPCAPI' -> the PCAPI Lambda has the extra permissions on top of the default ones.
* Tested also with PC 3.12.0, leaving the new parameter blank to prove backward compatibility

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
