### PR TITLE
[Infrastructure] Fix PCUI private deployment by making the PCUI template use and return the correct URLs

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -263,7 +263,13 @@ Resources:
               - { CustomDomainBasePath: !FindInMap [ ParallelClusterUI, Constants, CustomDomainBasePath ] }
             - !Sub
               - https://${Api}.execute-api.${AWS::Region}.${AWS::URLSuffix}/${Stage}
-              - { Api: !Ref ApiGatewayRestApi, Stage: !Ref ApiGatewayRestStage }
+              - Api: !If
+                  - IsPrivate
+                  - !Sub
+                    - '${ApiId}-${VpceId}'
+                    - { ApiId: !Ref ApiGatewayRestApi, VpceId: !Ref VpcEndpointId }
+                  - !Ref ApiGatewayRestApi
+                Stage: !Ref ApiGatewayRestStage
           AUTH_PATH: !If [ UseExistingCognito, !Ref UserPoolAuthDomain, !GetAtt [ Cognito, Outputs.UserPoolAuthDomain ]]
           SECRET_ID: !GetAtt UserPoolClientSecret.SecretName
           AUDIENCE: !Ref CognitoAppClient
@@ -424,7 +430,13 @@ Resources:
             - { CustomDomainBasePath: !FindInMap [ ParallelClusterUI, Constants, CustomDomainBasePath ] }
           - !Sub
             - https://${Api}.execute-api.${AWS::Region}.${AWS::URLSuffix}/${Stage}/login
-            - { Api: !Ref ApiGatewayRestApi, Stage: !Ref ApiGatewayRestStage }
+            - Api: !If
+                - IsPrivate
+                - !Sub
+                  - '${ApiId}-${VpceId}'
+                  - { ApiId: !Ref ApiGatewayRestApi, VpceId: !Ref VpcEndpointId }
+                - !Ref ApiGatewayRestApi
+              Stage: !Ref ApiGatewayRestStage
       SupportedIdentityProviders:
         - COGNITO
       UserPoolId: !If [ UseExistingCognito, !Ref UserPoolId, !GetAtt [ Cognito, Outputs.UserPoolId ]]
@@ -1102,7 +1114,13 @@ Outputs:
         - { CustomDomainBasePath: !FindInMap [ ParallelClusterUI, Constants, CustomDomainBasePath ] }
       - !Sub
         - https://${Api}.execute-api.${AWS::Region}.${AWS::URLSuffix}/${Stage}
-        - { Api: !Ref ApiGatewayRestApi, Stage: !Ref ApiGatewayRestStage }
+        - Api: !If
+            - IsPrivate
+            - !Sub
+              - '${ApiId}-${VpceId}'
+              - { ApiId: !Ref ApiGatewayRestApi, VpceId: !Ref VpcEndpointId }
+            - !Ref ApiGatewayRestApi
+          Stage: !Ref ApiGatewayRestStage
   CustomDomainEndpoint:
     Condition: UseCustomDomain
     Description: |


### PR DESCRIPTION
## Changes
Fix PCUI private deployment by making the PCUI template use and return the correct URLs

## How Has This Been Tested?
1. Deployed using the private deployment infrastructure created with 1-cl;ick template in https://github.com/aws/aws-parallelcluster-ui/pull/400.
2. Verified that the correct VPCE URL is returned as output
3. Verified that Cognito now redirects to the correct PCUI URL
4. Verified that. PCUI is accessible only from the DCV instance deployed in the same VPC, having perms to access the VPCE
5. Navigated PCUI pages checking that no errors are logged interacting with the PCAPI.
Also validated with a standard PCUI deployment to verify no regressions have been introduced.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
