### PR TITLE
[Test] Bump PC version to 3.12.0 in demo env and unit test

### DIFF
--- a/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
+++ b/frontend/src/feature-flags/__tests__/FeatureFlagsProvider.test.ts
@@ -155,7 +155,7 @@ describe('given a feature flags provider and a list of rules', () => {
     })
   })
 
-  for (const version of ["3.9.0", "3.11.1"]) {
+  for (const version of ["3.9.0", "3.12.0"]) {
     describe(`when the version is ${version}`, () => {
       it('should return the list of available features', async () => {
         const features = await subject(version, region)

--- a/infrastructure/environments/demo-cfn-create-args.yaml
+++ b/infrastructure/environments/demo-cfn-create-args.yaml
@@ -3,7 +3,7 @@ Parameters:
   - ParameterKey: AdminUserEmail
     ParameterValue: my@email.com
   - ParameterKey: Version
-    ParameterValue: 3.11.1
+    ParameterValue: 3.12.0
   - ParameterKey: InfrastructureBucket
     ParameterValue: BUCKET_URL_PLACEHOLDER
   - ParameterKey: PublicEcrImageUri

--- a/infrastructure/environments/demo-cfn-update-args.yaml
+++ b/infrastructure/environments/demo-cfn-update-args.yaml
@@ -3,7 +3,7 @@ Parameters:
   - ParameterKey: AdminUserEmail
     UsePreviousValue: true
   - ParameterKey: Version
-    ParameterValue: 3.11.1
+    ParameterValue: 3.12.0
   - ParameterKey: InfrastructureBucket
     ParameterValue: BUCKET_URL_PLACEHOLDER
   - ParameterKey: PublicEcrImageUri


### PR DESCRIPTION
## Changes
Bump PC version to 3.12.0 in demo env and unit test

## How Has This Been Tested?
We validated that PCUI is compatible w/ PC 3.12.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
