### PR TITLE
[Versioning] Bump PCUI version to 2026.04.0.

### DIFF
--- a/infrastructure/parallelcluster-ui.yaml
+++ b/infrastructure/parallelcluster-ui.yaml
@@ -7,7 +7,7 @@ Parameters:
   PublicEcrImageUri:
     Description: When specified, the URI of the Docker image for the Lambda of the ParallelCluster UI container
     Type: String
-    Default: public.ecr.aws/pcm/parallelcluster-ui:2025.07.0
+    Default: public.ecr.aws/pcm/parallelcluster-ui:2026.04.0
   VpcEndpointId:
     Description: Enter a VPC endpoint with type interface for the execute-api service to enable private PCUI implementation. When enabled, the API will only accept requests from within the given VPC.
     Type: String
@@ -173,7 +173,7 @@ Conditions:
 Mappings:
   ParallelClusterUI:
     Constants:
-      Version: 2025.07.0 # format YYYY.MM.REVISION
+      Version: 2026.04.0 # format YYYY.MM.REVISION
       CustomDomainBasePath: pcui
 
 Resources:


### PR DESCRIPTION
## Description

Bump PCUI version to 2026.04.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.