### PR TITLE
[Dependencies] Upgrade NodeJS from 18.20 to 22.14 in PCUI Docker container

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.20-alpine
+FROM node:22.14-alpine
 WORKDIR /app
 COPY . .
 COPY resources/attributions/npm-python-attributions.txt public/license.txt


### PR DESCRIPTION

## Description
Upgrade NodeJS from 18.20 to 22.14 in PCUI Docker container as NodeJs 18 will be EOL on 2025/04/30.
Nodejs 22 will be EOL 2027/04/30.

## How Has This Been Tested?
Deployment succeeded. Navigated the main pages.

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
