### PR TITLE
[BREAKING CHANGE] Remove default value for PC version. Now the user must specify the PC version to use.

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -32,9 +32,8 @@ Parameters:
     Type: String
     Default: ''
   Version:
-    Description: Version of AWS ParallelCluster to deploy
+    Description: Version of AWS ParallelCluster to deploy.
     Type: String
-    Default: 3.11.1
   ImageBuilderVpcId:
     Description: (Optional) Select the VPC to use for building the container images. If not selected, default VPC will be used.
     Type: String


### PR DESCRIPTION
## Changes
[BREAKING CHANGE] Remove default value for PC version. Now the user must specify the PC version to use.

From developer perspective, this means that we do not need to do a new release of PCUI only to bumo the default PC version.

<!-- List of relevant changes introduced -->

## How Has This Been Tested?
We already tested that the current release candidate is compatible with PC 3.12.0 (latest release) and 3.13.0 (next release candidate)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
