### PR TITLE
[JobInfo] Fix the retrieval of job info by making the SSM command to store the outputs on CloudWatch logs to prevent truncation.

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -11,6 +11,7 @@
 import datetime
 import os
 
+import boto3
 import dateutil
 from flask import Flask, Response, request, send_from_directory
 import requests
@@ -110,3 +111,68 @@ def serve_frontend(app, path=""):
         return proxy_to("http://localhost:3000/" + path)
 
     return send_from_directory(app.static_folder, "index.html")
+
+def read_and_delete_ssm_output_from_cloudwatch(
+        region: str,
+        log_group_name: str,
+        command_id: str,
+        instance_id: str,
+) -> str:
+    logs_client = boto3.client('logs', region_name=region)
+
+    log_stream_name =  f"{command_id}/{instance_id}/aws-runShellScript/stdout"
+
+    logger.info(
+        f"Reading output for SSM command {command_id} from logstream {log_stream_name} in log group {log_group_name}"
+    )
+
+    output_lines = []
+
+    try:
+        next_token = None
+        while True:
+            request_params = dict(
+                logGroupName=log_group_name,
+                logStreamName=log_stream_name,
+                startFromHead=True,
+            )
+            if next_token:
+                request_params['nextToken'] = next_token
+            response = logs_client.get_log_events(**request_params)
+            log_events = response.get('events', [])
+            next_token = response.get('nextForwardToken')
+            next_backward_token = response.get('nextBackwardToken')
+
+            for event in log_events:
+                message = event.get('message', '').strip()
+                if message:
+                    output_lines.append(message)
+            if not next_token or normalize_logs_token(next_token) == normalize_logs_token(next_backward_token):
+                break
+        delete_log_stream(logs_client, log_group_name, log_stream_name)
+    except Exception as ex:
+        logger.error(
+            f"Failed to read output for SSM command {command_id} "
+            f"from logstream {log_stream_name} in log group {log_group_name}: {ex}"
+        )
+        delete_log_stream(logs_client, log_group_name, log_stream_name)
+
+    logger.info(
+        f"Completed reading of output for SSM command {command_id} "
+        f"from logstream {log_stream_name} in log group {log_group_name}"
+    )
+
+    return "\n".join(output_lines)
+
+def normalize_logs_token(token: str) -> str:
+    return token.split('/', 1)[1] if token and '/' in token else token
+
+def delete_log_stream(logs_client, log_group_name: str, log_stream_name: str, logger):
+    try:
+        logs_client.delete_log_stream(
+            logGroupName=log_group_name,
+            logStreamName=log_stream_name,
+        )
+        logger.info(f"Deleted log stream {log_stream_name} in log group {log_group_name}")
+    except Exception as ex:
+        logger.error(f"Failed to delete log stream {log_stream_name} in log group {log_group_name}: {ex}")

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -278,6 +278,7 @@ Resources:
             - UseCustomDomain
             - !FindInMap [ ParallelClusterUI, Constants, CustomDomainBasePath ]
             - !Ref AWS::NoValue
+          SSM_LOG_GROUP_NAME: !Ref SsmLogGroup
       FunctionName: !Sub
         - ParallelClusterUIFun-${StackIdSuffix}
         - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
@@ -838,6 +839,12 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${ParallelClusterUIFun}
       RetentionInDays: 90
 
+  SsmLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/ssm/ParallelClusterUI-${AWS::StackName}
+      RetentionInDays: 1
+      LogGroupClass: STANDARD
 
   ParallelClusterUIUserRole:
     Type: AWS::IAM::Role
@@ -861,6 +868,7 @@ Resources:
         - !Ref CognitoPolicy
         - !Ref EC2Policy
         - !Ref StoragePolicy
+        - !Ref LogsPolicy
         - !Ref CostMonitoringAndPricingPolicy
         - !Ref SsmPolicy
       PermissionsBoundary: !If [UsePermissionBoundary, !Ref PermissionsBoundaryPolicy, !Ref 'AWS::NoValue']
@@ -1053,6 +1061,29 @@ Resources:
               - '*'
             Effect: Allow
             Sid: SsmGetCommandInvocationPolicy
+
+  LogsPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}LogsPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - logs:GetLogEvents
+            Resource:
+              - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${SsmLogGroup}:*"
+              - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${SsmLogGroup}:log-stream:*"
+            Effect: Allow
+            Sid: CloudWatchLogsRead
+          - Action:
+              - logs:DeleteLogStream
+            Resource:
+              - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${SsmLogGroup}:log-stream:*/*/aws-runShellScript/stdout"
+            Effect: Allow
+            Sid: CloudWatchLogsDelete
 
   ApiGatewayCustomDomain:
     Condition: UseCustomDomain


### PR DESCRIPTION
## Description

Fix the retrieval of job info by making the SSM command to store the outputs on CloudWatch logs to prevent truncation.
This change fixes https://github.com/aws/aws-parallelcluster-ui/issues/376

## How Has This Been Tested?

Verified that PCUI is now able to show information when 200+ jobs are submitted.

**Current Limitation**
Unit tests have been implemented, but commented out because they require the refactoring of the logging packages to prevent test failures, which is a more invasive change we want to decouple from this bugfix. This seems unreasonable, but actually caused by the fact that PCUI logging utilities clashes with the logging library of Python, disturbing pytest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
