### PR TITLE
[PCUI] Upgrade boto3, urllib3, and ecdsa to fix pentest findings

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,11 +1,12 @@
 Flask-Cors==6.0.0
 Flask==2.3.3
 Werkzeug==3.0.6
-boto3==1.24.30
+boto3==1.42.78
 requests==2.32.4
-urllib3==1.26.20
+urllib3==2.6.3
 # Installing cryptography backend since it is the recommended one: https://pypi.org/project/python-jose/
 python-jose[cryptography]==3.4.0
+ecdsa==0.19.1
 cryptography==44.0.1
 PyYAML==6.0.2
 pytest==7.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ attrs==23.1.0
     # via pytest
 blinker==1.7.0
     # via flask
-boto3==1.24.30
+boto3==1.42.78
     # via -r requirements.in
-botocore==1.27.96
+botocore==1.42.78
     # via
     #   boto3
     #   s3transfer
@@ -28,7 +28,7 @@ cryptography==44.0.1
     # via
     #   -r requirements.in
     #   python-jose
-ecdsa==0.18.0
+ecdsa==0.19.1
     # via python-jose
 flask==2.3.3
     # via
@@ -86,13 +86,13 @@ requests==2.32.4
     # via -r requirements.in
 rsa==4.9
     # via python-jose
-s3transfer==0.6.1
+s3transfer==0.16.0
     # via boto3
 six==1.16.0
     # via
     #   ecdsa
     #   python-dateutil
-urllib3==1.26.20
+urllib3==2.6.3
     # via
     #   -r requirements.in
     #   botocore


### PR DESCRIPTION
## Changes
- Upgrade boto3 from 1.24.30 to 1.42.78 (with botocore 1.42.78, s3transfer 0.16.0) to unblock urllib3 2.x
- Upgrade urllib3 from 1.26.20 to 2.6.3
- Upgrade ecdsa from 0.18.0 to 0.19.1

## How Has This Been Tested?

- Unit tests all passed.
- Manually deployed PCUI to AWS account and tested, worked well.

## References

<!-- Any link to resources, issues, other PRs that are relevant to this PR -->

## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
