### PR TITLE
[Dependencies] Upgraded nextjs, axios, cryptography and jinja2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "i18next": "^21.8.13",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
-        "next": "^14.2.21",
+        "next": "^14.2.25",
         "next-transpile-modules": "^10.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1658,9 +1658,9 @@
       "integrity": "sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw=="
     },
     "node_modules/@next/env": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.24.tgz",
-      "integrity": "sha512-LAm0Is2KHTNT6IT16lxT+suD0u+VVfYNQqM+EJTKuFRRuY2z+zj01kueWXPCxbMBDt0B5vONYzabHGUNbZYAhA==",
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.26.tgz",
+      "integrity": "sha512-vO//GJ/YBco+H7xdQhzJxF7ub3SUwft76jwaeOyVVQFHCi5DCnkP16WHB+JBylo4vOKPoZBlR94Z8xBxNBdNJA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1693,9 +1693,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.24.tgz",
-      "integrity": "sha512-7Tdi13aojnAZGpapVU6meVSpNzgrFwZ8joDcNS8cJVNuP3zqqrLqeory9Xec5TJZR/stsGJdfwo8KeyloT3+rQ==",
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.26.tgz",
+      "integrity": "sha512-zDJY8gsKEseGAxG+C2hTMT0w9Nk9N1Sk1qV7vXYz9MEiyRoF5ogQX2+vplyUMIfygnjn9/A04I6yrUTRTuRiyQ==",
       "cpu": [
         "arm64"
       ],
@@ -1709,9 +1709,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.24.tgz",
-      "integrity": "sha512-lXR2WQqUtu69l5JMdTwSvQUkdqAhEWOqJEYUQ21QczQsAlNOW2kWZCucA6b3EXmPbcvmHB1kSZDua/713d52xg==",
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.26.tgz",
+      "integrity": "sha512-U0adH5ryLfmTDkahLwG9sUQG2L0a9rYux8crQeC92rPhi3jGQEY47nByQHrVrt3prZigadwj/2HZ1LUUimuSbg==",
       "cpu": [
         "x64"
       ],
@@ -1725,9 +1725,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.24.tgz",
-      "integrity": "sha512-nxvJgWOpSNmzidYvvGDfXwxkijb6hL9+cjZx1PVG6urr2h2jUqBALkKjT7kpfurRWicK6hFOvarmaWsINT1hnA==",
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.26.tgz",
+      "integrity": "sha512-SINMl1I7UhfHGM7SoRiw0AbwnLEMUnJ/3XXVmhyptzriHbWvPPbbm0OEVG24uUKhuS1t0nvN/DBvm5kz6ZIqpg==",
       "cpu": [
         "arm64"
       ],
@@ -1741,9 +1741,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.24.tgz",
-      "integrity": "sha512-PaBgOPhqa4Abxa3y/P92F3kklNPsiFjcjldQGT7kFmiY5nuFn8ClBEoX8GIpqU1ODP2y8P6hio6vTomx2Vy0UQ==",
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.26.tgz",
+      "integrity": "sha512-s6JaezoyJK2DxrwHWxLWtJKlqKqTdi/zaYigDXUJ/gmx/72CrzdVZfMvUc6VqnZ7YEvRijvYo+0o4Z9DencduA==",
       "cpu": [
         "arm64"
       ],
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.24.tgz",
-      "integrity": "sha512-vEbyadiRI7GOr94hd2AB15LFVgcJZQWu7Cdi9cWjCMeCiUsHWA0U5BkGPuoYRnTxTn0HacuMb9NeAmStfBCLoQ==",
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.26.tgz",
+      "integrity": "sha512-FEXeUQi8/pLr/XI0hKbe0tgbLmHFRhgXOUiPScz2hk0hSmbGiU8aUqVslj/6C6KA38RzXnWoJXo4FMo6aBxjzg==",
       "cpu": [
         "x64"
       ],
@@ -1773,9 +1773,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.24.tgz",
-      "integrity": "sha512-df0FC9ptaYsd8nQCINCzFtDWtko8PNRTAU0/+d7hy47E0oC17tI54U/0NdGk7l/76jz1J377dvRjmt6IUdkpzQ==",
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.26.tgz",
+      "integrity": "sha512-BUsomaO4d2DuXhXhgQCVt2jjX4B4/Thts8nDoIruEJkhE5ifeQFtvW5c9JkdOtYvE5p2G0hcwQ0UbRaQmQwaVg==",
       "cpu": [
         "x64"
       ],
@@ -1789,9 +1789,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.24.tgz",
-      "integrity": "sha512-ZEntbLjeYAJ286eAqbxpZHhDFYpYjArotQ+/TW9j7UROh0DUmX7wYDGtsTPpfCV8V+UoqHBPU7q9D4nDNH014Q==",
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.26.tgz",
+      "integrity": "sha512-5auwsMVzT7wbB2CZXQxDctpWbdEnEW/e66DyXO1DcgHxIyhP06awu+rHKshZE+lPLIGiwtjo7bsyeuubewwxMw==",
       "cpu": [
         "arm64"
       ],
@@ -1805,9 +1805,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.24.tgz",
-      "integrity": "sha512-9KuS+XUXM3T6v7leeWU0erpJ6NsFIwiTFD5nzNg8J5uo/DMIPvCp3L1Ao5HjbHX0gkWPB1VrKoo/Il4F0cGK2Q==",
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
+      "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
       "cpu": [
         "ia32"
       ],
@@ -1821,9 +1821,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.24.tgz",
-      "integrity": "sha512-cXcJ2+x0fXQ2CntaE00d7uUH+u1Bfp/E0HsNQH79YiLaZE5Rbm7dZzyAYccn3uICM7mw+DxoMqEfGXZtF4Fgaw==",
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.26.tgz",
+      "integrity": "sha512-2rdB3T1/Gp7bv1eQTTm9d1Y1sv9UuJ2LAwOE0Pe2prHKe32UNscj7YS13fRB37d0GAiGNR+Y7ZcW8YjDI8Ns0w==",
       "cpu": [
         "x64"
       ],
@@ -8490,12 +8490,12 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "14.2.24",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.24.tgz",
-      "integrity": "sha512-En8VEexSJ0Py2FfVnRRh8gtERwDRaJGNvsvad47ShkC2Yi8AXQPXEA2vKoDJlGFSj5WE5SyF21zNi4M5gyi+SQ==",
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.26.tgz",
+      "integrity": "sha512-b81XSLihMwCfwiUVRRja3LphLo4uBBMZEzBBWMaISbKTwOmq3wPknIETy/8000tr7Gq4WmbuFYPS7jOYIf+ZJw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.24",
+        "@next/env": "14.2.26",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -8510,15 +8510,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.24",
-        "@next/swc-darwin-x64": "14.2.24",
-        "@next/swc-linux-arm64-gnu": "14.2.24",
-        "@next/swc-linux-arm64-musl": "14.2.24",
-        "@next/swc-linux-x64-gnu": "14.2.24",
-        "@next/swc-linux-x64-musl": "14.2.24",
-        "@next/swc-win32-arm64-msvc": "14.2.24",
-        "@next/swc-win32-ia32-msvc": "14.2.24",
-        "@next/swc-win32-x64-msvc": "14.2.24"
+        "@next/swc-darwin-arm64": "14.2.26",
+        "@next/swc-darwin-x64": "14.2.26",
+        "@next/swc-linux-arm64-gnu": "14.2.26",
+        "@next/swc-linux-arm64-musl": "14.2.26",
+        "@next/swc-linux-x64-gnu": "14.2.26",
+        "@next/swc-linux-x64-musl": "14.2.26",
+        "@next/swc-win32-arm64-msvc": "14.2.26",
+        "@next/swc-win32-ia32-msvc": "14.2.26",
+        "@next/swc-win32-x64-msvc": "14.2.26"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "@cloudscape-design/design-tokens": "^3.0.11",
         "@cloudscape-design/global-styles": "^1.0.8",
         "@reduxjs/toolkit": "^1.6.1",
-        "axios": "1.7.8",
+        "axios": "1.8.2",
         "i18next": "^21.8.13",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
@@ -2772,9 +2772,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.8.tgz",
-      "integrity": "sha512-Uu0wb7KNqK2t5K+YQyVCLM76prD5sRFjKHbJYCP1J7JFGEQ6nN7HWn9+04LAeiJ3ji54lgS/gZCH1oxyrf1SPw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "i18next": "^21.8.13",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
-    "next": "^14.2.21",
+    "next": "^14.2.25",
     "next-transpile-modules": "^10.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "@cloudscape-design/design-tokens": "^3.0.11",
     "@cloudscape-design/global-styles": "^1.0.8",
     "@reduxjs/toolkit": "^1.6.1",
-    "axios": "1.7.8",
+    "axios": "1.8.2",
     "i18next": "^21.8.13",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ requests==2.32.0
 urllib3==1.26.19
 # Installing cryptography backend since it is the recommended one: https://pypi.org/project/python-jose/
 python-jose[cryptography]==3.4.0
-cryptography==43.0.1
+cryptography==44.0.1
 PyYAML==6.0.2
 pytest==7.2.2
 pytest-mock==3.8.2

--- a/requirements.in
+++ b/requirements.in
@@ -13,4 +13,4 @@ pytest-mock==3.8.2
 itsdangerous==2.1.2
 marshmallow==3.19.0
 certifi==2024.7.4
-jinja2==3.1.5
+jinja2==3.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via flask
-cryptography==43.0.1
+cryptography==44.0.1
     # via
     #   -r requirements.in
     #   python-jose

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ itsdangerous==2.1.2
     # via
     #   -r requirements.in
     #   flask
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
## Description
1. Upgrade axios to version 1.8.2 (from 1.7.8).
1.  Upgrade cryptography to version 44.0.1 (from 43.0.1).
1.  Upgrade jinja to version 3.1.6 (from 3.1.5).
1. Upgrade nextjs to version 14.2.25 (from 14.2.21).

## How Has This Been Tested?
Deployed PCUI, login, logout, navigated cluster and images pages, create and deleted a cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
