### PR TITLE
Make CloudFormation return a more clear error when the parameter Version is not specified.

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -34,6 +34,8 @@ Parameters:
   Version:
     Description: Version of AWS ParallelCluster to deploy.
     Type: String
+    AllowedPattern: "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$"
+    ConstraintDescription: Please specify a valid ParallelCluster version.
   ImageBuilderVpcId:
     Description: (Optional) Select the VPC to use for building the container images. If not selected, default VPC will be used.
     Type: String


### PR DESCRIPTION
## Changes
Make CloudFormation return a more clear error when the parameter Version is not specified.
Without this change CloudFormation will return a more complex error message saying that `Template error: Fn::Select cannot select nonexistent value at index 1`

## How Has This Been Tested?
Manually verified  with:
1. empty value
2. incorrect value
3. correct value


In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
