### PR TITLE
[Workflows] Run GitHub workflows using latest Ubuntu version rather than Ubuntu 20.04

### DIFF
--- a/.github/workflows/demo_deploy.yml
+++ b/.github/workflows/demo_deploy.yml
@@ -13,7 +13,7 @@ concurrency: ci-${{ github.ref }}
 
 jobs:
   frontend-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./frontend
 
   backend-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo
@@ -62,7 +62,7 @@ jobs:
         run: pytest
 
   update-infrastructure:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     
     needs: [frontend-tests, backend-tests]
 
@@ -80,7 +80,7 @@ jobs:
         run: ./infrastructure/update-environment-infra.sh demo
 
   build-and-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     
     needs: [update-infrastructure]
 

--- a/.github/workflows/production_release.yml
+++ b/.github/workflows/production_release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   frontend-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo
@@ -40,7 +40,7 @@ jobs:
         working-directory: ./frontend
 
   backend-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo
@@ -59,7 +59,7 @@ jobs:
         run: pytest
 
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     
     needs: [frontend-tests, backend-tests]
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   frontend-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo
@@ -37,7 +37,7 @@ jobs:
         working-directory: ./frontend
 
   backend-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## Description

Run GitHub workflows using latest Ubuntu vrsion rather than Ubuntu 20.04 as 20.04 has been deprecated in workflows. 
See https://github.com/actions/runner-images/issues/11101

## How Has This Been Tested?

PR checks in this Pr runs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
