### PR TITLE
[JobInfo] Fix the retrieval of job info by making the SSM command to store the outputs on CloudWatch logs to prevent truncation. 

### DIFF
--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -1,0 +1,104 @@
+import pytest
+from unittest.mock import Mock, patch
+from api.utils import read_and_delete_ssm_output_from_cloudwatch, normalize_logs_token
+
+
+@pytest.fixture
+def mock_boto3_client():
+    with patch('boto3.client') as mock_client:
+        yield mock_client
+
+@pytest.mark.skip("this test is temporarily disabled because it requires refactoring of the logging utilities")
+@pytest.mark.parametrize(
+    "responses, expected_result, expected_call_count", [
+        pytest.param(
+            [
+                {
+                    'events': [
+                        {'message': 'line1'},
+                        {'message': 'line2'}
+                    ],
+                    'nextForwardToken': 'token1',
+                    'nextBackwardToken': 'token1'
+                },
+            ],
+            "line1\nline2",
+            1,
+            id="logs_on_single_page"
+        ),
+        pytest.param(
+            [
+                {
+                    'events': [
+                        {'message': 'line1'},
+                        {'message': 'line2'}
+                    ],
+                    'nextForwardToken': 'token1',
+                    'nextBackwardToken': 'token2'
+                },
+                {
+                    'events': [
+                        {'message': 'line3'}
+                    ],
+                    'nextForwardToken': 'token2',
+                    'nextBackwardToken': 'token2'
+                }
+            ],
+            "line1\nline2\nline3",
+            2,
+            id="logs_on_multiple_pages"
+        ),
+        pytest.param(
+            [
+                {
+                    'events': [],
+                    'nextForwardToken': 'token1',
+                    'nextBackwardToken': 'token1'
+                },
+            ],
+            "",
+            1,
+            id="empty_logs"
+        ),
+])
+def test_read_and_delete_ssm_output_from_cloudwatch_success(
+        mock_boto3_client, responses, expected_result, expected_call_count
+):
+    mock_logs = Mock()
+    mock_logs.get_log_events.side_effect = responses
+    mock_boto3_client.return_value = mock_logs
+
+    result = read_and_delete_ssm_output_from_cloudwatch(
+        region='us-east-1',
+        log_group_name='/aws/ssm/test',
+        command_id='cmd-123',
+        instance_id='i-123',
+    )
+
+    # Assert
+    assert result == expected_result
+    mock_boto3_client.assert_called_once_with('logs', region_name='us-east-1')
+    assert mock_logs.get_log_events.call_count == expected_call_count
+    assert mock_logs.delete_log_stream.call_count == 1
+
+@pytest.mark.skip("this test is temporarily disabled because it requires refactoring of the logging utilities")
+@pytest.mark.parametrize(
+    "input_token, expected_output", [
+        pytest.param(
+            'f/WHATEVER/s',
+            'WHATEVER/s',
+            id="forward_token"
+        ),
+        pytest.param(
+            'b/WHATEVER/s',
+            'WHATEVER/s',
+            id="backward_token"
+        ),
+    ]
+)
+def test_normalize_logs_token(input_token, expected_output):
+    result = normalize_logs_token(str(input_token))
+    assert result == expected_output, f"Failed for input '{input_token}'. Expected '{expected_output}', got '{result}'"
+
+
+

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -278,6 +278,7 @@ Resources:
             - UseCustomDomain
             - !FindInMap [ ParallelClusterUI, Constants, CustomDomainBasePath ]
             - !Ref AWS::NoValue
+          SSM_LOG_GROUP_NAME: !Ref SsmLogGroup
       FunctionName: !Sub
         - ParallelClusterUIFun-${StackIdSuffix}
         - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
@@ -838,6 +839,12 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${ParallelClusterUIFun}
       RetentionInDays: 90
 
+  SsmLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/ssm/ParallelClusterUI-${AWS::StackName}
+      RetentionInDays: 1
+      LogGroupClass: STANDARD
 
   ParallelClusterUIUserRole:
     Type: AWS::IAM::Role
@@ -861,6 +868,7 @@ Resources:
         - !Ref CognitoPolicy
         - !Ref EC2Policy
         - !Ref StoragePolicy
+        - !Ref LogsPolicy
         - !Ref CostMonitoringAndPricingPolicy
         - !Ref SsmPolicy
       PermissionsBoundary: !If [UsePermissionBoundary, !Ref PermissionsBoundaryPolicy, !Ref 'AWS::NoValue']
@@ -1053,6 +1061,29 @@ Resources:
               - '*'
             Effect: Allow
             Sid: SsmGetCommandInvocationPolicy
+
+  LogsPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub
+        - ${IAMRoleAndPolicyPrefix}LogsPolicy-${StackIdSuffix}
+        - { StackIdSuffix: !Select [ 0, !Split [ '-', !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ] ] ] }
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - logs:GetLogEvents
+            Resource:
+              - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${SsmLogGroup}:*"
+              - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${SsmLogGroup}:log-stream:*"
+            Effect: Allow
+            Sid: CloudWatchLogsRead
+          - Action:
+              - logs:DeleteLogStream
+            Resource:
+              - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${SsmLogGroup}:log-stream:*/*/aws-runShellScript/stdout"
+            Effect: Allow
+            Sid: CloudWatchLogsDelete
 
   ApiGatewayCustomDomain:
     Condition: UseCustomDomain


### PR DESCRIPTION
## Description

Fix the retrieval of job info by making the SSM command to store the outputs on CloudWatch logs to prevent truncation.
This change fixes https://github.com/aws/aws-parallelcluster-ui/issues/376

![Screenshot 2025-04-02 at 4 48 08 PM](https://github.com/user-attachments/assets/106ee265-68fe-4e7c-ab5d-fea1fa6669be)

## How Has This Been Tested?

Verified that PCUI is now able to show information when 200+ jobs are submitted.
In particular, tested with 9999 jobs, which seems to be the maximum amount of jobs that Slurm can handle in queue for a single compute node.

**Current Limitation**
Unit tests have been implemented, but skipped, because they require the refactoring of the logging packages to prevent test failures, which is a more invasive change we want to decouple from this bugfix. This seems unreasonable, but actually caused by the fact that PCUI logging utilities clashes with the logging library of Python, disturbing pytest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
