### PR TITLE
[Permissions] Fix permissions to read/delete logs from SSM.

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -1074,14 +1074,14 @@ Resources:
           - Action:
               - logs:GetLogEvents
             Resource:
-              - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${SsmLogGroup}:*"
-              - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${SsmLogGroup}:log-stream:*"
+              - !Sub "arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:${SsmLogGroup}:*"
+              - !Sub "arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:${SsmLogGroup}:log-stream:*"
             Effect: Allow
             Sid: CloudWatchLogsRead
           - Action:
               - logs:DeleteLogStream
             Resource:
-              - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${SsmLogGroup}:log-stream:*/*/aws-runShellScript/stdout"
+              - !Sub "arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:${SsmLogGroup}:log-stream:*/*/aws-runShellScript/stdout"
             Effect: Allow
             Sid: CloudWatchLogsDelete
 


### PR DESCRIPTION
Fix permissions to read/delete logs from SSM.
With this fix, PCUI can read/delete the SSM logs from clusters deployed in whatever region within the partition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
