### PR TITLE
[PCUI] Add EOL version warning to cluster creation template

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -33,7 +33,11 @@ Parameters:
     Type: String
     Default: ''
   Version:
+<<<<<<< Updated upstream
     Description: 'Version of AWS ParallelCluster to deploy. Warning: deploying an end-of-life (EOL) version is not recommended as it will no longer receive bug fixes or security patches. For the list of currently supported versions, see the ParallelCluster support policy: https://docs.aws.amazon.com/parallelcluster/latest/ug/support-policy.html'
+=======
+    Description: 'Version of AWS ParallelCluster to deploy. We recommend using a supported version of ParallelCluster to ensure you continue receiving the latest bug fixes, security patches and support. You can find the list of currently supported versions in the ParallelCluster support policy: https://docs.aws.amazon.com/parallelcluster/latest/ug/support-policy.html'
+>>>>>>> Stashed changes
     Type: String
     AllowedPattern: '^(?!.*(\d+\.\d+\.\d+).*\1)([0-9]+\.[0-9]+\.[0-9]+)(,[0-9]+\.[0-9]+\.[0-9]+)*$'
     ConstraintDescription: Please specify a comma separated list of valid ParallelCluster versions without duplicates. (Must be 3.6.0 and above)

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -33,11 +33,7 @@ Parameters:
     Type: String
     Default: ''
   Version:
-<<<<<<< Updated upstream
-    Description: 'Version of AWS ParallelCluster to deploy. Warning: deploying an end-of-life (EOL) version is not recommended as it will no longer receive bug fixes or security patches. For the list of currently supported versions, see the ParallelCluster support policy: https://docs.aws.amazon.com/parallelcluster/latest/ug/support-policy.html'
-=======
     Description: 'Version of AWS ParallelCluster to deploy. We recommend using a supported version of ParallelCluster to ensure you continue receiving the latest bug fixes, security patches and support. You can find the list of currently supported versions in the ParallelCluster support policy: https://docs.aws.amazon.com/parallelcluster/latest/ug/support-policy.html'
->>>>>>> Stashed changes
     Type: String
     AllowedPattern: '^(?!.*(\d+\.\d+\.\d+).*\1)([0-9]+\.[0-9]+\.[0-9]+)(,[0-9]+\.[0-9]+\.[0-9]+)*$'
     ConstraintDescription: Please specify a comma separated list of valid ParallelCluster versions without duplicates. (Must be 3.6.0 and above)

--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -33,7 +33,7 @@ Parameters:
     Type: String
     Default: ''
   Version:
-    Description: Version of AWS ParallelCluster to deploy.
+    Description: 'Version of AWS ParallelCluster to deploy. Warning: deploying an end-of-life (EOL) version is not recommended as it will no longer receive bug fixes or security patches. For the list of currently supported versions, see the ParallelCluster support policy: https://docs.aws.amazon.com/parallelcluster/latest/ug/support-policy.html'
     Type: String
     AllowedPattern: '^(?!.*(\d+\.\d+\.\d+).*\1)([0-9]+\.[0-9]+\.[0-9]+)(,[0-9]+\.[0-9]+\.[0-9]+)*$'
     ConstraintDescription: Please specify a comma separated list of valid ParallelCluster versions without duplicates. (Must be 3.6.0 and above)


### PR DESCRIPTION
<!-- If the PR is tagged for release changelog inclusion, remember to provide a meaningful title, since it will be used as a changelog entry -->
## Description

Add a warning about end-of-life (EOL) ParallelCluster versions to the Version parameter description in the CloudFormation template, along with a link to the support policy documentation so customers can check which versions are still supported before deploying.

This does not block customers from deploying EOL versions, it only informs them about the risk.




## PR Quality Checklist

- [ ] I added tests to new or existing code
- [ ] I removed hardcoded strings and used [`react-i18next`](https://react.i18next.com/) library ([useTranslation hook](https://react.i18next.com/latest/usetranslation-hook) and/or [Trans component](https://react.i18next.com/latest/trans-component)), see an example [here](https://github.com/aws/aws-parallelcluster-ui/commit/a6f1e2aa46b245b5bf7500a04b83195477a5cfa5)
- [ ] I made sure no sensitive info gets logged at any time in the codebase (see [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)) (e.g. no user info or details, no stacktraces, etc.)
- [ ] I made sure that any [GitHub issue](https://github.com/aws/aws-parallelcluster-ui/issues) solved by this PR is correctly linked
- [ ] I checked that infrastructure/update_infrastructure.sh runs without any error
- [ ] I checked that `npm run build` builds without any error
- [ ] I checked that clusters are listed correctly
- [ ] I checked that a new cluster can be created (config is produced and dry run passes)
- [ ] I checked that login and logout work as expected

In order to increase the likelihood of your contribution being accepted, please make sure you have read both the [Contributing Guidelines](../CONTRIBUTING.md) and the [Project Guidelines](../PROJECT_GUIDELINES.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
