### PR TITLE
[Examples] Add 1-click template to deploy resources for custom domain.

### DIFF
--- a/infrastructure/custom-domain/custom-domain.yaml
+++ b/infrastructure/custom-domain/custom-domain.yaml
@@ -1,0 +1,47 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: AWS ParallelCluster UI - Custom Domain
+
+Parameters:
+  CustomDomainName:
+    Description: Custom domain name.
+    Type: String
+    AllowedPattern: ^(\*\.)?(((?!-)[A-Za-z0-9-]{0,62}[A-Za-z0-9])\.)+((?!-)[A-Za-z0-9-]{1,62}[A-Za-z0-9])$
+    MinLength: 1
+    MaxLength: 253
+
+  HostedZoneId:
+    Description: HostedZoneId
+    Type: AWS::Route53::HostedZone::Id
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Domain
+        Parameters:
+          - CustomDomainName
+      - Label:
+          default: Networking
+        Parameters:
+          - HostedZoneId
+
+Resources:
+  CustomDomainCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Ref CustomDomainName
+      DomainValidationOptions:
+        - DomainName: !Ref CustomDomainName
+          HostedZoneId: !Ref HostedZoneId
+      KeyAlgorithm: RSA_2048
+      SubjectAlternativeNames:
+        - !Sub "*.${CustomDomainName}"
+      ValidationMethod: DNS
+
+Outputs:
+  CustomDomainName:
+    Value: !Ref CustomDomainName
+    Description: Custom domain name.
+  CustomDomainCertificate:
+    Value: !Ref CustomDomainCertificate
+    Description: ACM certificate to certify the custom domain name and its subdomains.


### PR DESCRIPTION
## Description
Add 1-click template to deploy resources for custom domain.

## How Has This Been Tested?
Used the template to deploy custom domain for both PCUI App and Cognito.
Then tested the created certificates with a PCUI deployment using custom domains.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
